### PR TITLE
Review ords skills

### DIFF
--- a/skills/ords/ords-architecture.md
+++ b/skills/ords/ords-architecture.md
@@ -174,9 +174,8 @@ ORDS ships with an embedded Eclipse Jetty server. No external application server
 ```shell
 # Start ORDS standalone
 ords --config /opt/oracle/ords/config serve \
-  --port 8080 \
-  --secure-port 8443 \
-  --certificate-hostname myserver.example.com
+  --secure \
+  --port 8443
 ```
 
 **Pros**: Simple, low overhead, easy to automate, officially supported for production.
@@ -307,5 +306,5 @@ Always check the [ORDS Release Notes](https://docs.oracle.com/en/database/oracle
 ## Sources
 
 - [Oracle REST Data Services Documentation](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/)
-- [ORDS Developer's Guide — Architecture Overview](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/orddg/index.html)
+- [Deploying and Monitoring Oracle REST Data Services — Serve Commands for Running in Standalone Mode](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/deploying-and-monitoring-oracle-rest-data-services.html#GUID-872EA939-5348-4B31-B4EC-EFD038F69837)
 - [ORDS Release Notes](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/)

--- a/skills/ords/ords-architecture.md
+++ b/skills/ords/ords-architecture.md
@@ -49,7 +49,7 @@ ords config set db.port 1521
 ords config set db.servicename mypdb.example.com
 ords config set db.username ORDS_PUBLIC_USER
 # Passwords go into the Oracle Wallet, never into a config file:
-ords config secret set db.password --password-stdin <<< "..."
+ords config secret --password-stdin db.password <<< "..."
 ords config set feature.sdw true
 ```
 

--- a/skills/ords/ords-authentication.md
+++ b/skills/ords/ords-authentication.md
@@ -523,8 +523,8 @@ END;
 
 ## Sources
 
-- [ORDS Developer's Guide — Developing Oracle REST Data Services Applications](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.3/orddg/developing-REST-applications.html)
-- [ORDS Installation and Configuration Guide — About the Oracle REST Data Services Configuration Files](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.3/ordig/about-REST-configuration-files.html)
-- [ORDS_SECURITY PL/SQL Package Reference](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.2/orddg/ords_security-pl-sql-package-reference.html)
-- [ORDS_SECURITY_ADMIN PL/SQL Package Reference](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.4/orddg/ords_security_admin-pl-sql-package.html)
-- [ORDS OAuth2 Client Credentials Flow](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/orddg/rest-enabled-sql-service.html)
+- [ORDS Developer's Guide — Developing Oracle REST Data Services Applications](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/orddg/developing-REST-applications.html)
+- [ORDS Installation and Configuration Guide — About the Oracle REST Data Services Configuration Files](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/about-REST-configuration-files.html)
+- [ORDS_SECURITY PL/SQL Package Reference](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/orddg/ords_security-pl-sql-package-reference.html)
+- [ORDS_SECURITY_ADMIN PL/SQL Package Reference](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/orddg/ords_security_admin-pl-sql-package.html)
+- [Get Started with Oracle REST Data Services — Register an OAuth Client Application to Access the REST API](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/qsord/get-started-with-oracle-rest-data-services.html#GUID-E5729D26-CA54-4F99-AB81-CA9C20BED46A)

--- a/skills/ords/ords-auto-rest.md
+++ b/skills/ords/ords-auto-rest.md
@@ -465,6 +465,6 @@ FROM dba_ords_enabled_schemas;
 
 ## Sources
 
-- [ORDS Developer's Guide — AutoREST](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/orddg/developing-oracle-rest-data-services-applications.html)
-- [Oracle REST Data Services PL/SQL API Reference — ORDS.ENABLE_OBJECT](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/orrst/index.html)
-- [ORDS REST API Collection Query Syntax (q parameter)](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/orddg/implicit-parameters.html)
+- [Developing REST Applications — Automatic Enabling of Schema Objects for REST Access (AutoREST)](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/orddg/developing-REST-applications.html#GUID-4CE630AA-2F06-41D9-96F6-DA77AB1E6395)
+- [ORDS PL/SQL Package Reference — ORDS.ENABLE_OBJECT](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/orddg/ORDS-reference.html#GUID-29C61AC7-E5CB-4977-9A77-03B4C1EE85FE)
+- [ORDS Implicit Parameters Reference](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/orddg/implicit-parameters.html)

--- a/skills/ords/ords-installation.md
+++ b/skills/ords/ords-installation.md
@@ -318,11 +318,11 @@ server {
 }
 ```
 
-Set ORDS to trust the forwarded-proto header:
+Tell ORDS which forwarded header indicates the original client request was HTTPS:
 
 ```shell
 ords --config /opt/oracle/ords/config config set \
-  security.forceHTTPS true
+  security.httpsHeaderCheck "X-Forwarded-Proto: https"
 ```
 
 ---

--- a/skills/ords/ords-installation.md
+++ b/skills/ords/ords-installation.md
@@ -263,25 +263,14 @@ ords --config /opt/oracle/ords/config config secret --password-stdin db.password
 ### Option A: ORDS Standalone with Self-Signed Certificate (Dev)
 
 ```shell
-# Generate self-signed cert
-keytool -genkeypair \
-  -alias ords-ssl \
-  -keyalg RSA \
-  -keysize 2048 \
-  -validity 365 \
-  -keystore /opt/oracle/ords/config/ords/standalone/ords.jks \
-  -storepass changeit \
-  -dname "CN=myserver.example.com, OU=ORDS, O=MyOrg, C=US"
-```
-
-```shell
-# Configure standalone to use it
+# Configure standalone HTTPS and let ORDS generate the self-signed certificate
 ords --config /opt/oracle/ords/config config set \
   standalone.https.port 8443
 ords --config /opt/oracle/ords/config config set \
-  standalone.https.cert /opt/oracle/ords/config/ords/standalone/ords.jks
-ords --config /opt/oracle/ords/config config set \
-  standalone.https.cert.secret changeit
+  standalone.https.host myserver.example.com
+
+# Start ORDS with HTTPS enabled
+ords --config /opt/oracle/ords/config serve --secure --port 8443
 ```
 
 ### Option B: ORDS behind a Reverse Proxy (Recommended for Production)
@@ -679,6 +668,7 @@ The `ords install` command is idempotent — re-running it upgrades the schema i
 
 ## Sources
 
-- [Oracle REST Data Services Installation and Configuration Guide](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/ordig/index.html)
-- [ORDS CLI Reference — ords install](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/ordig/installing-oracle-rest-data-services.html)
-- [ORDS Configuration Settings Reference](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/ordig/configuration-settings.html)
+- [Installing and Configuring Oracle REST Data Services — Installing Oracle REST Data Services](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/installing-and-configuring-oracle-rest-data-services.html#GUID-D86804FC-4365-4499-B170-2F901C971D30)
+- [About the Oracle REST Data Services Configuration Files — Understanding the Configuration Folder Structure](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/about-REST-configuration-files.html#GUID-3F19E9F2-13E6-42AC-958A-3DE50E3AF77D)
+- [About the Oracle REST Data Services Configuration Files — Understanding the Configurable Settings](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/about-REST-configuration-files.html#GUID-006F916B-8594-4A78-B500-BB85F35C12A0)
+- [Deploying and Monitoring Oracle REST Data Services — Non-Interactive Serve CLI](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/deploying-and-monitoring-oracle-rest-data-services.html#GUID-8B65CC69-1D98-4F26-B0A7-389A1332A129)

--- a/skills/ords/ords-installation.md
+++ b/skills/ords/ords-installation.md
@@ -127,13 +127,15 @@ After install, ORDS creates:
 
 ### Silent/Non-Interactive Installation for Automation
 
-For CI/CD pipelines, automated provisioning, or Ansible/Terraform workflows, use a silent install with a response file or environment variables.
+For CI/CD pipelines, automated provisioning, or Ansible/Terraform workflows, run `ords install` without `-i` and provide all required options on the command line. Use `--password-stdin` with either a password file or an inline stdin block. If you include `--proxy-user`, ORDS reads a second password from standard input for the runtime user (by default `ORDS_PUBLIC_USER`).
 
-**Method 1: Pipe responses via stdin**
+**Method 1: Use an inline stdin block for a new pool or fresh install**
 
 ```shell
 ords --config /opt/oracle/ords/config install \
+  --db-pool default \
   --admin-user SYS \
+  --proxy-user \
   --db-hostname mydb.example.com \
   --db-port 1521 \
   --db-servicename mypdb.example.com \
@@ -147,34 +149,52 @@ OrdsPublicUserPwd456!
 EOF
 ```
 
-**Method 2: Use `ords install --interactive false`**
+The first password is for `--admin-user`. The second password is for the runtime user because `--proxy-user` is present.
+
+**Method 2: Use a password file with input redirection**
 
 ```shell
+cat > passwords.txt <<EOF
+SysPassword123!
+OrdsPublicUserPwd456!
+EOF
+
 ords --config /opt/oracle/ords/config install \
-  --interactive false \
+  --db-pool default \
+  --admin-user SYS \
+  --proxy-user \
   --db-hostname mydb.example.com \
   --db-port 1521 \
   --db-servicename mypdb.example.com \
-  --db-username ORDS_PUBLIC_USER \
-  --admin-user SYS \
-  --feature-sdw true
-# Passwords prompted separately or via env vars
+  --feature-sdw true \
+  --log-folder /var/log/ords \
+  --password-stdin < passwords.txt
 ```
 
-**Method 3: Pre-write pool configuration, then install with `--db-only`**
+Use `--db-user <name>` only if you need a runtime user other than the default `ORDS_PUBLIC_USER`.
 
-Write the pool config first, then run the DB install phase only:
+**Method 3: Pre-write pool configuration, then run `--db-only`**
+
+Write the pool config first, then run the database install or upgrade phase only:
 
 ```shell
 ords --config /opt/oracle/ords/config config set db.hostname mydb.example.com
 ords --config /opt/oracle/ords/config config set db.port 1521
 ords --config /opt/oracle/ords/config config set db.servicename mypdb.example.com
 
-# Set passwords via stdin
-echo "SysPassword123!" | ords --config /opt/oracle/ords/config install \
+# Fresh db-only install: include --proxy-user and provide both passwords
+ords --config /opt/oracle/ords/config install \
+  --db-pool default \
+  --db-only \
   --admin-user "SYS AS SYSDBA" \
-  --password-stdin
+  --proxy-user \
+  --password-stdin <<EOF
+SysPassword123!
+OrdsPublicUserPwd456!
+EOF
 ```
+
+If ORDS is already installed in the database and you are only upgrading the database objects, omit `--proxy-user`; in that case, standard input contains only the administrator password.
 
 ---
 
@@ -440,11 +460,25 @@ The `ords install` command is idempotent — re-running it upgrades the schema i
   CREATE TABLESPACE ords_meta_tbs
     DATAFILE '/u01/app/oracle/oradata/ORDS_METADATA01.DBF'
     SIZE 100M AUTOEXTEND ON NEXT 10M MAXSIZE UNLIMITED;
+  ```
 
-  -- Then specify during installation:
-  # During interactive install, specify the custom tablespace
+  Then specify the tablespaces during installation:
+
+  ```shell
+  # During interactive install, specify the custom tablespace when prompted
   # Or via silent install:
-  ords config set db.tablespace ords_meta_tbs
+  ords --config /opt/oracle/ords/config install \
+    --admin-user SYS \
+    --proxy-user \
+    --db-hostname mydb.example.com \
+    --db-port 1521 \
+    --db-servicename mypdb.example.com \
+    --schema-tablespace ords_meta_tbs \
+    --schema-temp-tablespace TEMP \
+    --password-stdin <<EOF
+  SysPassword123!
+  OrdsPublicUserPwd456!
+  EOF
   ```
 
 - **Restrict ORDS_METADATA schema privileges:**
@@ -671,4 +705,5 @@ The `ords install` command is idempotent — re-running it upgrades the schema i
 - [Installing and Configuring Oracle REST Data Services — Installing Oracle REST Data Services](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/installing-and-configuring-oracle-rest-data-services.html#GUID-D86804FC-4365-4499-B170-2F901C971D30)
 - [About the Oracle REST Data Services Configuration Files — Understanding the Configuration Folder Structure](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/about-REST-configuration-files.html#GUID-3F19E9F2-13E6-42AC-958A-3DE50E3AF77D)
 - [About the Oracle REST Data Services Configuration Files — Understanding the Configurable Settings](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/about-REST-configuration-files.html#GUID-006F916B-8594-4A78-B500-BB85F35C12A0)
-- [Deploying and Monitoring Oracle REST Data Services — Non-Interactive Serve CLI](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/deploying-and-monitoring-oracle-rest-data-services.html#GUID-8B65CC69-1D98-4F26-B0A7-389A1332A129)
+- [Installing and Configuring Oracle REST Data Services — Non-Interactive Command-Line Interface Installation (Silent)](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/installing-and-configuring-oracle-rest-data-services.html#GUID-2D13E9CD-EB0C-4CE7-82B8-45BD5C62897B)
+- [Installing and Configuring Oracle REST Data Services — Using Input Redirection](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/installing-and-configuring-oracle-rest-data-services.html#GUID-ECEDA5F7-2023-47B8-A1FF-2CCD6A2D915A)

--- a/skills/ords/ords-installation.md
+++ b/skills/ords/ords-installation.md
@@ -87,13 +87,14 @@ After installation, the config directory looks like:
 /opt/oracle/ords/config/
 ├── databases/
 │   └── default/
-│       └── pool.json         # Connection pool settings (managed by CLI — do not hand-edit)
+│       ├── pool.xml          # Connection pool settings (managed by CLI — do not hand-edit)
+│       └── wallet/           # Pool secrets such as db.password
 ├── global/
-│   └── settings.json         # Global ORDS settings (managed by CLI)
-└── credentials              # Oracle Wallet directory — passwords stored here, never in JSON
+│   ├── settings.xml         # Global ORDS settings (managed by CLI)
+│   └── wallet/              # Present if you store global secrets via --global
 ```
 
-> All configuration files are managed by the `ords config set` CLI. Do not hand-edit JSON files. Passwords are stored in the Oracle Wallet (`credentials/`) and never appear in any config file.
+> All configuration files are managed by the ORDS CLI. Do not hand-edit XML files. Pool secrets such as `db.password` are stored in `databases/{pool_name}/wallet`, and global secrets use `global/wallet`.
 
 ---
 
@@ -179,7 +180,7 @@ echo "SysPassword123!" | ords --config /opt/oracle/ords/config install \
 
 ## Pool Configuration Reference
 
-All pool settings are managed exclusively via the `ords config set` CLI. **Passwords are stored in an Oracle Wallet** in the `credentials/` directory — they never appear in any configuration file. Do not hand-edit the JSON config files ORDS generates.
+All pool settings are managed exclusively via the `ords config set` CLI. **Pool passwords are stored in an Oracle Wallet** in the `databases/{pool_name}/wallet` directory — they never appear in any configuration file. Do not hand-edit the XML config files ORDS generates.
 
 ```shell
 # Set connection parameters
@@ -189,8 +190,7 @@ ords --config /opt/oracle/ords/config config set db.servicename mypdb.example.co
 ords --config /opt/oracle/ords/config config set db.username ORDS_PUBLIC_USER
 
 # Set password — stored in Oracle Wallet, never in a config file
-ords --config /opt/oracle/ords/config config secret set db.password \
-  --password-stdin <<< "MySecurePassword123!"
+ords --config /opt/oracle/ords/config config secret --password-stdin db.password <<< "MySecurePassword123!"
 
 # UCP pool sizing
 ords --config /opt/oracle/ords/config config set jdbc.InitialLimit 5
@@ -253,8 +253,7 @@ ords --config /opt/oracle/ords/config config set db.tnsAliasName myatp_high
 ords --config /opt/oracle/ords/config config set \
   db.wallet.zip.path /opt/oracle/ords/wallet/Wallet_MYATP.zip
 ords --config /opt/oracle/ords/config config set db.username ORDS_PUBLIC_USER
-ords --config /opt/oracle/ords/config config secret set db.password \
-  --password-stdin <<< "MySecurePassword123!"
+ords --config /opt/oracle/ords/config config secret --password-stdin db.password <<< "MySecurePassword123!"
 ```
 
 ---
@@ -398,7 +397,7 @@ The `ords install` command is idempotent — re-running it upgrades the schema i
 
 - **Separate config directory from software directory**: The config dir should persist across software upgrades. Store in `/opt/oracle/ords/config` (not inside the ORDS software directory).
 - **Use ORDS CLI for all config changes**: Avoid manually editing XML files. The CLI handles wallet management, schema validation, and config refresh.
-- **Passwords live in the Oracle Wallet**: ORDS stores all passwords in an Oracle Wallet (`credentials/` in the config directory). Passwords never appear in any config file. Always use `ords config secret set db.password` to set or rotate credentials — never attempt to write a password directly into a config file.
+- **Passwords live in an Oracle Wallet**: Pool passwords such as `db.password` are stored in `databases/{pool_name}/wallet`, while global secrets use `global/wallet`. Passwords never appear in config files. Always use `ords config secret --password-stdin db.password` to set or rotate pool credentials — never attempt to write a password directly into a config file.
 - **Use TNS aliases for ADB**: Wallet-based connections via TNS aliases are more maintainable than custom JDBC URLs.
 - **Test with `ords validate`** before starting after a config change: `ords --config /path/config validate` checks pool connectivity and reports issues.
 - **Set `jdbc.MaxLimit` based on DB max sessions**: Too high a limit can exhaust DB connections. Use `SELECT * FROM v$resource_limit WHERE resource_name = 'sessions'` to check limits.
@@ -474,11 +473,10 @@ The `ords install` command is idempotent — re-running it upgrades the schema i
 - **Always use the Oracle Wallet for credential storage:**
   ```bash
   # CORRECT: Passwords stored in Oracle Wallet only
-  ords --config /opt/oracle/ords/config config secret set db.password \
-    --password-stdin <<< "SecureDatabasePassword123!"
+  ords --config /opt/oracle/ords/config config secret --password-stdin db.password <<< "SecureDatabasePassword123!"
 
   # INCORRECT: Attempting to store passwords in config files (won't work)
-  # DO NOT ATTEMPT TO MANUALLY EDIT pool.json TO ADD PASSWORDS
+  # DO NOT ATTEMPT TO MANUALLY EDIT pool.xml TO ADD PASSWORDS
   ```
 
 - **Use strong, unique passwords for all ORDS-related accounts:**
@@ -527,7 +525,8 @@ The `ords install` command is idempotent — re-running it upgrades the schema i
   - Apply same access controls to backups as live configuration
 
 - **Secure wallet backups:**
-  - The Oracle Wallet in credentials/ contains all passwords
+  - Pool passwords are stored in `databases/{pool_name}/wallet`
+  - Global secrets, if used, are stored in `global/wallet`
   - Back up the wallet securely and separately from other backups
   - Ensure wallet backups are encrypted and access-controlled
 
@@ -650,10 +649,10 @@ The `ords install` command is idempotent — re-running it upgrades the schema i
 - **Validate installation security:**
   ```bash
   # Check that passwords are not in config files
-  grep -r "password" /opt/oracle/ords/config/ --exclude-dir=credentials
+  grep -r "password" /opt/oracle/ords/config/ --exclude-dir=wallet
 
   # Verify wallet directory permissions
-  ls -la /opt/oracle/ords/config/credentials/
+  ls -la /opt/oracle/ords/config/databases/default/wallet/
 
   # Check OS user ORDS is running as
   ps -ef | grep ords

--- a/skills/ords/ords-metadata-catalog.md
+++ b/skills/ords/ords-metadata-catalog.md
@@ -472,6 +472,6 @@ The exported CLOB contains rerunnable `ORDS.DEFINE_MODULE`, `ORDS.DEFINE_TEMPLAT
 
 ## Sources
 
-- [ORDS Developer's Guide — OpenAPI and Metadata Catalog](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/orddg/developing-oracle-rest-data-services-applications.html)
-- [Oracle REST Data Services PL/SQL API Reference — ORDS.DEFINE_PARAMETER](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/orrst/index.html)
+- [Developing REST Applications](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/orddg/developing-REST-applications.html)
+- [ORDS PL/SQL Package Reference — ORDS.DEFINE_PARAMETER](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/orddg/ORDS-reference.html#GUID-BBB858FB-DB54-44E3-A2D5-387443FF6B8E)
 - [Oracle REST Data Services PL/SQL API Reference — ORDS_EXPORT and ORDS_EXPORT_ADMIN](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/orddg/ORDS-reference.html)

--- a/skills/ords/ords-monitoring.md
+++ b/skills/ords/ords-monitoring.md
@@ -10,81 +10,49 @@ Effective ORDS operations require visibility into request patterns, connection p
 
 ### Log Directory
 
-By default, ORDS writes logs to a `logs/` directory inside the ORDS config directory:
-
-```
-/opt/oracle/ords/config/
-└── logs/
-    ├── ords/
-    │   ├── ords_log_2024-01-15.log     # Main application log
-    │   ├── ords_log_2024-01-15.log.1   # Rolled-over log
-    │   └── ...
-    └── ...
-```
-
-Configure a standalone access log path:
+In standalone mode, ORDS writes HTTP access logs only when `standalone.access.log` is configured:
 
 ```shell
-ords --config /opt/oracle/ords/config config set standalone.access.log /var/log/ords
+ords --config /opt/oracle/ords/config config set standalone.access.log /var/log/ords/access
+ords --config /opt/oracle/ords/config config set standalone.access.log.retainDays 10
 ```
 
 Use `--log-folder` with `ords install` or `ords install repair` when you want installation or upgrade logs written to a specific folder.
 
 ### Log Levels
 
-ORDS uses Java Logging (JUL) with configurable levels:
+ORDS uses Java Logging (JUL) for application logs. Configure JUL with a `logging.properties` file rather than an ORDS config setting:
 
-```shell
-# Set global log level
-ords --config /opt/oracle/ords/config config set log.level INFO
-
-# Available levels: FINEST, FINER, FINE, CONFIG, INFO, WARNING, SEVERE
-# FINE = debug level, shows individual SQL executions
-# INFO = normal operations
-# WARNING = recoverable errors
-# SEVERE = critical errors
+```properties
+handlers=java.util.logging.FileHandler,java.util.logging.ConsoleHandler
+.level=INFO
+java.util.logging.FileHandler.level=INFO
+java.util.logging.FileHandler.pattern=/var/log/ords/ords.%g.log
+java.util.logging.FileHandler.limit=10485760
+java.util.logging.FileHandler.count=10
+java.util.logging.FileHandler.append=true
+java.util.logging.FileHandler.formatter=oracle.dbtools.logging.JSONLogFormatter
 ```
 
-For production: `INFO` level. For troubleshooting: `FINE` or `FINER`.
+```shell
+export JDK_JAVA_OPTIONS="-Djava.util.logging.config.file=/etc/ords/logging.properties"
+ords --config /opt/oracle/ords/config serve --secure --port 8443
+```
+
+For production, start with `INFO` or `WARNING`. For troubleshooting, temporarily use `FINE` or `FINER` for the specific logger you are investigating.
 
 ---
 
-## Enabling Request Logging
+## Enabling Standalone Access Logging
 
-Request logging records each HTTP request with URL, method, status code, response time, and client info.
-
-```shell
-# Configure external error path via the ORDS CLI
-ords --config /opt/oracle/ords/config config set error.externalPath /var/log/ords/errors
-```
-
-Configure request logging via the ORDS CLI:
+Standalone access logging records each HTTP request for operational monitoring and downstream analysis:
 
 ```shell
-# Enable access/request log
-ords --config /opt/oracle/ords/config config set log.logging.requestlog true
-
-# Log format (combined = Apache combined log format)
-ords --config /opt/oracle/ords/config config set log.logging.requestlog.format combined
-
-# Log requests slower than 5000ms as "slow"
-ords --config /opt/oracle/ords/config config set log.logging.requestlog.slow 5000
+ords --config /opt/oracle/ords/config config set standalone.access.log /var/log/ords/access
+ords --config /opt/oracle/ords/config config set standalone.access.log.retainDays 10
 ```
 
-### Sample Request Log Entry
-
-```
-2024-01-15 14:23:05.123 [INFO] [worker-5] oracle.dbtools.http.ords.RequestLog
-  method=GET path=/ords/hr/v1/employees/ status=200
-  elapsed=145ms rows=25 pool=default user=reporting-svc
-  remote=10.0.1.42 userAgent=MyApp/1.0
-```
-
-Fields:
-- `elapsed`: Total handler execution time in milliseconds
-- `rows`: Number of result rows returned
-- `pool`: Connection pool name used
-- `user`: Authenticated username (or `oracle` for public requests)
+Access logs are separate from application logs. If you need structured application logs for aggregation or OCI Logging, use a `logging.properties` file with JUL and the ORDS JSON formatter.
 
 ---
 
@@ -314,19 +282,22 @@ Environment="JAVA_OPTS=-Xms512m -Xmx2g -XX:+UseG1GC -XX:MaxGCPauseMillis=200"
 ### Request Thread Pool
 
 ```shell
-# Increase HTTP request threads for high-concurrency (Jetty standalone)
-ords --config /opt/oracle/ords/config config set standalone.threadPoolMax 200
+# Increase HTTP request threads for high-concurrency (standalone mode)
+ords --java-options "-Dthreads.max=200" \
+  --config /opt/oracle/ords/config serve --secure --port 8443
 ```
 
-### Pagination Default
+Request thread tuning is a runtime Java option, not an ORDS config setting.
 
-Reduce default page size to lower average response time and DB load:
+### Pagination Limits
+
+Use `misc.pagination.maxRows` to cap the maximum rows ORDS will return from query-based REST services:
 
 ```shell
-# Default is 25 rows; reduce for mobile/API clients
-ords --config /opt/oracle/ords/config config set misc.pagination.defaultLimit 10
 ords --config /opt/oracle/ords/config config set misc.pagination.maxRows 500
 ```
+
+For custom REST modules, control the default page size with `p_items_per_page` in `ORDS.DEFINE_MODULE` or `ORDS.DEFINE_HANDLER`.
 
 ---
 
@@ -524,5 +495,7 @@ Common validation failures:
 ## Sources
 
 - [Deploying and Monitoring Oracle REST Data Services — Monitoring Oracle REST Data Services](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/deploying-and-monitoring-oracle-rest-data-services.html#GUID-116149DE-01E1-4056-A723-0EFB96737377)
+- [Deploying and Monitoring Oracle REST Data Services — Configure Java Logging in ORDS](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/deploying-and-monitoring-oracle-rest-data-services.html#GUID-1E921E59-53FC-431B-B8AB-5C1312B230FC)
 - [About the Oracle REST Data Services Configuration Files — Understanding the Configurable Settings](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/about-REST-configuration-files.html#GUID-006F916B-8594-4A78-B500-BB85F35C12A0)
-- [Installing and Configuring Oracle REST Data Services](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/installing-and-configuring-oracle-rest-data-services.html#GUID-B6661F35-3EE3-4CB3-9379-40D0B8E24635)
+- [Miscellaneous Configuration Options of Oracle REST Data Services — Configuring Jetty in ORDS Standalone Mode](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/miscellaneous-configuration-options-of-ORDS.html#GUID-9F3CE874-6C6F-4C5D-B0DE-AAFC9332DEA9)
+- [Miscellaneous Configuration Options of Oracle REST Data Services — Configuring the Maximum Number of Rows Returned from a Query](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/miscellaneous-configuration-options-of-ORDS.html#GUID-FACEB063-8809-4BC2-B4DA-501C8511D6E0)

--- a/skills/ords/ords-monitoring.md
+++ b/skills/ords/ords-monitoring.md
@@ -22,18 +22,13 @@ By default, ORDS writes logs to a `logs/` directory inside the ORDS config direc
     └── ...
 ```
 
-Configure a custom log path:
+Configure a standalone access log path:
 
 ```shell
-ords --config /opt/oracle/ords/config config set log.dir /var/log/ords
+ords --config /opt/oracle/ords/config config set standalone.access.log /var/log/ords
 ```
 
-Or specify at startup:
-
-```shell
-ords --config /opt/oracle/ords/config serve \
-  --log-folder /var/log/ords
-```
+Use `--log-folder` with `ords install` or `ords install repair` when you want installation or upgrade logs written to a specific folder.
 
 ### Log Levels
 
@@ -528,6 +523,6 @@ Common validation failures:
 
 ## Sources
 
-- [ORDS Developer's Guide — Monitoring and Diagnosing Oracle REST Data Services](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/orddg/about-oracle-rest-data-services.html)
-- [ORDS Configuration Settings Reference — Logging and Performance](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/ordig/configuration-settings.html)
-- [ORDS CLI Reference — ords validate](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/ordig/ords-command-line-interface.html)
+- [Deploying and Monitoring Oracle REST Data Services — Monitoring Oracle REST Data Services](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/deploying-and-monitoring-oracle-rest-data-services.html#GUID-116149DE-01E1-4056-A723-0EFB96737377)
+- [About the Oracle REST Data Services Configuration Files — Understanding the Configurable Settings](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/about-REST-configuration-files.html#GUID-006F916B-8594-4A78-B500-BB85F35C12A0)
+- [Installing and Configuring Oracle REST Data Services](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/installing-and-configuring-oracle-rest-data-services.html#GUID-B6661F35-3EE3-4CB3-9379-40D0B8E24635)

--- a/skills/ords/ords-pl-sql-gateway.md
+++ b/skills/ords/ords-pl-sql-gateway.md
@@ -536,6 +536,6 @@ ORDS.DEFINE_HANDLER(
 
 ## Sources
 
-- [ORDS Developer's Guide — Developing PL/SQL-Based REST Services](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/orddg/developing-oracle-rest-data-services-applications.html)
-- [Oracle REST Data Services Handler Source Types Reference](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/orrst/index.html)
-- [ORDS Implicit Parameters Reference (status_code, body, forward_location)](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/orddg/implicit-parameters.html)
+- [Developing REST Applications — Manually Creating RESTful Services Using SQL and PL/SQL](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/orddg/developing-REST-applications.html#GUID-C9D763FD-9B74-4A27-9B80-6E500756E464)
+- [ORDS PL/SQL Package Reference](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/orddg/ORDS-reference.html)
+- [ORDS Implicit Parameters Reference (status_code, body, forward_location)](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/orddg/implicit-parameters.html)

--- a/skills/ords/ords-rest-api-design.md
+++ b/skills/ords/ords-rest-api-design.md
@@ -515,6 +515,6 @@ Aggregation:            GET    /v1/departments/:id/headcount
 
 ## Sources
 
-- [ORDS Developer's Guide — Creating and Editing REST APIs](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/orddg/developing-oracle-rest-data-services-applications.html)
-- [Oracle REST Data Services PL/SQL API Reference — ORDS.DEFINE_MODULE](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/orrst/index.html)
-- [ORDS Implicit Parameters Reference](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/orddg/implicit-parameters.html)
+- [Developing REST Applications — Manually Creating RESTful Services Using SQL and PL/SQL](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/orddg/developing-REST-applications.html#GUID-C9D763FD-9B74-4A27-9B80-6E500756E464)
+- [ORDS PL/SQL Package Reference — ORDS.DEFINE_MODULE](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/orddg/ORDS-reference.html#GUID-7FC25CDA-E359-4406-9555-04C68FB55EE4)
+- [ORDS Implicit Parameters Reference](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/orddg/implicit-parameters.html)

--- a/skills/ords/ords-security.md
+++ b/skills/ords/ords-security.md
@@ -28,21 +28,18 @@ When `security.forceHTTPS = true`, ORDS:
 Using a certificate from Let's Encrypt or a commercial CA:
 
 ```shell
-# Convert PEM certificate to PKCS12 for Java keystore
-openssl pkcs12 -export \
-  -in /etc/ssl/certs/api.example.com.crt \
-  -inkey /etc/ssl/private/api.example.com.key \
-  -certfile /etc/ssl/certs/chain.crt \
-  -out /opt/oracle/ords/config/ords/standalone/api.p12 \
-  -name ords-ssl \
-  -passout pass:changeit
+# Convert the private key to DER for ORDS
+openssl pkcs8 -topk8 -inform PEM -outform DER \
+  -in /etc/letsencrypt/live/api.example.com/privkey.pem \
+  -out /etc/letsencrypt/live/api.example.com/privkey.der \
+  -nocrypt
 
 # Configure ORDS to use it
 ords --config /opt/oracle/ords/config config set standalone.https.port 443
 ords --config /opt/oracle/ords/config config set standalone.https.cert \
-  /opt/oracle/ords/config/ords/standalone/api.p12
+  /etc/letsencrypt/live/api.example.com/fullchain.pem
 ords --config /opt/oracle/ords/config config set \
-  standalone.https.cert.secret changeit
+  standalone.https.cert.key /etc/letsencrypt/live/api.example.com/privkey.der
 ```
 
 ### TLS Minimum Version and Cipher Suites
@@ -479,6 +476,7 @@ add_header Permissions-Policy        "geolocation=(), microphone=()" always;
 
 ## Sources
 
-- [ORDS Developer's Guide — Securing Oracle REST Data Services](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/orddg/about-oracle-rest-data-services.html)
-- [ORDS Configuration Settings Reference — Security Settings](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/24.2/ordig/configuration-settings.html)
+- [Deploying and Monitoring Oracle REST Data Services — Serve Commands for Running in Standalone Mode](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/deploying-and-monitoring-oracle-rest-data-services.html#GUID-872EA939-5348-4B31-B4EC-EFD038F69837)
+- [Deploying and Monitoring Oracle REST Data Services — Converting a Private Key to DER (Linux and Unix)](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/deploying-and-monitoring-oracle-rest-data-services.html#GUID-1E64886C-C85C-49B5-A98E-79B9EC8455B4)
+- [About the Oracle REST Data Services Configuration Files — Understanding the Configurable Settings](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/about-REST-configuration-files.html#GUID-006F916B-8594-4A78-B500-BB85F35C12A0)
 - [Oracle Database Vault Administrator's Guide 19c](https://docs.oracle.com/en/database/oracle/oracle-database/19/dvadm/index.html)

--- a/skills/ords/ords-security.md
+++ b/skills/ords/ords-security.md
@@ -12,16 +12,15 @@ This guide covers ORDS-specific security controls, complementing Oracle Database
 
 Never expose ORDS over plain HTTP in any non-development environment. Configure ORDS to refuse or redirect HTTP requests.
 
-### Force HTTPS in ORDS Configuration
+### Reverse Proxy HTTPS Header Handling
 
 ```shell
-# Require HTTPS for all requests
-ords --config /opt/oracle/ords/config config set security.forceHTTPS true
+# Tell ORDS the original client request arrived over HTTPS at the proxy
+ords --config /opt/oracle/ords/config config set \
+  security.httpsHeaderCheck "X-Forwarded-Proto: https"
 ```
 
-When `security.forceHTTPS = true`, ORDS:
-- Redirects HTTP requests to HTTPS (301)
-- Adds `Strict-Transport-Security` header to responses
+Use this when TLS is terminated at Nginx, Apache HTTPD, a load balancer, or another reverse proxy that forwards requests to ORDS over HTTP. Configure HTTP-to-HTTPS redirects and `Strict-Transport-Security` at the reverse proxy layer.
 
 ### HTTPS with ORDS Standalone (Production Certificate)
 

--- a/skills/ords/ords-security.md
+++ b/skills/ords/ords-security.md
@@ -270,22 +270,20 @@ END;
 
 ### ORDS Wallet-Based Secret Storage (Default Mechanism)
 
-All passwords in ORDS are stored in an **Oracle Wallet** (credential store) in the `credentials/` directory of the ORDS config. Passwords never appear in any configuration file. Use `ords config secret set` to set or rotate any credential:
+Pool secrets such as `db.password` are stored in an **Oracle Wallet** in `databases/{pool_name}/wallet`. If you use `ords config secret --global`, ORDS stores the secret in `global/wallet`. Secrets never appear in configuration files. Use `ords config secret` to set or rotate them:
 
 ```shell
 # Set the DB password — stored in Oracle Wallet only
-ords --config /opt/oracle/ords/config config secret set db.password \
-  --password-stdin <<< "MySecurePassword123!"
+ords --config /opt/oracle/ords/config config secret --password-stdin db.password <<< "MySecurePassword123!"
 
 # Rotate a password — re-run with the new value
-ords --config /opt/oracle/ords/config config secret set db.password \
-  --password-stdin <<< "NewSecurePassword456!"
+ords --config /opt/oracle/ords/config config secret --password-stdin db.password <<< "NewSecurePassword456!"
 
 # Verify the wallet is present (passwords are not readable from config files)
-ls /opt/oracle/ords/config/credentials/
+ls /opt/oracle/ords/config/databases/default/wallet/
 ```
 
-Protect the `credentials/` directory with OS-level permissions (`chmod 700`) and include it in backup procedures alongside the rest of the config directory.
+Protect wallet directories with OS-level permissions (`chmod 700`) and include them in backup procedures alongside the rest of the config directory.
 
 ### OCI Vault Integration
 
@@ -297,8 +295,7 @@ OCI_SECRET=$(oci secrets secret-bundle get \
   --query 'data."secret-bundle-content".content' \
   --raw-output | base64 --decode)
 
-ords --config /opt/oracle/ords/config config secret set db.password \
-  --password-stdin <<< "$OCI_SECRET"
+ords --config /opt/oracle/ords/config config secret --password-stdin db.password <<< "$OCI_SECRET"
 ```
 
 ---
@@ -465,7 +462,7 @@ add_header Permissions-Policy        "geolocation=(), microphone=()" always;
 ## Common Mistakes
 
 - **Wildcard CORS on authenticated endpoints**: `*` CORS policy with OAuth2 Bearer tokens negates the token security — any site can make cross-origin requests. Use explicit origin allowlists.
-- **Attempting to write passwords into config files**: ORDS stores all credentials in an Oracle Wallet (`credentials/` directory) — passwords never belong in any config file. Use `ords config secret set db.password` to set or rotate them. Attempting to embed a password directly in a config file will not work and may break ORDS startup.
+- **Attempting to write passwords into config files**: ORDS stores secrets in wallet directories, not in config files. Use `ords config secret --password-stdin db.password` for pool credentials. Attempting to embed a password directly into a config file will not work and may break ORDS startup.
 - **Not disabling Database Actions in production (if not needed)**: Database Actions (`feature.sdw=true`) provides a powerful SQL execution interface. Disable it on API-only ORDS instances: `feature.sdw=false`.
 - **Using the same OAuth client for all services**: If a shared client is compromised, all services lose access. Use one OAuth client per service/application.
 - **Not testing authentication on every endpoint after a schema change**: Adding a new module does not automatically protect it. Verify each new endpoint requires the expected authentication.

--- a/skills/ords/ords-security.md
+++ b/skills/ords/ords-security.md
@@ -69,44 +69,54 @@ CORS (Cross-Origin Resource Sharing) controls which browser origins are allowed 
 
 ### Configure CORS in ORDS
 
-CORS settings are configured via the ORDS CLI:
+CORS configuration differs depending on whether you are exposing ORDS REST modules or PL/SQL Gateway procedures.
+
+### REST Modules
+
+For ORDS REST modules, use `ORDS.SET_MODULE_ORIGINS_ALLOWED` to set the allowed origins for a module. `p_module_name` must be the internal module name defined by `ORDS.DEFINE_MODULE`, not the URL path:
+
+```sql
+BEGIN
+  ORDS.SET_MODULE_ORIGINS_ALLOWED(
+    p_module_name     => 'employees_api',
+    p_origins_allowed => 'https://app.example.com,https://admin.example.com'
+  );
+  COMMIT;
+END;
+/
+```
+
+To remove any existing allowed origins for a module, set `p_origins_allowed` to an empty string:
+
+```sql
+BEGIN
+  ORDS.SET_MODULE_ORIGINS_ALLOWED(
+    p_module_name     => 'employees_api',
+    p_origins_allowed => ''
+  );
+  COMMIT;
+END;
+/
+```
+
+### PL/SQL Gateway
+
+For PL/SQL Gateway external sessions, configure the trusted origins with `security.externalSessionTrustedOrigins`:
 
 ```shell
-# Allow specific origins
-ords --config /opt/oracle/ords/config config set security.requestValidationFunction ords_util.authorize_plsql_gateway
-
-# Set allowed origins (comma-separated, no wildcards for authenticated endpoints)
-ords --config /opt/oracle/ords/config config set security.allowedCORSOrigins \
+ords --config /opt/oracle/ords/config config set \
+  security.externalSessionTrustedOrigins \
   "https://app.example.com,https://admin.example.com"
 ```
 
-Set all CORS parameters via the ORDS CLI:
-
-```shell
-ords --config /opt/oracle/ords/config config set \
-  security.allowedCORSOrigins "https://app.example.com,https://admin.example.com"
-ords --config /opt/oracle/ords/config config set \
-  security.allowedCORSHeaders "Authorization,Content-Type,X-Requested-With"
-ords --config /opt/oracle/ords/config config set \
-  security.allowedCORSMethods "GET,POST,PUT,DELETE,OPTIONS"
-ords --config /opt/oracle/ords/config config set security.maxAge 3600
-```
+If `security.externalSessionTrustedOrigins` is empty or not configured, then CORS requests to the PL/SQL Gateway are not allowed.
 
 ### CORS Best Practices
 
-```shell
-# WRONG: Wildcard on an authenticated API — allows any origin to send credentials
-ords config set security.allowedCORSOrigins "*"
-
-# CORRECT: Explicit trusted origins only
-ords config set security.allowedCORSOrigins "https://myapp.example.com"
-
-# For truly public read-only APIs, wildcard is acceptable
-# but protect all write operations with OAuth2 regardless
-ords config set security.allowedCORSOrigins "*"
-```
-
-When `security.forceHTTPS = true`, CORS allows HTTPS origins only. Mixed HTTP/HTTPS origins are rejected.
+- **Configure CORS per REST module**: Use `ORDS.SET_MODULE_ORIGINS_ALLOWED` for REST handlers.
+- **Use explicit trusted origins**: Prefer exact origins such as `https://app.example.com` over broad allowlists, especially for authenticated endpoints.
+- **Do not confuse request validation with CORS**: `security.requestValidationFunction` controls whether a PL/SQL Gateway procedure is allowed to execute; it is not the CORS allowlist.
+- **Configure PL/SQL Gateway separately**: Use `security.externalSessionTrustedOrigins` only for PL/SQL Gateway external sessions.
 
 ---
 
@@ -478,5 +488,6 @@ add_header Permissions-Policy        "geolocation=(), microphone=()" always;
 
 - [Deploying and Monitoring Oracle REST Data Services — Serve Commands for Running in Standalone Mode](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/deploying-and-monitoring-oracle-rest-data-services.html#GUID-872EA939-5348-4B31-B4EC-EFD038F69837)
 - [Deploying and Monitoring Oracle REST Data Services — Converting a Private Key to DER (Linux and Unix)](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/deploying-and-monitoring-oracle-rest-data-services.html#GUID-1E64886C-C85C-49B5-A98E-79B9EC8455B4)
+- [ORDS PL/SQL Package Reference — ORDS.SET_MODULE_ORIGINS_ALLOWED](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/orddg/ORDS-reference.html#GUID-012CD717-ACBE-4E36-9587-2D156A523BD3)
 - [About the Oracle REST Data Services Configuration Files — Understanding the Configurable Settings](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/ordig/about-REST-configuration-files.html#GUID-006F916B-8594-4A78-B500-BB85F35C12A0)
 - [Oracle Database Vault Administrator's Guide 19c](https://docs.oracle.com/en/database/oracle/oracle-database/19/dvadm/index.html)


### PR DESCRIPTION
## Summary

This PR updates the ORDS skills to correct outdated, inaccurate, and broken ORDS documentation examples. It aligns the skills with current ORDS CLI and configuration behavior, refreshes standalone HTTPS and reverse-proxy guidance, fixes the silent install walkthrough, replaces invalid monitoring settings with supported ones, corrects CORS guidance, and updates broken or outdated Oracle documentation links to 25.4 references.

## Commit Breakdown

  | Commit | Focus |
  |---|---|
  | docs(ords): align secret commands and wallet paths with current ORDS CLI | Fixes outdated secret-storage commands, updates wallet-path guidance, and corrects the current ORDS config layout references. |
  | docs(ords): refresh standalone HTTPS and logging commands | Replaces outdated standalone HTTPS flags and settings, updates reverse-proxy HTTPS handling, and refreshes logging-related command examples. |
  | docs(ords): fix silent install examples and update refs | Fixes the non-interactive install walkthrough, corrects stdin/password usage, adds documented tablespace options, and updates the related Oracle references. |
  | docs(ords): correct CORS guidance for REST modules and PL/SQL gateway | Replaces invalid CORS settings with documented REST module and PL/SQL Gateway guidance and clarifies the role of request validation. |
  | docs(ords): replace forceHTTPS with documented httpsHeaderCheck | Replaces undocumented security.forceHTTPS guidance with documented security.httpsHeaderCheck reverse-proxy handling. |
  | docs(ords): replace invalid monitoring settings with supported ones | Removes unsupported monitoring and tuning settings and replaces them with supported 25.4 logging, access-log, Java logging, thread, and pagination guidance. |
  | docs(ords): replace broken doc links and update sources to 25.4 | Removes broken Oracle doc links and updates the corrected ORDS skill source references to verified 25.4 pages and anchors. |


## What changed

- Replaced invalid `ords config secret set` examples with the correct ords config secret --password-stdin <secret> form.
- Updated wallet-path guidance to reflect the current ORDS configuration layout.
- Replaced invalid standalone HTTPS examples that used `--secure-port`, `--certificate-hostname`, and `standalone.https.cert.secret`.
- Updated standalone HTTPS guidance to use `serve --secure --port`, `standalone.https.cert`, `standalone.https.cert.key`, `standalone.https.port`, and `standalone.https.host`.
- Replaced invalid reverse-proxy HTTPS guidance that used `security.forceHTTPS` with the documented `security.httpsHeaderCheck`.
- Clarified that in reverse-proxy deployments, HTTP-to-HTTPS redirects and HTTP Strict Transport Security should be configured on the proxy or load balancer, not in ORDS.
- Fixed the silent install walkthrough by removing `--interactive false`.
- Removed the invalid `--db-username` example and clarified that `--db-user` is the correct flag when overriding the default runtime user.
- Added documented non-interactive install examples that use `--password-stdin` with both inline stdin input and file-based input redirection.
- Added `--proxy-user` where the examples provide both administrator and runtime-user passwords on stdin.
- Replaced the invalid `ords config set db.tablespace` guidance with install-time `--schema-tablespace` and `--schema-temp-tablespace` options.
- Replaced misleading CORS guidance that used invalid `security.allowedCORS*` settings.
- Added documented CORS guidance for REST modules using `ORDS.SET_MODULE_ORIGINS_ALLOWED`.
- Added documented PL/SQL Gateway CORS guidance using `security.externalSessionTrustedOrigins`.
- Clarified that `security.requestValidationFunction` is not the CORS allowlist.
- Removed invalid monitoring settings such as `log.level`, `log.logging.requestlog*`, `standalone.threadPoolMax`, and `misc.pagination.defaultLimit`.
- Removed broken or outdated Oracle doc links and updated remaining source references to Oracle REST Data Services 25.4 pages and anchors.

## Validation

- Reviewed the updated ORDS sections for internal consistency and structure.
- Verified the revised command examples against local ORDS binaries, including ORDS 25.4.0.
- Confirmed outdated `config secret set`, `security.forceHTTPS`, `allowedCORS*`, `--secure-port`, `standalone.https.cert.secret`, `--interactive false`, and invalid monitoring settings were removed from the revised skills.
- Confirmed the silent install section now reflects documented `--password-stdin`, `--proxy-user`, and install-time tablespace options.
- Confirmed the CORS section now documents `ORDS.SET_MODULE_ORIGINS_ALLOWED` and `security.externalSessionTrustedOrigins`.
- Confirmed broken or outdated 24.2/25.3 ORDS source links in the updated files were replaced with 25.4 references.
- Ran git diff --check on the touched documentation files.
- Used Codex during review to cross-check command names, settings, and documentation links.

## Notes
This is a skills/documentation change only.
