### PR TITLE
Add ORDS pre-authenticated requests and sessionless transaction skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 **Repository:** https://github.com/krisrice/oracle-db-skills
 **Version:** 1.0.0
 
-This repository is a collection of 117 standalone reference guides for Oracle Database. Each file covers one topic with explanations, practical examples, best practices, and common mistakes.
+This repository is a collection of 150 standalone reference guides for Oracle Database. Each file covers one topic with explanations, practical examples, best practices, and common mistakes.
 
 ## How to Use This Collection
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ skills/
 | Vector search, SELECT AI, DBMS_VECTOR, AI profiles, embeddings, RAG | `skills/features/` (vector-search, select-ai, dbms-vector, ai-profiles) |
 | Migrating from PostgreSQL, MySQL, SQL Server, MongoDB, etc. | `skills/migrations/` |
 | Alert log, ADR, adrci, space, top SQL, health checks | `skills/monitoring/` |
-| ORDS, REST APIs, OAuth2, AutoREST, PL/SQL gateway | `skills/ords/` |
+| ORDS, REST APIs, OAuth2, AutoREST, PL/SQL gateway, sessionless transactions, pre-authenticated requests (PAR) | `skills/ords/` |
 | AWR, ASH, explain plan, indexes, optimizer stats, wait events, memory | `skills/performance/` |
 | Packages, cursors, collections, error handling, unit testing, debugging | `skills/plsql/` |
 | Privileges, VPD, TDE, encryption, auditing, network security | `skills/security/` |
@@ -63,6 +63,8 @@ skills/
 - **`skills/performance/explain-plan.md`** — foundation for all SQL performance work
 - **`skills/plsql/plsql-package-design.md`** — foundation for PL/SQL architecture questions
 - **`skills/devops/schema-migrations.md`** — Liquibase/Flyway with Oracle in CI/CD pipelines
+- **`skills/ords/ords-pre-authenticated-requests.md`** — ORDS_PAR-based pre-authenticated links for protected handlers
+- **`skills/ords/ords-sessionless-transactions.md`** — GTRID-based transaction control across REST requests in ORDS
 - **`skills/agent/schema-discovery.md`** — run these queries at the start of every agent session
 - **`skills/agent/safe-dml-patterns.md`** — always apply before generating UPDATE/DELETE
 - **`skills/features/select-ai.md`** — Oracle's built-in NL-to-SQL (Oracle 26ai)

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: oracle-db-skills
-description: 117 Oracle Database reference guides covering SQL, PL/SQL, performance tuning, security, ORDS, SQLcl, migrations, and more. Load individual skill files on demand for expert guidance on any Oracle topic.
+description: 150 Oracle Database reference guides covering SQL, PL/SQL, performance tuning, security, ORDS, SQLcl, migrations, and more. Load individual skill files on demand for expert guidance on any Oracle topic.
 version: 1.0.0
 repository: https://github.com/krisrice/oracle-db-skills
 ---
 
 # Oracle DB Skills
 
-A collection of 103 standalone reference guides for Oracle Database. Each file covers one topic with explanations, practical examples, best practices, and common mistakes.
+A collection of 150 standalone reference guides for Oracle Database. Each file covers one topic with explanations, practical examples, best practices, and common mistakes.
 
 ## How to Use
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -27,7 +27,7 @@ A collection of 103 standalone reference guides for Oracle Database. Each file c
 | Advanced Queuing, DBMS_SCHEDULER, materialized views, DBLinks, APEX | `skills/features/` |
 | Migrating from PostgreSQL, MySQL, SQL Server, MongoDB, etc. | `skills/migrations/` |
 | Alert log, ADR, adrci, space, top SQL, health checks | `skills/monitoring/` |
-| ORDS, REST APIs, OAuth2, AutoREST, PL/SQL gateway | `skills/ords/` |
+| ORDS, REST APIs, OAuth2, AutoREST, PL/SQL gateway, sessionless transactions, pre-authenticated requests (PAR) | `skills/ords/` |
 | AWR, ASH, explain plan, indexes, optimizer stats, wait events, memory | `skills/performance/` |
 | Packages, cursors, collections, error handling, unit testing, debugging | `skills/plsql/` |
 | Privileges, VPD, TDE, encryption, auditing, network security | `skills/security/` |
@@ -61,3 +61,5 @@ skills/
 - **`skills/performance/explain-plan.md`** — foundation for all SQL performance work
 - **`skills/plsql/plsql-package-design.md`** — foundation for PL/SQL architecture questions
 - **`skills/devops/schema-migrations.md`** — Liquibase/Flyway with Oracle in CI/CD pipelines
+- **`skills/ords/ords-pre-authenticated-requests.md`** — ORDS_PAR-based pre-authenticated links for protected handlers
+- **`skills/ords/ords-sessionless-transactions.md`** — GTRID-based transaction control across REST requests in ORDS

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -119,6 +119,8 @@
 | `skills/ords/ords-installation.md` | ords | Installing ORDS, `ords config set`, wallet-based credential storage, mTLS for ATP/ADW |
 | `skills/ords/ords-auto-rest.md` | ords | ORDS.ENABLE_SCHEMA/OBJECT, endpoint patterns, JSON filter syntax, pagination |
 | `skills/ords/ords-rest-api-design.md` | ords | DEFINE_MODULE/TEMPLATE/HANDLER, source types, implicit bind parameters, CRUD examples |
+| `skills/ords/ords-pre-authenticated-requests.md` | ords | ORDS_PAR create/use/revoke flow, token lifecycle, URI parameter handling, expiry |
+| `skills/ords/ords-sessionless-transactions.md` | ords | GTRID lifecycle, `x-ords-sessionless-transaction-id`, timeout setting, database API commit/rollback |
 | `skills/ords/ords-authentication.md` | ords | OAuth2 client credentials and auth code flows, JWT validation, role mapping |
 | `skills/ords/ords-pl-sql-gateway.md` | ords | Calling PL/SQL from REST, REF CURSORs, APEX_JSON, error handling, CLOB/BLOB |
 | `skills/ords/ords-file-upload-download.md` | ords | BLOB upload/download, multipart form data, Content-Type/Content-Disposition |

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -3,7 +3,7 @@
 **Repository:** https://github.com/krisrice/oracle-db-skills
 **Version:** 1.0.0
 
-126 Oracle Database reference guides for AI agents. Each file is a standalone skill covering one topic with examples, best practices, and common mistakes.
+150 Oracle Database reference guides for AI agents. Each file is a standalone skill covering one topic with examples, best practices, and common mistakes.
 
 **Install:** `npx skills add krisrice/oracle-db-skills`
 

--- a/skills-index.md
+++ b/skills-index.md
@@ -129,6 +129,8 @@ A tracking file for skills.md topics to create for working with Oracle DB.
 - [x] `ords-installation.md` — Installing and configuring ORDS, pool configuration, wallet setup for ATP/ADW, upgrading
 - [x] `ords-auto-rest.md` — AutoREST enabling tables/views, generated endpoint patterns, filtering, pagination, ordering
 - [x] `ords-rest-api-design.md` — ORDS.DEFINE_MODULE/TEMPLATE/HANDLER, HTTP methods, bind parameters, implicit/explicit parameters
+- [x] `ords-pre-authenticated-requests.md` — ORDS_PAR create/use/revoke flow, token lifecycle, URI parameter handling, expiry
+- [x] `ords-sessionless-transactions.md` — GTRID lifecycle, `x-ords-sessionless-transaction-id`, timeout setting, database API commit/rollback
 - [x] `ords-authentication.md` — OAuth2 flows (client credentials, auth code), privilege definitions, role mapping, JWT validation
 - [x] `ords-pl-sql-gateway.md` — Calling PL/SQL from REST, OUT parameters, result sets via REF CURSORs, APEX_JSON, error handling
 - [x] `ords-file-upload-download.md` — BLOB upload/download endpoints, multipart form data, content-type handling

--- a/skills/ords/ords-pre-authenticated-requests.md
+++ b/skills/ords/ords-pre-authenticated-requests.md
@@ -1,0 +1,201 @@
+# ORDS Pre-Authenticated Requests (PAR)
+
+## Overview
+
+Oracle REST Data Services (ORDS) pre-authenticated requests (PAR) let you generate and use pre-authenticated links to access protected ORDS RESTful services without user credentials. When you create a PAR, ORDS generates a unique URL that you can provide to another user or system so it can interact with a specific RESTful entity using standard HTTP tools.
+
+ORDS exposes this feature through the `ORDS_PAR` PL/SQL package. Use it when you need a pre-authenticated URL for an existing protected handler in a REST-enabled schema.
+
+---
+
+## Prerequisites
+
+- The target schema must already be **REST-enabled**.
+- The PAR is valid only in the context of the **current REST-enabled schema**.
+- The target handler must already exist in the current schema.
+- The module name, pattern, and method passed to `ORDS_PAR.DEFINE_FOR_HANDLER` must match an existing handler.
+- If they do not match an existing handler exactly, ORDS raises `ORA-20071: No matching ORDS handler`.
+
+For the broader setup of schemas, handlers, and protection, see [ords-rest-api-design.md](./ords-rest-api-design.md) and [ords-authentication.md](./ords-authentication.md).
+
+---
+
+## Create a Matching Handler First (If Needed)
+
+The sample values `demo`, `emp/`, and `GET` are not universal. Use them only if that handler already exists in the current REST-enabled schema, or create a matching handler first:
+
+```sql
+BEGIN
+  ORDS.DEFINE_MODULE(
+    p_module_name    => 'demo',
+    p_base_path      => '/demo_prefix/',
+    p_items_per_page => 25,
+    p_status         => 'PUBLISHED',
+    p_comments       => 'PAR demo module'
+  );
+
+  ORDS.DEFINE_TEMPLATE(
+    p_module_name => 'demo',
+    p_pattern     => 'emp/',
+    p_comments    => 'PAR demo template'
+  );
+
+  ORDS.DEFINE_HANDLER(
+    p_module_name    => 'demo',
+    p_pattern        => 'emp/',
+    p_method         => 'GET',
+    p_source_type    => ORDS.source_type_collection_feed,
+    p_items_per_page => 25,
+    p_comments       => 'PAR demo handler',
+    p_source         => q'[
+      SELECT 'ok' AS status
+      FROM   dual
+    ]'
+  );
+
+  COMMIT;
+END;
+/
+```
+
+If you already have an existing handler, substitute its actual internal `p_module_name`, template `p_pattern`, and `p_method` values in the PAR example below.
+
+---
+
+## Create a Pre-Authenticated Request
+
+Use `ORDS_PAR.DEFINE_FOR_HANDLER` to create a PAR for an existing ORDS handler.
+
+Parameters documented by Oracle:
+
+- `p_module_name`: name of the existing RESTful service module; this value is case sensitive
+- `p_pattern`: matching pattern for an existing resource template
+- `p_method`: existing handler HTTP method; valid values are `GET`, `POST`, `PUT`, or `DELETE`
+- `p_duration`: validity duration in seconds
+
+Example:
+
+```sql
+SET SERVEROUTPUT ON
+
+DECLARE
+  l_par_json CLOB;
+  l_par_obj  JSON_OBJECT_T;
+BEGIN
+  l_par_json := ORDS_PAR.DEFINE_FOR_HANDLER(
+    p_module_name => 'demo',
+    p_pattern     => 'emp/',
+    p_method      => 'GET',
+    p_duration    => 360
+  );
+
+  COMMIT;
+
+  l_par_obj := JSON_OBJECT_T.PARSE(l_par_json);
+
+  DBMS_OUTPUT.PUT_LINE('token=' || l_par_obj.get_string('token'));
+  DBMS_OUTPUT.PUT_LINE('alias=' || l_par_obj.get_string('alias'));
+  DBMS_OUTPUT.PUT_LINE('uri='   || l_par_obj.get_string('uri'));
+END;
+/
+```
+
+Oracle documents that the function returns a JSON object containing:
+
+- `token`
+- `alias`
+- `uri`
+
+Keep track of the token and alias when you create the PAR because Oracle documents that you cannot obtain their values later.
+
+---
+
+## Use the Pre-Authenticated URL
+
+Use the exact `uri` value returned during PAR creation. The returned `uri` is relative, so prepend your ORDS base URL and schema mapping.
+
+Example:
+
+If `DEFINE_FOR_HANDLER` returned:
+
+```text
+uri=/_/par/<par_token>/demo_prefix/emp/
+```
+
+then call:
+
+```shell
+curl -i -X GET \
+  http://localhost:8080/ords/ordstest/_/par/<par_token>/demo_prefix/emp/
+```
+
+If the pre-authenticated request URL contains URI parameters identified by `:`, then you must replace them with concrete values before invoking the endpoint.
+
+Do not substitute an unrelated sample path; the request URL must match the `uri` returned for the handler you actually registered.
+
+---
+
+## Revoke a PAR
+
+Use `ORDS_PAR.REVOKE_PAR` with the token from the PAR URL.
+
+```sql
+BEGIN
+  ORDS_PAR.REVOKE_PAR(
+    p_par_token => '<par_token>'
+  );
+  COMMIT;
+END;
+/
+```
+
+Oracle documents that it may take up to **30 seconds** for the revoke request to take effect.
+
+---
+
+## Operational Notes
+
+- A PAR is created for an **existing handler**; it does not define a new module, template, or handler.
+- The returned `uri` is relative and is the URL you should use for later calls.
+- If the handler pattern includes URI parameters, the returned PAR URI uses the generic pattern and you must substitute real values before making the request.
+- If you drop or recreate the underlying handler or module, recreate any associated PARs as well. PARs are tied to existing handler metadata, and ORDS documents that redefining modules, templates, or handlers replaces the existing definitions.
+
+---
+
+## Best Practices
+
+- Store the returned token and alias immediately after creation because Oracle documents that they cannot be retrieved later.
+- Ensure the module, pattern, and method already exist in the current REST-enabled schema before calling `ORDS_PAR.DEFINE_FOR_HANDLER`.
+- Use a `p_duration` value that matches the intended validity window, remembering that Oracle documents the value in seconds.
+- Prefer short-lived PARs for ad hoc sharing, one-time access, or support workflows, and use longer durations only when the operational need is explicit.
+- Treat the full PAR URL as a bearer secret: anyone who has it can call the protected handler until it expires or is revoked.
+- Share PAR URLs only over trusted HTTPS channels and store them in a secret store or other controlled location.
+- Avoid logging, pasting, or screenshotting full PAR URLs in tickets, chat, dashboards, or application logs; redact the token if you must record it.
+- Substitute concrete values for any URI parameters in the returned PAR URL before invoking the endpoint.
+
+---
+
+## Common Mistakes
+
+- Trying to create a PAR for a handler that does not exist in the current REST-enabled schema.
+- Passing the wrong case for `p_module_name`.
+- Assuming ORDS will substitute URI parameter values in the returned PAR URI automatically.
+- Creating PARs with durations that are much longer than the real access window and then treating them as if they were short-lived.
+- Treating the PAR URL as harmless metadata and exposing it in logs, tickets, or chat.
+- Losing the returned token or alias and then trying to recover them later.
+- Dropping or recreating a handler or module and assuming existing PARs will continue to be valid without regeneration.
+- Expecting revocation to take effect immediately without allowing for the documented propagation delay.
+
+---
+
+## Oracle Version Notes (19c vs 26ai)
+
+- This PAR workflow is documented in the ORDS **25.4** and **26.1** developer guides.
+- The `ORDS_PAR.DEFINE_FOR_HANDLER` and `ORDS_PAR.REVOKE_PAR` interfaces cited here are also described in the ORDS **25.2** package reference.
+- This file does not rely on any **26.1**-only PAR syntax.
+
+## Sources
+
+- [Developing Oracle REST Data Services Applications (25.4)](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/orddg/developing-REST-applications.html)
+- [Developing Oracle REST Data Services Applications (26.1)](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/26.1/orddg/developing-REST-applications.html)
+- [ORDS_PAR PL/SQL Package Reference](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.2/orddg/ords_par-pl-sql-package-reference.html)

--- a/skills/ords/ords-sessionless-transactions.md
+++ b/skills/ords/ords-sessionless-transactions.md
@@ -1,0 +1,189 @@
+# ORDS Sessionless Transactions
+
+## Overview
+
+Sessionless transactions in Oracle REST Data Services (ORDS) let a client start a transaction on one database session, suspend it, and then resume and commit or roll it back from another request by using a global transaction identifier (`GTRID`). ORDS exposes database APIs to start, commit, and roll back the transaction, and then lets you carry the `GTRID` in `x-ords-sessionless-transaction-id` when calling REST-Enabled SQL, REST modules, or AutoREST services.
+
+Use this feature when a multi-step workflow must keep a single transaction open across multiple HTTP requests without tying up the same database session for the entire duration. Keep in mind that sessionless transactions are subject to a timeout, so the workflow must complete or explicitly resume and finalize the transaction before it expires.
+
+---
+
+## Prerequisites and Version Support
+
+- ORDS added documented sessionless transaction support in release **25.3**.
+- Oracle Database support starts with **Oracle AI Database Release 26ai, version 23.6**.
+- The control APIs require a client with the ORDS **SQL Administrator** or **SQL Developer** role.
+- Sessionless transactions apply to **a single Oracle Database**. Do not use them to coordinate work across multiple resource managers.
+
+Before using these examples, ensure the target pool is configured for ORDS Database API. In practice, that means `database.api.enabled=true` for the Database API endpoints and `restEnabledSql.active=true` for the current example flow. After changing pool settings, restart ORDS. Also use a REST-enabled schema alias and credentials authorized for the endpoint being called. See [ords-installation.md](./ords-installation.md) and [ords-authentication.md](./ords-authentication.md) for broader setup and authentication context.
+
+---
+
+## Configuring the Timeout
+
+ORDS uses the `jdbc.sessionlesstxn.timeout` pool setting to control how long a suspended sessionless transaction may remain suspended.
+
+```shell
+ords config --db-pool <pool_name> set jdbc.sessionlesstxn.timeout <timeout_value>
+```
+
+Example:
+
+```shell
+ords config --db-pool default set jdbc.sessionlesstxn.timeout 5m
+```
+
+If you omit `--db-pool`, ORDS applies the setting to the `default` pool. If you do not set this value, ORDS uses a **60-second** timeout. If a suspended sessionless transaction is not resumed within the configured duration, Oracle Database cancels the transaction.
+
+---
+
+## Management APIs
+
+ORDS exposes three database API endpoints for sessionless transaction control:
+
+| Operation | Method | Endpoint |
+|---|---|---|
+| Start | `POST` | `/ords/<schema_alias>/_/db-api/stable/database/sessionless-transactions/` |
+| Commit | `PUT` | `/ords/<schema_alias>/_/db-api/stable/database/sessionless-transactions/<GTRID>` |
+| Roll back | `DELETE` | `/ords/<schema_alias>/_/db-api/stable/database/sessionless-transactions/<GTRID>` |
+
+The `POST` call returns the `GTRID`, which must be reused on subsequent requests.
+
+---
+
+## Start a Transaction
+
+Use the database API to start a new sessionless transaction:
+
+```shell
+curl -X POST --location "https://localhost:8080/ords/<schema_alias>/_/db-api/stable/database/sessionless-transactions/" \
+    --user <username>:<password>
+```
+
+Response:
+
+```json
+{
+  "gtrid": "25fd48199404437aa5faf33fe2b9fe0c",
+  "status": "Start transaction"
+}
+```
+
+Persist the returned `gtrid` for the rest of the workflow.
+
+---
+
+## Invoke Services Within the Same Transaction
+
+To execute subsequent requests inside the same sessionless transaction, include the `GTRID` in either:
+
+- the `x-ords-sessionless-transaction-id` request header
+- the `x-ords-sessionless-transaction-id` query parameter
+
+ORDS documents this for REST-Enabled SQL, REST modules, and AutoREST calls.
+
+Examples:
+
+```http
+POST /ords/<schema_alias>/_/sql?x-ords-sessionless-transaction-id=<GTRID>
+
+GET /ords/<schema_alias>/table?x-ords-sessionless-transaction-id=<GTRID>
+```
+
+Using the query parameter:
+
+```shell
+curl -X POST --location "https://localhost:8080/ords/admin/_/sql?x-ords-sessionless-transaction-id=25fd48199404437aa5faf33fe2b9fe0c" \
+    --user <username>:<password> \
+    -H "Content-Type: application/sql" \
+    --data "SELECT * FROM my_table"
+```
+
+Using the header:
+
+```shell
+curl -X POST --location "https://localhost:8080/ords/admin/_/sql" \
+    --user <username>:<password> \
+    -H "Content-Type: application/sql" \
+    -H "x-ords-sessionless-transaction-id: 25fd48199404437aa5faf33fe2b9fe0c" \
+    --data "SELECT * FROM my_table"
+```
+
+As long as you keep sending the same `GTRID`, ORDS continues the work in the same sessionless transaction context.
+
+---
+
+## Commit or Roll Back the Transaction
+
+Commit:
+
+```shell
+curl -X PUT --location "https://localhost:8080/ords/<schema_alias>/_/db-api/stable/database/sessionless-transactions/<GTRID>" \
+     --user <username>:<password>
+```
+
+Roll back:
+
+```shell
+curl -X DELETE --location "https://localhost:8080/ords/<schema_alias>/_/db-api/stable/database/sessionless-transactions/<GTRID>" \
+     --user <username>:<password>
+```
+
+---
+
+## Transaction-Ending Behaviors
+
+ORDS explicitly notes that some REST requests can end the sessionless transaction without calling the control APIs:
+
+- A `COMMIT` statement ends the sessionless transaction.
+- A `ROLLBACK` statement ends the sessionless transaction.
+- DDL statements such as `CREATE`, `ALTER`, and `DROP` also end the sessionless transaction because they implicitly commit.
+
+Avoid mixing explicit transaction-control SQL or DDL into a workflow unless ending the transaction is intentional.
+
+---
+
+## Operational Notes
+
+Sessionless transactions break the usual coupling between the transaction and the session. After work is suspended, the session or connection can be released and used by another client while the transaction remains identified by its `GTRID`.
+
+When choosing the timeout, Oracle documents these tradeoffs:
+
+- very high timeout values can hold database resources, including locked rows, for longer
+- very low timeout values can cancel the transaction as soon as it is suspended and released
+- the default is `60` seconds
+
+---
+
+## Best Practices
+
+- Set `jdbc.sessionlesstxn.timeout` explicitly for the pool instead of relying on the default when the workflow spans multiple HTTP calls.
+- Treat the returned `GTRID` as required workflow state and pass it on every follow-up request.
+- Keep the unit of work inside one Oracle Database only.
+- Keep DDL and explicit `COMMIT` or `ROLLBACK` statements out of the service calls unless you intend to end the transaction.
+
+---
+
+## Common Mistakes
+
+- Starting a sessionless transaction and then forgetting to send the `GTRID` on the next request.
+- Letting the workflow sit longer than the configured timeout after the transaction is suspended.
+- Attempting to use the feature on Oracle Database 19c or earlier releases that do not support sessionless transactions.
+- Treating sessionless transactions as a multi-resource distributed transaction mechanism.
+
+---
+
+## Oracle Version Notes (19c vs 26ai)
+
+- Oracle Database **19c** does not support sessionless transactions.
+- ORDS introduced documented sessionless transaction support in **25.3**.
+- The database prerequisite is **Oracle AI Database Release 26ai, version 23.6**.
+- The same API pattern remains documented in the ORDS **25.4** and **26.1** developer guides.
+
+## Sources
+
+- [Changes in Release 25.3 Oracle REST Data Services Developer's Guide](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.3/orddg/changes-release-25.3-oracle-rest-data-services-developers-guide.html)
+- [Enabling ORDS Database API](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/orddg/enabling-ords-database-api.html)
+- [Developing Oracle REST Data Services Applications (25.4)](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/25.4/orddg/developing-REST-applications.html)
+- [Developing Oracle REST Data Services Applications (26.1)](https://docs.oracle.com/en/database/oracle/oracle-rest-data-services/26.1/orddg/developing-REST-applications.html)
+- [Oracle Database JDBC Developer's Guide — Sessionless Transactions](https://docs.oracle.com/en/database/oracle/oracle-database/23/jjdbc/sessionless-transactions.html)


### PR DESCRIPTION
### Summary
This PR adds two new ORDS skills covering pre-authenticated requests (PAR) and sessionless transactions. It documents the current ORDS workflows, operational constraints, best practices, and common mistakes for both features, and updates the repository metadata so the advertised skill count matches the actual number of skills in the project.

### What changed

- Added a new ORDS pre-authenticated requests skill covering:
    - prerequisites for ORDS_PAR.DEFINE_FOR_HANDLER
    - PAR creation and revoke flows
    - token, alias, and URI handling
    - URI parameter substitution requirements
    - security handling for PAR URLs as bearer secrets
    - operational notes for handler/module lifecycle
    - best practices for PAR duration and short-lived access
    - common mistakes around handler matching, token recovery, long durations, and revocation timing

- Added a new ORDS sessionless transactions skill covering:
    - the sessionless transaction workflow
    - transaction start, continue, commit, and rollback patterns
    - GTRID handling and request choreography
    - lifecycle, timeout, and safety guidance
    - common implementation mistakes and operational notes

- Updated the top-level skill metadata and index files to reflect the current total of 150 skills.
- Normalized inconsistent advertised totals across the repo.

### Validation

- Reviewed both new ORDS skills for structure, consistency, and alignment with the rest of skills/ords.
- Re-checked the PAR guidance against current Oracle documentation and incorporated review feedback on duration, lifecycle, and revocation behavior.
- Validated the generated output against a live ORDS environment and used the results to correct the documentation where needed.
- Confirmed the repository skill count now matches the actual markdown skill files in skills/ after adding the two new ORDS skills.
- Verified the published totals are now consistent across:
    - AGENTS.md
    - SKILL.md
    - SKILLS.md

### Notes

- This is a skills/documentation change only.
- No application code or runtime behavior was changed.
