### PR TITLE
Add MLE/JavaScript and Typescript to the index

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Oracle DB Skills is a curated library of 100+ practical, documentation-backed gu
 | [Database Design & Modeling](#database-design--modeling) | 4 | `skills/design/` |
 | [SQL Development](#sql-development) | 5 | `skills/sql-dev/` |
 | [Performance & Tuning](#performance--tuning) | 7 | `skills/performance/` |
-| [Application Development](#application-development) | 14 | `skills/appdev/` |
+| [Application Development](#application-development) | 15 | `skills/appdev/` |
 | [Security](#security) | 6 | `skills/security/` |
 | [Administration](#administration) | 6 | `skills/admin/` |
 | [Monitoring & Diagnostics](#monitoring--diagnostics) | 5 | `skills/monitoring/` |
@@ -105,6 +105,7 @@ Oracle DB Skills is a curated library of 100+ practical, documentation-backed gu
 | `nodejs-oracledb.md` | node-oracledb driver, async/await, pools, result sets, LOBs |
 | `dotnet-oracle.md` | ODP.NET managed driver, EF Core, array binding, OracleParameter |
 | `golang-oracle.md` | godror driver, database/sql interface, named binds, REF CURSORs |
+| `mle-javascript-in-database.md` | Multilingual Engine (MLE) JavaScript and Typescript support for Oracle AI Database 26ai |
 
 ---
 

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -30,6 +30,7 @@
 | `skills/appdev/connection-pooling.md` | appdev | UCP, DRCP, pool sizing, connection validation, JDBC/Python/Node.js examples |
 | `skills/appdev/transaction-management.md` | appdev | ACID properties, savepoints, autonomous transactions, distributed transactions |
 | `skills/appdev/locking-concurrency.md` | appdev | MVCC, SELECT FOR UPDATE, NOWAIT/SKIP LOCKED, deadlock avoidance |
+| `skills/appdev/mle-javascript-in-database.md` | appdev | Multilingual Engine (MLE)/JavaScript and Typescript support for Oracle AI Database 26ai |
 | `skills/appdev/sequences-identity.md` | appdev | Sequence caching, identity columns, UUID alternatives, gap behavior |
 | `skills/appdev/json-in-oracle.md` | appdev | Native JSON type, JSON_VALUE/QUERY/TABLE, JSON Duality Views (23c) |
 | `skills/appdev/xml-in-oracle.md` | appdev | XMLType storage, XQuery, XMLTable, XML indexes, XMLDB repository |

--- a/skills-index.md
+++ b/skills-index.md
@@ -37,6 +37,7 @@ A tracking file for skills.md topics to create for working with Oracle DB.
 - [x] `connection-pooling.md` — UCP, DRCP, connection best practices
 - [x] `transaction-management.md` — Commit frequency, savepoints, autonomous transactions
 - [x] `locking-concurrency.md` — Row locks, deadlocks, NOWAIT/SKIP LOCKED
+- [x] `mle-javascript-in-database.md` - Use MLE/JavaScript and Typescript in Oracle AI Database 26ai
 - [x] `sequences-identity.md` — Sequence caching, identity columns, UUID alternatives
 - [x] `json-in-oracle.md` — JSON data type, JSON_TABLE, dot notation, indexes
 - [x] `xml-in-oracle.md` — XMLType, XQuery, XML indexes


### PR DESCRIPTION
Request #19 added the MLE/JavaScript & Typescript skill to `skills/appdev/`. It did _not_ add these to the index, making it harder for the LLMs to find and use. This PR asks for the skill to be added to the index files:

- `skills.md`
- `skills-index.md`

Kindly review and merge this pull request.