### PR TITLE
Corrections, enhancements to core database component skills

### DIFF
--- a/skills/admin/user-management.md
+++ b/skills/admin/user-management.md
@@ -48,6 +48,8 @@ CREATE USER app_user
 
 **`ACCOUNT LOCK / UNLOCK`** — creates the account locked (prevents login until explicitly unlocked).
 
+**`NOAUTHENTICATION`** — creates the account without any mechanism for a session to be created with this account. Best practice for accounts that contain schema objects where direct login to that account should not be allowed.
+
 ### Altering Users
 
 ```sql
@@ -478,6 +480,8 @@ ORDER BY timestamp DESC;
 - **Review stale accounts monthly.** Lock accounts for users who have left the organization or whose projects have ended.
 
 - **Use proxy authentication for connection pools** to preserve end-user identity in audit trails.
+
+- **Use noauthentication for schema accounts in Production** to reduce potential harm from security breaches with passwords
 
 ---
 

--- a/skills/appdev/json-in-oracle.md
+++ b/skills/appdev/json-in-oracle.md
@@ -10,7 +10,7 @@ This guide covers the full spectrum: storage options, the complete SQL/JSON func
 
 ## JSON Storage Options
 
-### Pre-21c: VARCHAR2 / CLOB with IS JSON Constraint
+### Pre-21c: VARCHAR2 / BLOB with IS JSON Constraint
 
 ```sql
 -- VARCHAR2 for small JSON documents (≤32767 bytes)
@@ -21,10 +21,10 @@ CREATE TABLE product_catalog (
         CONSTRAINT chk_attributes_json CHECK (attributes IS JSON)
 );
 
--- CLOB for large documents
+-- BLOB for large documents
 CREATE TABLE event_log (
     event_id     NUMBER PRIMARY KEY,
-    event_data   CLOB
+    event_data   BLOB
         CONSTRAINT chk_event_json CHECK (event_data IS JSON)
 );
 
@@ -36,6 +36,8 @@ CREATE TABLE strict_json_table (
     data CLOB CONSTRAINT chk_strict CHECK (data IS JSON STRICT)
 );
 ```
+
+BLOBs are more storage efficient than CLOBs when storing JSON. Consider also using the FORMAT OSON clause until 21c+
 
 ### 21c+: Native JSON Data Type
 

--- a/skills/appdev/locking-concurrency.md
+++ b/skills/appdev/locking-concurrency.md
@@ -15,7 +15,7 @@ Understanding Oracle's locking architecture is essential for writing application
 When a row is modified, Oracle does not overwrite the old data in place. Instead:
 
 1. The new row version is written to the data block
-2. The old row version is stored in the **undo tablespace** (rollback segments)
+2. Instructions on how to resurrect the old row version is stored in the **undo tablespace** (rollback segments)
 3. Readers needing the old version reconstruct it from undo data on demand
 
 This creates a "time-travel" capability: every read sees a **consistent snapshot** of the database at the query's start SCN (System Change Number), regardless of concurrent writers.
@@ -55,6 +55,9 @@ ALTER SYSTEM SET UNDO_RETENTION = 3600;  -- 1 hour
 SELECT d.undoblks, d.maxquerylen, d.tuned_undoretention
 FROM   v$undostat d
 WHERE  rownum <= 1;
+
+-- Increase current or potential size of undo tablespace
+ALTER DATABASE DATAFILE '<undo file>' RESIZE | AUTOEXEND;
 
 -- Enable undo retention guarantee (prevents undo from being overwritten)
 ALTER TABLESPACE undotbs1 RETENTION GUARANTEE;
@@ -121,7 +124,14 @@ BEGIN
         UPDATE accounts SET balance = balance + 500 WHERE account_id = 2001;
         COMMIT;
     ELSE
-        ROLLBACK;
+        --
+        -- Generally a rollback should be used here, because the PL/SQL error 
+        -- will automatically roll back changes made in the PL/SQL block, and a rollback
+        -- will also roll back any outstanding made BEFORE this block was called which
+        -- is typically not the desired behaviour
+        --
+        --ROLLBACK;
+        --
         RAISE_APPLICATION_ERROR(-20001, 'Insufficient funds');
     END IF;
 END;
@@ -171,29 +181,32 @@ FOR UPDATE WAIT 5;
 ```sql
 -- Worker process: claim the next available pending job
 DECLARE
-    v_job_id   NUMBER;
-    v_payload  VARCHAR2(4000);
+    l_job_id   NUMBER;
+    l_payload  VARCHAR2(4000);
+    l_rc       SYS_REFCURSOR;
 BEGIN
-    -- Grab one unprocessed job, skipping any locked by other workers
-    SELECT job_id, payload INTO v_job_id, v_payload
-    FROM   job_queue
-    WHERE  status = 'PENDING'
-      AND  ROWNUM = 1
-    ORDER  BY created_at
-    FOR UPDATE SKIP LOCKED;
+    open l_rc for
+      SELECT job_id, payload
+      FROM   job_queue
+      WHERE  status = 'PENDING'
+      ORDER  BY created_at
+      FOR UPDATE SKIP LOCKED;
+
+    FETCH l_rc INTO l_job_id, l_payload;
+    EXIT WHEN l_rc%NOTFOUND;
 
     -- Mark as in-progress
     UPDATE job_queue SET status = 'PROCESSING', started_at = SYSTIMESTAMP
-    WHERE  job_id = v_job_id;
+    WHERE  job_id = l_job_id;
 
     COMMIT;
 
     -- Process the job (outside the lock)
-    process_job(v_job_id, v_payload);
+    process_job(l_job_id, l_payload);
 
     -- Mark complete
     UPDATE job_queue SET status = 'DONE', completed_at = SYSTIMESTAMP
-    WHERE  job_id = v_job_id;
+    WHERE  job_id = l_job_id;
     COMMIT;
 
 EXCEPTION
@@ -202,7 +215,19 @@ EXCEPTION
 END;
 ```
 
+will not produce correct behaviour. It will fetch PENDING one row (which may already be locked by another process) and only then attempt to lock it, and subsequently skip it, thus returning no rows.
+
 Multiple instances of this worker can run concurrently without any inter-process coordination — Oracle handles the row-level locking automatically.
+
+A common mistake when using SKIP LOCKED is using ROWNUM to limit the returned row. For example
+
+```sql
+    SELECT job_id, payload INTO l_job_id, l_payload
+    FROM   job_queue
+    WHERE  status = 'PENDING'
+    AND    ROWNUM = 1
+    FOR UPDATE SKIP LOCKED;
+```
 
 ---
 
@@ -288,7 +313,7 @@ END;
 
 **Strategy 4: Minimize Transaction Duration**
 
-The longer a transaction holds locks, the more opportunity for deadlocks. Commit frequently for batch operations.
+The longer a transaction holds locks, the more opportunity for deadlocks. 
 
 ---
 
@@ -315,7 +340,7 @@ LOCK TABLE orders IN ROW EXCLUSIVE MODE;
 
 Table locks in `EXCLUSIVE MODE` are rarely needed in application code. Primary use cases:
 - Bulk load operations where you want to prevent any concurrent DML
-- Schema changes when `ONLINE DDL` is not available
+- The database may lock a table during schema changes when ONLINE DDL is not available
 - Explicit synchronization for ETL processes
 
 ```sql
@@ -430,16 +455,17 @@ Read the row without locking. Only at update time, verify the row hasn't changed
 
 ```sql
 -- Read (no lock)
-SELECT order_id, status, last_modified, ORA_ROWSCN AS read_scn
+SELECT order_id, status, last_modified
+INTO   :order_id, :status, :last_modified
 FROM   orders
 WHERE  order_id = 1001;
 -- Application processes the data, user thinks about it...
 
--- Update with collision detection using ORA_ROWSCN or version column
+-- Update with collision detection using comparison with values previously fetched
 UPDATE orders
 SET    status = 'APPROVED', last_modified = SYSTIMESTAMP
 WHERE  order_id = 1001
-  AND  ORA_ROWSCN = :read_scn;  -- fails if row was changed since we read it
+  AND  last_modified = :last_modified; -- fails if row was changed since we read it
 
 IF SQL%ROWCOUNT = 0 THEN
     -- Row was modified by someone else; retry or raise conflict error
@@ -447,6 +473,13 @@ IF SQL%ROWCOUNT = 0 THEN
 END IF;
 COMMIT;
 ```
+
+An anti-pattern is to use the ORA_ROWSCN function as a mechanism for optimistic locking. Avoid this because
+- Tables require the ROW DEPENDENCIES clause, but no error will be raised if this is not the case
+- ORA_ROWSCN does not work on Index Organized Tables
+- ORA_ROWSCN requires columns in the UPDATE-SET clause are also referenced as predicates in the WHERE clause, otherwise it can return null
+
+In version 26ai an above, the SYS_ROW_ETAG can be used for optimistic locking without the drawbacks of ORA_ROWSCN
 
 **Using a version column for optimistic locking:**
 

--- a/skills/appdev/sequences-identity.md
+++ b/skills/appdev/sequences-identity.md
@@ -20,7 +20,7 @@ CREATE SEQUENCE schema.sequence_name
     MINVALUE        min_value            -- lower bound
     MAXVALUE        max_value            -- upper bound (default: 10^27 for ASC)
     NOCYCLE | CYCLE                      -- NOCYCLE raises ORA-08004 at limit (default: NOCYCLE)
-    CACHE n | NOCACHE                    -- pre-allocate n values in memory (default: 20)
+    CACHE n | NOCACHE                    -- Use memory for a sequence increment count to improve performance (default: 20)
     ORDER | NOORDER                      -- ORDER guarantees generation order (only matters for RAC)
     KEEP | NOKEEP                        -- affects sequence behavior after session restore
     SCALE | NOSCALE;                     -- introduced in 23ai: prepend instance/shard info for uniqueness
@@ -110,13 +110,15 @@ DROP SEQUENCE seq_customer_id;
 
 ## The CACHE Option: Performance Impact
 
-`CACHE` is the most impactful sequence parameter for performance. Oracle pre-allocates `CACHE` values in the SGA. Incrementing a cached sequence is a pure in-memory operation — extremely fast. Without caching (`NOCACHE`), every `NEXTVAL` requires a write to the `seq$` system table.
+`CACHE` is the most impactful sequence parameter for performance. Oracle uses the SGA to increment `CACHE` values before synchronising with the data dictionary table (SEQ$). Incrementing a cached sequence is a pure in-memory operation — extremely fast. Without caching (`NOCACHE`), every `NEXTVAL` requires a write to the `seq$` system table.
 
 ### Performance Comparison
 
+In 19c+ as long as you do not specify NOCACHE, a cached sequence will have its cache size automatically tuned by the database to achieve optimal performance. If you want to explicitly set a CACHE, these are some guidelines
+
+
 | Configuration | NEXTVAL Cost | Notes |
 |---|---|---|
-| `NOCACHE` | ~1 redo log write | ~100x slower; avoid in OLTP |
 | `CACHE 20` (default) | In-memory increment | Good for low-volume |
 | `CACHE 100` | In-memory increment | Good for moderate OLTP |
 | `CACHE 1000+` | In-memory increment | Bulk inserts, high-volume |
@@ -132,7 +134,7 @@ WHERE  sn.name = 'sequence misses'
 
 ### Cache Loss on Instance Restart
 
-When the database restarts, cached but unused sequence values are **discarded**. If you cached 1000 values and used 50, the next session starts at value 1051 — a gap of 950. This is normal and expected. If your application cannot tolerate gaps, you cannot use CACHE (and will pay the performance penalty).
+When the database restarts, cached but unused sequence values are **discarded**. If you cached 1000 values and used 50, the next session starts at value 1051 — a gap of 950. This is normal and expected. If your application cannot tolerate gaps, you cannot use sequences (and will pay the performance penalty).
 
 ```sql
 -- How many values will be lost on restart?

--- a/skills/appdev/transaction-management.md
+++ b/skills/appdev/transaction-management.md
@@ -112,12 +112,10 @@ BEGIN
     VALUES (p_from_account, p_to_account, p_amount, SYSDATE);
 
     COMMIT;  -- all three changes committed together
-EXCEPTION
-    WHEN OTHERS THEN
-        ROLLBACK;  -- all three changes discarded
-        RAISE;
 END;
 ```
+
+A benefit of PL/SQL is that a PL/SQL block is also a statement level transaction. If any of the three DMLs above had failed, all three will be rolled back automatically because the entire PL/SQL block is deemed a statement level transaction.
 
 ---
 
@@ -346,33 +344,14 @@ ORDER  BY mb_used DESC;
 
 ### Batch Processing Pattern — Commit in Batches
 
-```plpgsql
--- WRONG: one commit for millions of rows
-BEGIN
-    FOR r IN (SELECT id FROM large_table WHERE needs_processing = 'Y') LOOP
-        UPDATE large_table SET processed_date = SYSDATE WHERE id = r.id;
-    END LOOP;
-    COMMIT;  -- holds all locks for the entire loop duration
-END;
+For example, it may be the case that a single large UPDATE holds locks for too long a period
 
--- RIGHT: commit every N rows
-DECLARE
-    v_batch_size CONSTANT PLS_INTEGER := 1000;
-    v_count      PLS_INTEGER := 0;
-BEGIN
-    FOR r IN (SELECT id FROM large_table WHERE needs_processing = 'Y') LOOP
-        UPDATE large_table SET processed_date = SYSDATE WHERE id = r.id;
-        v_count := v_count + 1;
-
-        IF MOD(v_count, v_batch_size) = 0 THEN
-            COMMIT;
-        END IF;
-    END LOOP;
-    COMMIT;  -- final batch
-END;
+```sql
+UPDATE large_table SET processed_date = SYSDATE WHERE needs_processing = 'Y'
+COMMIT;  -- holds all locks for the entire loop duration
 ```
 
-### Using FORALL for Bulk DML
+To avoid this, commit every N rows also ensuring that the cursor is freshly reopened to avoid ORA-1555 errors.
 
 ```plpgsql
 DECLARE
@@ -381,19 +360,19 @@ DECLARE
     CURSOR c_pending IS
         SELECT id FROM large_table WHERE needs_processing = 'Y';
 BEGIN
-    OPEN c_pending;
     LOOP
-        FETCH c_pending BULK COLLECT INTO v_ids LIMIT 5000;
-        EXIT WHEN v_ids.COUNT = 0;
+      OPEN c_pending;
+      FETCH c_pending BULK COLLECT INTO v_ids LIMIT 5000;
+      EXIT WHEN v_ids.COUNT = 0;
 
-        FORALL i IN 1..v_ids.COUNT
-            UPDATE large_table
-            SET    processed_date = SYSDATE
-            WHERE  id = v_ids(i);
+      FORALL i IN 1..v_ids.COUNT
+          UPDATE large_table
+          SET    processed_date = SYSDATE
+          WHERE  id = v_ids(i);
 
         COMMIT;
+      CLOSE c_pending;
     END LOOP;
-    CLOSE c_pending;
 END;
 ```
 
@@ -403,7 +382,7 @@ END;
 
 - **Keep transactions as short as possible.** Do all computation before the transaction, execute DML, commit immediately.
 - **Never wait for user input inside a transaction.** The user might walk away, leaving locks held.
-- **Always handle exceptions and call ROLLBACK.** An unhandled exception in application code that disconnects without rollback leaves the transaction open until the session is killed.
+- **Always handle exceptions. Call ROLLBACK if necessary** An unhandled exception in application code that disconnects without rollback may leave the transaction open until the session is killed.
 - **Use `COMMIT WRITE BATCH NOWAIT` only for bulk loads** where you understand the durability trade-off.
 - **Prefer `FORALL` and bulk operations** over row-by-row DML to reduce commit frequency while keeping transactions short.
 - **Test with `SERIALIZABLE` isolation** if your application logic depends on consistent reads across multiple statements; do not assume `READ COMMITTED` provides snapshot consistency at the transaction level.
@@ -431,9 +410,17 @@ BEGIN
     UPDATE accounts SET balance = balance - 500 WHERE id = 1;
     UPDATE accounts SET balance = balance + 500 WHERE id = 2;
     COMMIT;
+    -- any error will be raised and both statements rolled back automatically by PL/SQL
+END;
+
+-- ALTERNATIVE 
+BEGIN
+    UPDATE accounts SET balance = balance - 500 WHERE id = 1;
+    UPDATE accounts SET balance = balance + 500 WHERE id = 2;
+    COMMIT;
 EXCEPTION
     WHEN OTHERS THEN
-        ROLLBACK;
+        log_error(...)  -- if we want to capture error details
         RAISE;  -- re-raise so the caller knows
 END;
 ```

--- a/skills/architecture/inmemory-column-store.md
+++ b/skills/architecture/inmemory-column-store.md
@@ -8,6 +8,7 @@ The primary benefit is analytic query acceleration: columnar storage, vectorized
 
 DBIM is an Oracle Database option — it requires a separate license unless you are using Oracle Exadata (where it is included) or Oracle Autonomous Database (where it is included and managed automatically).
 
+However, 19c+ permits 16GB of IN-MEMORY to be used per instance without requiring additional licensing options.
 ---
 
 ## 1. Architecture Overview

--- a/skills/design/partitioning-strategy.md
+++ b/skills/design/partitioning-strategy.md
@@ -152,7 +152,7 @@ PARTITION BY LIST (payment_type) AUTOMATIC  -- new partitions created on-the-fly
 - No natural range or category boundary exists
 - The goal is even I/O distribution across storage devices
 - Enabling **partition-wise joins** (when joining two hash-partitioned tables on the same key with the same number of partitions)
-- Reducing hot-block contention on high-concurrency insert tables
+- Reducing hot-block contention on high-concurrency insert tables or indexes
 
 ### Syntax
 
@@ -340,7 +340,7 @@ ORDER  BY partition_position;
 
 ### Local Indexes
 
-A **local index** is partitioned using the same strategy as the underlying table. Each index partition corresponds to exactly one table partition. Local indexes are the preferred choice for partitioned tables.
+A **local index** is partitioned using the same strategy as the underlying table. Each index partition corresponds to exactly one table partition. Local indexes are the preferred choice for partitioned tables if there is a requirement to keep partition maintenance as inexpensive as possible.
 
 ```sql
 -- Local non-unique index
@@ -383,8 +383,8 @@ TABLESPACE orders_idx;
 
 **Global index characteristics:**
 - Allows unique constraints on columns that don't include the partition key
-- Must be rebuilt (or marked UNUSABLE) after partition maintenance operations unless `UPDATE GLOBAL INDEXES` is specified
-- More expensive to maintain during partition DDL
+- Become stale after partition maintenance operations unless `UPDATE GLOBAL INDEXES` is specified. Once stale, the index can be manually rebuilt or the database automatically correct state global indexes over time with the back ground job
+- Can be more expensive to maintain during partition DDL if `UPDATE GLOBAL INDEXES` is specified
 
 ```sql
 -- Partition maintenance with global index update
@@ -426,7 +426,7 @@ ALTER TABLE SALES TRUNCATE PARTITION p_2022_q1;
 
 -- Exchange a partition with a staging table (zero-copy ETL)
 -- 1. Create staging table with identical structure (no partitioning)
-CREATE TABLE SALES_STAGING AS SELECT * FROM SALES WHERE 1=0;
+CREATE TABLE SALES_STAGING FOR EXCHANGE WITH SALES;
 
 -- 2. Load data into staging table (bulk insert, external table, etc.)
 INSERT /*+ APPEND */ INTO SALES_STAGING SELECT ...;

--- a/skills/design/tablespace-design.md
+++ b/skills/design/tablespace-design.md
@@ -88,7 +88,7 @@ CREATE TABLESPACE users_data
 - Data file up to **4 billion blocks** (32 TB with 8K blocks, up to 128 TB with 32K blocks)
 - Only 1 file number consumed per tablespace
 - Simpler management for very large tablespaces
-- RMAN backup of a bigfile tablespace = backup of 1 very large file (less I/O parallelism)
+- RMAN backup of a bigfile tablespace may require altering default settings to ensure I/O parallelism
 - Required for Oracle Managed Files (OMF) on some storage configurations
 
 ```sql
@@ -109,7 +109,6 @@ ALTER TABLESPACE dw_facts_data RESIZE 200G;  -- only valid for bigfile tablespac
 | Number of files | Up to 1022 per TS | Exactly 1 per TS |
 | Individual file size | Up to ~128 TB | Up to ~128 TB |
 | File number consumption | Multiple files per TS | 1 file per TS |
-| RMAN backup parallelism | High (multiple files backed up concurrently) | Low (single file) |
 | Management simplicity | More files to track | Simpler (1 file) |
 | Best for | OLTP, medium-size tables, flexibility | Huge DW fact tables, ASM environments |
 | ASM compatibility | Both work | Preferred on ASM (ASM handles striping) |
@@ -125,17 +124,18 @@ Extents are contiguous groups of Oracle blocks allocated to a segment. Extent ma
 Oracle tracks extent allocation in a bitmap stored within the tablespace's data files themselves, not in the SYSTEM tablespace's data dictionary. This eliminates contention on the data dictionary and is the default for all tablespaces since Oracle 9i.
 
 ```sql
--- Uniform extent size: all extents the same size (preferred for DW/uniform-size objects)
+-- Uniform extent size: all extents the same size
 CREATE TABLESPACE dw_idx
     DATAFILE '/u02/oradata/ORCL/dw_idx01.dbf' SIZE 10G AUTOEXTEND ON NEXT 1G MAXSIZE 100G
     EXTENT MANAGEMENT LOCAL UNIFORM SIZE 8M;  -- every extent is exactly 8M
 
 -- Autoallocate: Oracle chooses extent sizes (64K -> 1M -> 8M -> 64M...)
--- Preferred for OLTP with mixed object sizes
 CREATE TABLESPACE users_data
     DATAFILE '/u01/oradata/ORCL/users_data01.dbf' SIZE 4G AUTOEXTEND ON NEXT 512M MAXSIZE 50G
     EXTENT MANAGEMENT LOCAL AUTOALLOCATE;
 ```
+
+Autoallocate is likely sufficient for all workloads unless there are specific niche reasons to require a uniform extent size.
 
 **Uniform size guidelines:**
 
@@ -258,22 +258,15 @@ CREATE TABLESPACE app_data
     EXTENT MANAGEMENT LOCAL AUTOALLOCATE
     SEGMENT SPACE MANAGEMENT AUTO;
 
+--
+-- If you expect the need to do significant maintenance on LOBs, then 
+-- optionally dedicate a separate tablespace for them. Usually not required.
+--
 -- Large object (LOB) tablespace — separate from row data
 CREATE TABLESPACE app_lob
     DATAFILE '/u04/oradata/ORCL/app_lob_01.dbf' SIZE 20G
              AUTOEXTEND ON NEXT 2G MAXSIZE 1T
     EXTENT MANAGEMENT LOCAL UNIFORM SIZE 8M  -- uniform for LOB efficiency
-    SEGMENT SPACE MANAGEMENT AUTO;
-
--- ============================================================
--- APPLICATION INDEXES: always separate from data for I/O isolation
--- ============================================================
-CREATE TABLESPACE app_idx
-    DATAFILE '/u05/oradata/ORCL/app_idx_01.dbf' SIZE 5G
-             AUTOEXTEND ON NEXT 512M MAXSIZE 200G,
-            '/u05/oradata/ORCL/app_idx_02.dbf' SIZE 5G
-             AUTOEXTEND ON NEXT 512M MAXSIZE 200G
-    EXTENT MANAGEMENT LOCAL AUTOALLOCATE
     SEGMENT SPACE MANAGEMENT AUTO;
 
 -- ============================================================
@@ -513,11 +506,9 @@ WHERE  username = 'APP_OWNER';
 
 ## 9. Best Practices
 
-- **Separate data from indexes.** Index I/O patterns (random access) differ from table I/O patterns (sequential scans) — keeping them on separate tablespaces (ideally separate storage devices) improves I/O throughput.
 - **Separate OLTP data from DW data.** Different compression settings, extent sizes, and backup frequencies make separation critical.
 - **Never store application objects in SYSTEM or SYSAUX.** Corruption or space exhaustion in SYSTEM brings the entire database down.
 - **Cap AUTOEXTEND with a realistic MAXSIZE.** Unlimited autoextend on a filesystem will fill the disk and crash the database. Set `MAXSIZE` to leave at least 20% filesystem headroom.
-- **Use uniform extent sizes for DW tablespaces.** Uniform extents improve full scan performance (contiguous I/O) and simplify space management. Use `AUTOALLOCATE` for OLTP tablespaces with highly variable object sizes.
 - **Put LOB segments in a dedicated tablespace.** LOB segments grow independently from their row tables; isolating them prevents space contention and simplifies monitoring.
 - **Create read-only tablespaces for historical archive data.** Read-only tablespaces don't need backup after the final datafile checkpoint, dramatically reducing backup windows.
 - **Monitor tablespace usage proactively.** Set Oracle thresholds or custom alerts at 75% and 85% usage — never wait for `ORA-01653: unable to extend table`.
@@ -579,25 +570,7 @@ EXEC DBMS_SPACE_ADMIN.TABLESPACE_MIGRATE_TO_LOCAL('OLD_DMT_TABLESPACE');
 
 MSSM freelist contention is a documented scalability bottleneck. Always use ASSM (`SEGMENT SPACE MANAGEMENT AUTO`) for new tablespaces.
 
-### Mistake 5: Ignoring Fragmentation
-
-Frequent drop/create cycles leave free space fragmented across a tablespace. Monitor fragmentation:
-
-```sql
-SELECT COUNT(*) AS free_space_chunks,
-       ROUND(MAX(bytes)/1048576, 2)   AS largest_free_chunk_mb,
-       ROUND(SUM(bytes)/1048576, 2)   AS total_free_mb
-FROM   dba_free_space
-WHERE  tablespace_name = 'APP_DATA';
-```
-
-If a locally managed tablespace has many small free chunks but large objects cannot allocate space efficiently, investigate segment layout, add or resize datafiles, or move/rebuild large segments as needed. `ALTER TABLESPACE ... COALESCE` is a legacy remedy for dictionary-managed tablespaces, not the normal fix for modern locally managed tablespaces.
-
-### Mistake 6: Putting Indexes on the Same Tablespace as Their Table
-
-When a full table scan with an index lookup occurs, Oracle must read both the table and the index. If they share a data file, I/O becomes a bottleneck. Separate data and index tablespaces onto different storage paths (different ASM disk groups, different LUNs, or different filesystem paths).
-
-### Mistake 7: Undersizing the Undo Tablespace
+### Mistake 5: Undersizing the Undo Tablespace
 
 An undersized undo tablespace causes `ORA-01555: snapshot too old` errors for long-running queries and prevents Flashback Query from working for the intended retention window. Size undo based on the longest expected transaction and the `UNDO_RETENTION` setting.
 

--- a/skills/performance/index-strategy.md
+++ b/skills/performance/index-strategy.md
@@ -52,14 +52,12 @@ Bitmap indexes store one bit per row for each distinct value. They are extremely
 
 ### When to Use
 
-- Columns with very **low cardinality** (2–100 distinct values): status codes, regions, Boolean flags
 - **Data warehouse** or reporting environments with heavy `SELECT` and infrequent `INSERT/UPDATE/DELETE`
 - Queries combining multiple low-cardinality filters (`AND`/`OR`) — Oracle can combine bitmaps with bitwise operations
 
 ### When to Avoid
 
 - **OLTP environments** — bitmap indexes lock entire bitmaps during DML, causing severe contention
-- High-cardinality columns — wasteful; B-tree is better
 - Heavily updated columns — each DML locks bitmaps for all rows with the same value
 
 ```sql
@@ -86,7 +84,7 @@ WHERE  table_name = 'SALES'
 
 | Characteristic | B-Tree | Bitmap |
 |---|---|---|
-| Best cardinality | High | Low (< 100 distinct) |
+| Best cardinality | High | Low |
 | DML performance | Moderate overhead per row | Heavy contention; row-level lock escalates |
 | Storage | Per-value entries | Very compact for low cardinality |
 | Combined predicates | Separate index lookups | Bitwise operations; very efficient |
@@ -303,8 +301,7 @@ ALTER INDEX emp_dept_sal_ix REBUILD COMPRESS 1;
 | Scenario | Recommendation |
 |---|---|
 | Many deletes caused leaf block waste | Coalesce (fast, online-safe) |
-| Index height grown to 4+ levels on small-medium table | Rebuild |
-| Clustering factor severely degraded | Rebuild (or reorganize table with move) |
+| Clustering factor severely degraded | Consider reorganising the **table** |
 | Moving index to different tablespace | Rebuild |
 | Periodic "maintenance" on a healthy index | Neither — unnecessary on healthy indexes |
 
@@ -333,7 +330,9 @@ FROM   index_stats;
 A frequently overlooked index is on the **foreign key column** of a child table. Without it:
 
 - Full table scans occur when navigating from parent to child
-- Deleting or updating a parent row causes an **exclusive table-level lock** on the child table in Oracle (until the cascade/validation completes)
+- Deleting a parent row or updating the parent primary key value (rare) will cause an brief **exclusive table-level lock** on the child table in Oracle (until the cascade/validation completes)
+
+If the parent table is never deleted from, a foreign key index decision is the same as standard index decision, namely, will it improve performance of queries?
 
 ```sql
 -- Identify unindexed foreign keys
@@ -504,11 +503,11 @@ EXEC DBMS_AUTO_INDEX.CONFIGURE('AUTO_INDEX_MODE', 'IMPLEMENT');
 |---|---|---|
 | Creating B-tree on a Y/N flag column | Rarely used; DML overhead for no benefit | Use bitmap index (if DW) or no index (if OLTP) |
 | Wrong column order in composite index | Index not used for common queries | Put equality columns first, then range |
-| Not indexing FK columns | Lock escalation on parent DML; slow joins | Always index FK columns |
+| Not indexing FK columns | Lock escalation on parent DML; slow joins | Index FK columns when required |
 | Using FTS result to conclude "no index needed" | May be an FBI or type mismatch issue | Check predicate info; fix function application |
 | Rebuilding all indexes on schedule | Wasted maintenance window; no real benefit | Rebuild only when fragmentation is confirmed |
 | Dropping an index without testing | May cause performance regression | Make invisible first; test; then drop |
-| Creating duplicate indexes | DML overhead; storage waste | Check existing indexes before creating new ones |
+| Creating overlapping indexes | DML overhead; storage waste | Check existing indexes before creating new ones |
 
 ---
 

--- a/skills/performance/memory-tuning.md
+++ b/skills/performance/memory-tuning.md
@@ -316,7 +316,7 @@ ORDER  BY snap_id;
 
 ### Automatic Memory Management (AMM)
 
-AMM manages both SGA and PGA automatically. Set only `MEMORY_TARGET` and optionally `MEMORY_MAX_TARGET`.
+AMM manages both SGA and PGA automatically. Set only `MEMORY_TARGET` and optionally `MEMORY_MAX_TARGET`. This is recommended only on small systems with a total SGA less than 4GB.
 
 ```sql
 -- Enable AMM

--- a/skills/performance/optimizer-stats.md
+++ b/skills/performance/optimizer-stats.md
@@ -18,8 +18,19 @@ The primary tool for managing statistics is the `DBMS_STATS` package.
 
 ### Gather Table Statistics
 
+**Note:** A default installation of the database ships with the most appropriate defaults for optimizer statistics gathering. In most case, using the default parameters for DBMS_STATS calls will be optimal. 
+
 ```sql
--- Basic gather with auto-sample size (recommended default)
+-- Basic gather using system defaults
+BEGIN
+  DBMS_STATS.GATHER_TABLE_STATS(
+    ownname   => 'HR',
+    tabname   => 'EMPLOYEES'
+  );
+END;
+/
+
+-- Basic gather with additional parameters specified
 BEGIN
   DBMS_STATS.GATHER_TABLE_STATS(
     ownname   => 'HR',
@@ -481,6 +492,7 @@ END;
 
 ## Best Practices
 
+- **Use defaults unless customisation required** — A default installation of the database ships with the most appropriate defaults for optimizer statistics gathering. In most case, using the default parameters for DBMS_STATS calls will be optimal. 
 - **Use `AUTO_SAMPLE_SIZE`** — Oracle's incremental statistics algorithm produces accurate stats with minimal overhead in 11g+. Fixed sample sizes (e.g., 10%) are rarely better.
 - **Use incremental statistics for partitioned tables** — avoids full re-scan of unchanged partitions.
 
@@ -496,7 +508,7 @@ END;
 /
 ```
 
-- **Gather stats after bulk loads before running queries** — a batch that inserts millions of rows makes stats stale immediately.
+- **Gather stats after conventional bulk loads before running queries** — a batch that inserts millions of rows makes stats stale immediately.
 - **Export stats before major changes** (upgrades, schema changes) so you can restore the previous state if plan regressions occur.
 - **Use `METHOD_OPT => 'FOR ALL COLUMNS SIZE AUTO'`** as the default — Oracle decides which columns need histograms based on workload feedback.
 - **Check `STALE_STATS` before large batch jobs** — running a 2-hour batch against stale stats is common but avoidable.
@@ -508,12 +520,11 @@ END;
 
 | Mistake | Impact | Fix |
 |---|---|---|
-| Never gathering stats on new tables | Optimizer uses dynamic sampling; may be inaccurate | Gather stats after initial load |
+| Never gathering stats on new tables | Optimizer uses dynamic sampling; may be inaccurate | Gather stats after initial load if statistics were not automatically generated |
 | Using fixed sample size (e.g., 1%) | Inaccurate for skewed data | Use `AUTO_SAMPLE_SIZE` |
 | Gathering stats with `NO_INVALIDATE=TRUE` always | Old plans persist with new stats | Set `FALSE` or use the default (deferred invalidation) |
 | Forgetting to regather after creating extended stats | Extended stats exist but have no data | Always gather after `CREATE_EXTENDED_STATS` |
 | Disabling autostats globally without a replacement | Stats go stale; plan regressions over time | Replace with a custom job; never just disable |
-| Not locking stats on small lookup tables | Stats change unpredictably; optimizer changes join order | Lock stats for stable small tables |
 | Histograms on columns with bind variables | Bind peeking + histogram can cause plan instability | Use `SIZE 1` (no histogram) or `CURSOR_SHARING=FORCE` carefully |
 
 ---


### PR DESCRIPTION
Bring up to date some of the content in the various skills to reflect best practices and changed functionality.

skills/admin/user-management.md
- added noauth accounts

skills/appdev/json-in-oracle.md
- blob preference plus OSON

skills/appdev/locking-concurrency.md
- corrections to skip locked, ora_rowscn, plus expanded commentary on DDL / locking 

skills/appdev/sequences-identity.md
- clarified CACHE usage and added automatic 19c cache management

skills/appdev/transaction-management.md
- corrections to PLSQL commit/rollback handling

skills/architecture/inmemory-column-store.md
- added 16G free

skills/design/partitioning-strategy.md
- brought global indexes up to date with asynch maintenance
 
skills/design/tablespace-design.md
- remove obsolete advice on index separation, clarified uniform/autoallocate

skills/performance/index-strategy.md
- corrected some bitmap and foreign key index topics

skills/performance/memory-tuning.md
- clarified restrictions on AMM

skills/performance/optimizer-stats.md
- increased emphasis on using defaults