### PR TITLE
Add install metadata for Oracle Database skill

### DIFF
--- a/SKILL_AUTHORING_GUIDE.md
+++ b/SKILL_AUTHORING_GUIDE.md
@@ -27,6 +27,17 @@ Each domain should own:
 - A `SKILL.md` file that explains the domain and how to navigate it.
 - Topic folders or markdown files that stay coherent within that domain.
 
+Each installable domain `SKILL.md` must start with YAML front matter containing
+`name` and `description` fields. Skill installers use these fields to discover
+and validate skills.
+
+```markdown
+---
+name: db
+description: Oracle Database skills for administration, SQL and PL/SQL development, performance tuning, security, ORDS, SQLcl, migrations, frameworks, and agent-safe database workflows.
+---
+```
+
 For a populated domain, organize content by category directories under the domain path and use the domain `SKILL.md` as the domain table of contents. The standard pattern is:
 
 - Category-based subdirectories such as `admin/`, `security/`, `integration/`, or other domain-appropriate groupings

--- a/skills/db/SKILL.md
+++ b/skills/db/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: db
+description: Oracle Database skills for administration, SQL and PL/SQL development, performance tuning, security, ORDS, SQLcl, migrations, frameworks, Oracle Container Registry guidance, and agent-safe database workflows.
+---
+
 # Oracle Database Skills
 
 This domain contains Oracle Database skills for administration, SQL and PL/SQL development, performance tuning, security, ORDS, SQLcl, migrations, frameworks, OCR container guidance, and agent-safe database workflows.


### PR DESCRIPTION
## Summary

Adds the required `name` and `description` front matter to `skills/db/SKILL.md` so skill installers can discover and validate the Oracle Database skill.

Also updates the authoring guide to document that installable domain `SKILL.md` files must include this metadata.

## Validation

- Verified `skills/db/SKILL.md` starts with YAML front matter.
- Verified both required fields are present.
- Ran `git diff --check`.
