### PR TITLE
expand SQLcl skills: MCP server, scheduler daemon, AWR, background jobs

### DIFF
--- a/db/SKILL.md
+++ b/db/SKILL.md
@@ -55,7 +55,7 @@ db/
 | Package design, error handling, performance, collections, cursors, debugging | `db/plsql/` |
 | Privileges, VPD, masking, auditing, encryption, network security | `db/security/` |
 | SQL tuning, SQL patterns, dynamic SQL, injection avoidance | `db/sql-dev/` |
-| SQLcl basics, scripting, Liquibase, formatting, DDL generation, data loading, MCP server | `db/sqlcl/` |
+| SQLcl basics, scripting, Liquibase, formatting, DDL generation, data loading, MCP server, scheduler daemon, AWR, background jobs | `db/sqlcl/` |
 
 ## Key Starting Points
 
@@ -75,3 +75,4 @@ db/
 | Plan a migration | `migration-assessment` → `oracle-migration-tools` → source-specific `migrate-*.md` → `migration-cutover-strategy` |
 | Build RAG on Oracle Database | `ai-profiles` → `vector-search` → `dbms-vector` |
 | Perform agent-safe schema change | `schema-discovery` → `destructive-op-guards` → `idempotency-patterns` → `schema-migrations` |
+| Set up AI-driven database access via MCP | `sqlcl-basics` (save connections) → `security/privilege-management` (least-privilege user) → `sqlcl-mcp-server` (configure + start) |

--- a/db/sqlcl/sqlcl-awr.md
+++ b/db/sqlcl/sqlcl-awr.md
@@ -1,0 +1,235 @@
+# SQLcl AWR Command
+
+## Overview
+
+The `awr` command in SQLcl creates and retrieves Automatic Workload Repository (AWR) reports for the connected Oracle Database instance. AWR reports capture database workload, performance, and resource usage metrics between two snapshots, making them the primary tool for diagnosing performance problems and understanding database behavior over time.
+
+SQLcl's `awr` command is a lightweight wrapper around Oracle's AWR infrastructure — no separate tooling or manual DBMS_WORKLOAD_REPOSITORY calls required.
+
+**Requires:** DBA privilege or access to the `DBA_HIST_*` views (typically granted via the `SELECT ANY DICTIONARY` or `SELECT_CATALOG_ROLE` privilege).
+
+---
+
+## Syntax
+
+```sql
+awr <subcommand>
+```
+
+Three subcommands are available:
+
+| Subcommand | Description |
+|------------|-------------|
+| `awr create snapshot` | Take a new AWR snapshot |
+| `awr create report` | Generate an AWR report between two snapshots |
+| `awr list snapshots` | List all available snapshots |
+
+---
+
+## Subcommand Reference
+
+### awr list snapshots
+
+Lists all AWR snapshots available in the current database instance:
+
+```sql
+awr list snapshots
+```
+
+Alias:
+
+```sql
+awr list snap
+```
+
+Output shows snapshot IDs, timestamps, and instance information. Use the IDs from this output as the `begin-snapshot-id` and `end-snapshot-id` for report generation.
+
+---
+
+### awr create snapshot
+
+Takes a new AWR snapshot immediately and prints the assigned snapshot ID:
+
+```sql
+awr create snapshot
+```
+
+Optional flush-level controls the amount of data captured:
+
+```sql
+awr create snapshot bestfit   -- Default: Oracle chooses the optimal level
+awr create snapshot lite      -- Minimal data; fastest
+awr create snapshot typical   -- Standard data set
+awr create snapshot all       -- Maximum data; slowest
+```
+
+`bestfit` is the default when no level is specified.
+
+Use this to bracket a specific workload period — take a snapshot before and after running a workload, then generate a report between those two IDs.
+
+---
+
+### awr create report
+
+Generates an AWR report as a file in the current working directory:
+
+```sql
+awr create html <begin-snapshot-id> <end-snapshot-id>
+awr create text <begin-snapshot-id> <end-snapshot-id>
+```
+
+The output file is named automatically:
+
+```
+AWR-<DB_Name>-<PDB_Name>-<Timestamp>.html
+AWR-<DB_Name>-<PDB_Name>-<Timestamp>.txt
+```
+
+**Default behavior when snapshot IDs are omitted:**
+
+```sql
+-- Uses the last two snapshots (second-to-last as begin, last as end)
+awr create html
+awr create text
+```
+
+---
+
+## Common Workflows
+
+### Diagnose a recent performance problem
+
+```sql
+-- List snapshots to find the relevant time window
+awr list snapshots
+
+-- Generate an HTML report for that window (e.g., snapshots 142 to 145)
+awr create html 142 145
+```
+
+Open the resulting `.html` file in a browser for the full formatted report including Top SQL, wait events, load profile, and instance efficiency metrics.
+
+### Bracket a specific workload
+
+```sql
+-- Take a snapshot before running the workload
+awr create snapshot
+-- note the snapshot ID printed, e.g. 200
+
+-- Run your workload / test here
+
+-- Take a snapshot after
+awr create snapshot
+-- note the snapshot ID printed, e.g. 201
+
+-- Generate a report covering exactly that workload period
+awr create html 200 201
+```
+
+### Quick report from the last snapshot interval
+
+```sql
+-- No IDs needed — uses the most recent interval automatically
+awr create html
+```
+
+### Generate a plain-text report for scripted parsing
+
+```sql
+awr create text 142 145
+```
+
+Text format is useful for automated parsing, email delivery, or logging to a file with SPOOL:
+
+```sql
+SPOOL /var/reports/awr_latest.txt
+awr create text
+SPOOL OFF
+```
+
+---
+
+## Reading an AWR Report
+
+Key sections to check in every AWR report:
+
+| Section | What to Look For |
+|---------|-----------------|
+| **Load Profile** | DB Time per second — high values indicate a busy or slow database |
+| **Instance Efficiency** | Buffer hit %, soft parse % — should both be > 95% |
+| **Top 5 Timed Events** | The dominant wait events during the interval |
+| **SQL Statistics** | Top SQL by elapsed time, CPU, I/O — identifies expensive queries |
+| **Segment Statistics** | Hot tables/indexes by physical reads or buffer gets |
+| **Memory Statistics** | SGA/PGA usage and advice |
+| **I/O Statistics** | Read/write throughput and latency by file |
+
+---
+
+## Scheduling Regular AWR Reports
+
+Use the SQLcl Scheduler Daemon to automate nightly AWR reports:
+
+```yaml
+# ~/.dbtools/schedules/scheduler.yaml
+jobs:
+  - name: nightly-awr-report
+    cron: 0 0 7 * * ?
+    connection: my_prod_db
+    payload: |
+      awr create html
+      exit
+```
+
+Or via a wrapper script:
+
+```sql
+-- /opt/scripts/awr_report.sql
+awr create html
+exit
+```
+
+```shell
+sql -S user/pass@service @/opt/scripts/awr_report.sql
+```
+
+---
+
+## Best Practices
+
+- Run `awr list snapshots` before generating a report to confirm the snapshot IDs exist and span the time window you want.
+- Use HTML format for human review; use text format when the output needs to be parsed programmatically or sent in plain-text email.
+- Keep snapshot intervals short (15–30 minutes) during active problem investigation so you can isolate the exact period when performance degraded.
+- The default AWR snapshot interval is 60 minutes. For fine-grained baselining during a test, take manual snapshots at shorter intervals with `awr create snapshot`.
+- Run AWR reports on a non-production replica when possible — generating large AWR reports against a heavily loaded production database consumes I/O and memory.
+
+---
+
+## Common Mistakes and How to Avoid Them
+
+**Mistake: Insufficient privileges**
+The `awr` command requires access to `DBA_HIST_*` views. If you see `ORA-00942` errors, ensure the user has `SELECT ANY DICTIONARY` or `SELECT_CATALOG_ROLE`.
+
+**Mistake: Snapshot IDs from a different instance**
+In a RAC environment, AWR snapshots are instance-specific. Ensure the begin and end snapshots are from the same instance. Check `awr list snapshots` for the instance column.
+
+**Mistake: Interval too wide to be useful**
+An AWR report spanning 8 hours will average out peaks and make it hard to identify short performance spikes. Narrow the interval to the window when the problem occurred.
+
+**Mistake: Not checking the current directory**
+The report file is written to the current working directory at the time SQLcl is running. If you are running non-interactively, set your working directory explicitly before calling `awr create`.
+
+---
+
+## Related Skills
+
+- `sqlcl-basics.md` — Connecting and session setup
+- `sqlcl-scheduler-daemon.md` — Automate nightly AWR report generation
+- `sqlcl-cicd.md` — Running `awr create` non-interactively in pipelines
+- `monitoring/top-sql-queries.md` — Querying V$SQL for real-time SQL performance
+
+---
+
+## Sources
+
+- [AWR Command Reference — Oracle SQLcl 25.4 User's Guide](https://docs.oracle.com/en/database/oracle/sql-developer-command-line/25.4/sqcug/awr.html)
+- [Oracle Database Performance Tuning Guide — AWR](https://docs.oracle.com/en/database/oracle/oracle-database/21/tgdba/gathering-database-statistics.html)

--- a/db/sqlcl/sqlcl-background-jobs.md
+++ b/db/sqlcl/sqlcl-background-jobs.md
@@ -1,0 +1,257 @@
+# SQLcl Background Jobs
+
+## Overview
+
+SQLcl provides `BACKGROUND` (alias `bg`) and `JOBS` (alias `jb`) commands for running SQLcl commands asynchronously and managing the resulting background tasks. This allows long-running operations to execute without blocking the interactive prompt, and multiple tasks to run in parallel within the same SQLcl session.
+
+The `WAIT4` (alias `w4`) command complements these by blocking the session until specified tasks complete — enabling simple dependency chains.
+
+Use background jobs for:
+- Running multiple export or reporting commands in parallel
+- Firing off a long-running operation while continuing interactive work
+- Orchestrating dependent tasks (run B only after A completes)
+
+---
+
+## BACKGROUND Command
+
+Runs any SQLcl command as a background task.
+
+### Syntax
+
+```sql
+background|bg [OPTIONS] <command>
+```
+
+### Options
+
+| Option | Alias | Description |
+|--------|-------|-------------|
+| `-taskname <name>` | `-tn` | Assign a name to this task for later reference |
+| `-wait4 <names>` | `-w4` | Comma-separated list of task names this job should wait for before starting |
+
+### Basic Usage
+
+```sql
+-- Run a command in the background (auto-assigned task ID)
+background apex list
+
+-- Run with a named task
+background -taskname export1 apex list
+
+-- Run after other named tasks complete
+background -taskname task3 -wait4 task1,task2 apex list
+```
+
+---
+
+## JOBS Command
+
+Lists, monitors, and manages background tasks.
+
+### Syntax
+
+```sql
+jobs|jb [SUBCOMMAND] [OPTIONS]
+```
+
+### Options
+
+| Option | Alias | Description |
+|--------|-------|-------------|
+| `-id <id>` | `-i` | Target a specific task by numeric ID |
+| `-taskname <name>` | `-tn` | Target a specific task by name |
+
+### List All Jobs
+
+```sql
+jobs
+```
+
+Shows all background tasks with their IDs, names, status, and result summary.
+
+### Show a Specific Job
+
+```sql
+jobs -id 2
+jobs -taskname export1
+```
+
+### View Job Logs
+
+```sql
+jobs logs -id 2
+jobs logs -taskname export1
+```
+
+Shows the full output produced by the background task.
+
+### Cancel a Running Job
+
+```sql
+jobs cancel -id 2
+jobs cancel -taskname export1
+```
+
+### Delete Jobs from the List
+
+```sql
+-- Delete a specific finished job
+jobs delete -id 2
+
+-- Delete all finished jobs
+jobs delete -finished
+
+-- Delete all jobs (finished and running)
+jobs delete -all
+```
+
+---
+
+## WAIT4 Command
+
+Blocks the current session until one or more named background tasks finish.
+
+### Syntax
+
+```sql
+wait4|w4 [OPTIONS] <task-name>[,<task-name>...]
+```
+
+### Options
+
+| Option | Alias | Description |
+|--------|-------|-------------|
+| `-delay <ms>` | `-d` | Milliseconds to poll between checks (default: 0) |
+
+### Examples
+
+```sql
+-- Wait for a single task
+wait4 export1
+
+-- Wait for multiple tasks
+wait4 task1,task3
+
+-- Wait with a polling delay of 500ms
+wait4 -delay 500 task1,task2
+```
+
+---
+
+## Practical Examples
+
+### Run Two Exports in Parallel
+
+```sql
+-- Start both exports simultaneously
+background -taskname export-employees SET SQLFORMAT CSV
+background -taskname export-orders SET SQLFORMAT CSV
+
+-- Wait for both to finish
+wait4 export-employees,export-orders
+
+-- Check results
+jobs logs -taskname export-employees
+jobs logs -taskname export-orders
+```
+
+### Sequential Dependency Chain
+
+```sql
+-- task2 only starts after task1 completes
+background -taskname task1 apex list
+background -taskname task2 -wait4 task1 apex export -applicationid 100
+
+wait4 task2
+```
+
+### Run a Long SQLcl Command Without Blocking
+
+```sql
+-- Fire off a Liquibase status check in the background
+background -taskname lb-status lb status -changelog-file controller.xml
+
+-- Continue working interactively while it runs
+SELECT COUNT(*) FROM employees;
+
+-- When ready, check the result
+jobs logs -taskname lb-status
+```
+
+### Parallel AWR Reports for Multiple Snapshots
+
+```sql
+background -taskname awr-morning  awr create html 140 145
+background -taskname awr-evening  awr create html 146 150
+
+wait4 awr-morning,awr-evening
+jobs
+```
+
+### Clean Up After a Session
+
+```sql
+-- Remove all finished tasks from the list
+jobs delete -finished
+
+-- Or remove everything
+jobs delete -all
+```
+
+---
+
+## Job Status Values
+
+When you run `jobs`, each task shows one of these statuses:
+
+| Status | Meaning |
+|--------|---------|
+| `RUNNING` | Task is currently executing |
+| `COMPLETED` | Task finished successfully |
+| `FAILED` | Task encountered an error |
+| `WAITING` | Task is queued, waiting for its `-wait4` dependencies |
+| `CANCELLED` | Task was cancelled via `jobs cancel` |
+
+---
+
+## Best Practices
+
+- Always name tasks with `-taskname` when running more than one background job. Auto-assigned numeric IDs are hard to track.
+- Use `wait4` before accessing results of background tasks — reading logs before a task finishes gives partial output.
+- Use `-delay` with `wait4` for long-running tasks to reduce CPU polling overhead: `wait4 -delay 1000 mytask`.
+- Clean up completed jobs with `jobs delete -finished` at the end of a session to keep the jobs list readable.
+- Background jobs run within the same SQLcl session and share the database connection. Avoid running background jobs that issue conflicting DDL or DML against the same objects simultaneously.
+- For scheduled recurring background tasks (not just ad-hoc parallelism), use the SQLcl Scheduler Daemon instead.
+
+---
+
+## Common Mistakes and How to Avoid Them
+
+**Mistake: Reading logs before the task finishes**
+`jobs logs` returns whatever output exists at that moment. If the task is still running, you get partial output. Use `wait4` first.
+
+**Mistake: `-wait4` referencing a non-existent task name**
+If the task named in `-wait4` does not exist or has already been deleted, the dependent job may start immediately or hang. Check `jobs` to confirm the dependency task is listed.
+
+**Mistake: Running conflicting DML in parallel tasks**
+Background tasks share the session connection. Two tasks updating the same rows concurrently will cause lock contention. Design parallel tasks to operate on distinct data sets.
+
+**Mistake: Forgetting to clean up**
+The jobs list accumulates across the session. `jobs delete -all` or `jobs delete -finished` keeps it manageable.
+
+---
+
+## Related Skills
+
+- `sqlcl-awr.md` — Run AWR reports in parallel using background jobs
+- `sqlcl-scheduler-daemon.md` — Schedule recurring jobs outside of an interactive session
+- `sqlcl-scripting.md` — JavaScript scripts that can be dispatched as background payloads
+- `sqlcl-cicd.md` — Non-interactive SQLcl patterns
+
+---
+
+## Sources
+
+- [BACKGROUND Command Reference — Oracle SQLcl 25.4 User's Guide](https://docs.oracle.com/en/database/oracle/sql-developer-command-line/25.4/sqcug/background.html)
+- [Oracle SQLcl 25.2 User's Guide](https://docs.oracle.com/en/database/oracle/sql-developer-command-line/25.2/sqcug/oracle-sqlcl-users-guide.pdf)

--- a/db/sqlcl/sqlcl-basics.md
+++ b/db/sqlcl/sqlcl-basics.md
@@ -125,6 +125,45 @@ sql sys/password@localhost:1521/ORCL as sysdba
 sql / as sysdba
 ```
 
+### Starting Up and Shutting Down a Database
+
+SQLcl supports Oracle's `STARTUP` and `SHUTDOWN` commands when connected as SYSDBA or SYSOPER.
+
+**STARTUP modes:**
+
+```sql
+STARTUP                  -- Full open (default)
+STARTUP NOMOUNT          -- Instance started, database not mounted (for RMAN restore, controlfile recreation)
+STARTUP MOUNT            -- Instance started, database mounted but not open (for media recovery)
+STARTUP OPEN             -- Same as default
+STARTUP FORCE            -- Shutdown abort + startup (forces restart of a hung instance)
+STARTUP RESTRICT         -- Open in restricted mode (only users with RESTRICTED SESSION privilege)
+STARTUP OPEN READ ONLY   -- Open for read-only access
+```
+
+**SHUTDOWN modes:**
+
+```sql
+SHUTDOWN NORMAL        -- Wait for all sessions to disconnect (can take a long time)
+SHUTDOWN IMMEDIATE     -- Roll back active transactions, disconnect sessions, clean shutdown
+SHUTDOWN TRANSACTIONAL -- Wait for active transactions to commit, then disconnect
+SHUTDOWN ABORT         -- Immediate, unclean stop (instance recovery required on next startup)
+```
+
+`SHUTDOWN IMMEDIATE` is the standard choice for planned maintenance. `SHUTDOWN ABORT` should only be used when the database is hung and `IMMEDIATE` is not responding.
+
+**Connecting locally for startup/shutdown:**
+
+```shell
+# Connect without a listener (local OS authentication)
+sql / as sysdba
+```
+
+```sql
+SHUTDOWN IMMEDIATE
+STARTUP
+```
+
 ### Connecting from Within SQLcl
 
 Use the `CONNECT` command to switch connections without restarting:
@@ -272,6 +311,32 @@ ALIAS LOAD
 @script.sql arg1 arg2
 -- Arguments accessible as &1, &2, etc.
 ```
+
+### ARGUMENT Command
+
+The `ARGUMENT` command defines named, typed parameters for SQLcl scripts — a more readable and self-documenting alternative to positional `&1`, `&2` substitution variables.
+
+```sql
+-- Define a named argument (in a script file)
+ARGUMENT department_id NUMBER "Department ID to report on"
+ARGUMENT output_format VARCHAR2 "Output format: CSV or JSON"
+
+-- Reference the argument like a substitution variable
+SELECT * FROM employees WHERE department_id = &department_id;
+```
+
+Call the script and pass values positionally:
+
+```shell
+sql user/pass@service @my_report.sql 90 CSV
+```
+
+Arguments are matched by position to the order they are declared in the script. They support basic types (`NUMBER`, `VARCHAR2`, `DATE`) and an optional description string used by `HELP` within the script.
+
+Difference from bare `&1` substitution:
+- `ARGUMENT` gives the variable a name — `&department_id` is clearer than `&1`
+- The type declaration enables basic validation
+- The description is visible when the script is inspected or documented
 
 ---
 

--- a/db/sqlcl/sqlcl-mcp-server.md
+++ b/db/sqlcl/sqlcl-mcp-server.md
@@ -10,7 +10,7 @@ Communication uses **`stdio` only**. The AI client spawns SQLcl as a child proce
 
 ## Prerequisites
 
-- **SQLcl 25.2 or later** (MCP was not present in 24.3 or earlier)
+- **SQLcl 25.2 or later** (MCP was not present in 24.3 or earlier) — download: https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-latest.zip
 - **JRE 17 or 21**
 
 Verify your version:
@@ -24,6 +24,30 @@ Upgrade on macOS:
 
 ```shell
 brew upgrade sqlcl
+```
+
+Upgrade on Windows (PowerShell):
+
+```powershell
+winget upgrade Oracle.SQLcl
+```
+
+Manual install from zip (macOS/Linux):
+
+```shell
+curl -O https://download.oracle.com/otn_software/java/sqldeveloper/sqlcl-latest.zip
+unzip sqlcl-latest.zip -d ~/sqlcl
+export PATH="$HOME/sqlcl/sqlcl/bin:$PATH"
+```
+
+Find the absolute path to `sql` (needed for MCP config):
+
+```shell
+# macOS / Linux
+which sql
+
+# Windows
+where sql
 ```
 
 ---
@@ -182,9 +206,13 @@ Five tools are exposed by the SQLcl MCP server. Oracle adds new tools in each SQ
 | `connect` | Establishes a connection to one of the saved named connections |
 | `disconnect` | Terminates the current active Oracle Database connection |
 | `run-sql` | Executes standard SQL queries and PL/SQL code blocks against the connected database |
-| `run-sqlcl` | Executes SQLcl-specific commands and extensions |
+| `run-sqlcl` | Executes SQLcl-specific commands and extensions, including: output formatting (`SET SQLFORMAT CSV/JSON`), data loading (`LOAD`), DDL generation (`DDL tablename`), Liquibase operations (`lb update`, `lb status`, `lb rollback`), and JavaScript automation (`script`) |
 
 The AI client will first call `list-connections` to discover available connections, then `connect` to establish a session, then `run-sql` or `run-sqlcl` to interact with the database.
+
+### Multiple Connections
+
+You can save multiple named connections in `~/.dbtools` and switch between them within the same MCP session. Ask the AI to call `list-connections` to see all available connections, then `connect` with a different connection name to switch databases. Only one connection is active at a time — switching disconnects the previous one.
 
 ---
 
@@ -218,6 +246,144 @@ Example config with restrict level:
   }
 }
 ```
+
+---
+
+## Common Use Cases
+
+### Natural Language Queries
+
+Ask the AI to query your database in plain English:
+
+> "Show me the top 10 customers by revenue this quarter."
+> "How many orders were placed yesterday, grouped by status?"
+> "Find all employees in the SALES department earning above 80000."
+
+The AI translates these into SQL via `run-sql` and returns formatted results.
+
+### Schema Exploration
+
+> "What tables are in the OE schema?"
+> "Describe the structure of the ORDERS table including constraints."
+> "What indexes exist on the CUSTOMERS table?"
+
+Useful for onboarding to an unfamiliar database without writing any SQL manually.
+
+### Report Generation
+
+> "Export the monthly sales summary as CSV."
+> "Generate an HTML report of open support tickets."
+
+The AI can use `run-sqlcl` to spool output or format results using SQLcl's built-in report commands.
+
+### Query Tuning and Debugging
+
+> "Why is this query slow?" (paste query)
+> "Show me the execution plan for this SQL."
+> "Find the top 5 SQL statements by elapsed time from V\$SQL."
+
+Combine with V$SQL tagging — AI-generated queries are marked with `/* LLM in use is [model] */` so you can identify them in AWR/ASH.
+
+### Transaction Review Before Commit
+
+The AI can stage changes and wait for explicit approval before committing:
+
+> "Update all customer records in the Northeast region, but show me what will change before committing."
+> "Delete orders older than 2 years — let me review the count first."
+
+The AI will run a `SELECT` preview, present the results, then only execute the `UPDATE`/`DELETE` and `COMMIT` after confirmation.
+
+### Multi-Environment Comparison
+
+With multiple saved connections you can compare across environments in one session:
+
+> "Compare the customer count between the dev and prod databases."
+> "Show me which tables exist in prod but not in dev."
+
+The AI switches between named connections via the `connect` tool and presents results side-by-side.
+
+### Performance Monitoring and Optimization
+
+> "Show me which queries are running slow today and give me optimization tips."
+> "Find the top 5 SQL statements by elapsed time."
+> "Check for missing indexes on the ORDERS table."
+
+The AI queries `V$SQL`, `V$SESSION`, and related views, and can suggest query rewrites or index additions based on what it finds.
+
+### Schema Changes and Migrations
+
+With a less restrictive user and restrict level, the AI can assist with DDL:
+
+> "Add a NOT NULL column STATUS to the ORDERS table with a default of 'OPEN'."
+> "Create an index on ORDERS(CUSTOMER_ID, ORDER_DATE)."
+
+Always review generated DDL before confirming execution.
+
+### DDL Extraction
+
+The `DDL` command (via `run-sqlcl`) generates clean, portable `CREATE` statements for any object:
+
+> "Show me the DDL for the ORDERS table."
+> "Extract the package spec and body for HR_UTILS."
+> "Generate CREATE TABLE DDL for all tables starting with APP_."
+
+Use `SET DDL STORAGE OFF` / `SET DDL SEGMENT_ATTRIBUTES OFF` first for environment-portable output.
+
+### Data Loading
+
+The `LOAD` command (via `run-sqlcl`) ingests CSV or JSON files directly into Oracle tables:
+
+> "Load this CSV file into the STAGING_EMPLOYEES table."
+> "Import the reference data file into COUNTRIES with TRUNCATE ON."
+
+See `sqlcl-data-loading.md` for options like `DATEFORMAT`, `BATCHSIZE`, and `ERROR_LOG`.
+
+### Formatted Output and Export
+
+Use `SET SQLFORMAT` (via `run-sqlcl`) to control result format before querying:
+
+> "Export the EMPLOYEES table as CSV."
+> "Give me the top 10 orders as JSON for the API team."
+
+Common formats: `CSV`, `JSON`, `JSON-FORMATTED`, `XML`, `INSERT`, `ANSICONSOLE`.
+
+### Liquibase Operations
+
+All `lb` commands are available via `run-sqlcl`:
+
+> "Show me the pending Liquibase changesets."
+> "Apply the changelog to the test database."
+> "Roll back to tag v1.2.0."
+
+```
+lb status -changelog-file controller.xml
+lb update -changelog-file controller.xml
+lb rollback -tag v1.2.0 -changelog-file controller.xml
+lb generate-schema -split
+```
+
+### JavaScript Automation
+
+Complex multi-step automation can be run via `script` (through `run-sqlcl`):
+
+> "Run the schema inventory script and write the output to /tmp/inventory.csv."
+> "Execute the batch update script for PENDING orders."
+
+JavaScript scripts have access to `util.executeReturnList`, file I/O via Java types, and full JDBC access. See `sqlcl-scripting.md`.
+
+---
+
+## Limitations
+
+| Limitation | Detail |
+|------------|--------|
+| Transport | `stdio` only — no HTTP, SSE, or WebSocket support |
+| Single active connection | Only one database connection is active at a time per MCP server instance |
+| Result set size | Very large result sets may be truncated by the AI client's context window, not by SQLcl itself — use `WHERE`, `ROWNUM`, or `FETCH FIRST` to limit rows |
+| No credential passing at runtime | Passwords must be pre-saved; there is no way to pass them dynamically |
+| No interactive prompts | SQLcl commands that prompt for input (e.g., `ACCEPT`) will hang — avoid these in MCP mode |
+| Restrict level 4 by default | Many SQLcl commands are blocked unless you explicitly lower the restrict level |
+| No parallel sessions | One `sql -mcp` process = one session; run multiple processes for multiple concurrent connections |
 
 ---
 
@@ -291,16 +457,60 @@ The only environment variable documented for the SQLcl MCP server is `TNS_ADMIN`
 
 ---
 
-## Common Mistakes
+## Troubleshooting
+
+### Common Configuration Mistakes
 
 | Mistake | Fix |
 |---------|-----|
 | Using SQLcl 24.3 or earlier | Upgrade to 25.2+; MCP was not available in earlier versions |
 | Passing credentials on the `sql -mcp` command line | Pre-save connections with `conn -save -savepwd` instead |
-| Using a relative path to `sql` in the MCP config | Use the absolute path (`which sql`) — AI clients do not inherit your shell PATH |
+| Using a relative path to `sql` in the MCP config | Use the absolute path (`which sql` / `where sql`) — AI clients do not inherit your shell PATH |
 | Forgetting `TNS_ADMIN` in the config `env` block for TNS connections | MCP client processes don't inherit shell env vars; set `TNS_ADMIN` explicitly in the config |
 | Saving a connection without `-savepwd` | The MCP server cannot connect without a saved password; always include `-savepwd` |
 | Expecting HTTP/SSE transport | SQLcl MCP is stdio only — no network port is involved |
+
+### MCP Server Not Appearing in AI Client
+
+1. Confirm the absolute path to `sql` is correct and the binary is executable.
+2. Run `sql -V` from the exact path in the config to verify the version is 25.2+.
+3. Check that `JRE 17` or `JRE 21` is on the PATH used by the AI client process — set `JAVA_HOME` in the config `env` block if needed:
+
+```json
+"env": {
+  "JAVA_HOME": "/path/to/jre"
+}
+```
+
+4. Restart the AI client after any config change.
+
+### Connection Fails After `connect` Tool Call
+
+- Verify the named connection exists: `ls ~/.dbtools/`
+- Re-save the connection with `-savepwd` if the password was not stored.
+- Check that the database host/port/service is reachable from the machine running SQLcl.
+
+### `DBTOOLS$MCP_LOG` Table Not Created
+
+The log table is created in the schema of the connected user on first use. Ensure the user has `CREATE TABLE` privilege, or grant it:
+
+```sql
+GRANT CREATE TABLE TO mcp_reader;
+```
+
+### Java Not Found at Startup
+
+Set `JAVA_HOME` explicitly in the MCP server config `env` block. SQLcl requires JRE 17 or 21 — other versions are not supported.
+
+### Non-ASCII Characters Garbled in Results
+
+SQLcl uses the JVM's default charset for output. For UTF-8 data, set `JAVA_TOOL_OPTIONS` in the MCP server config `env` block:
+
+```json
+"env": {
+  "JAVA_TOOL_OPTIONS": "-Dfile.encoding=UTF-8"
+}
+```
 
 ---
 
@@ -308,6 +518,14 @@ The only environment variable documented for the SQLcl MCP server is `TNS_ADMIN`
 
 - `sqlcl-basics.md` — SQLcl installation, connection methods, and core commands
 - `sqlcl-cicd.md` — Using SQLcl non-interactively in pipelines
+- `sqlcl-formatting.md` — `SET SQLFORMAT` modes (CSV, JSON, XML, ANSICONSOLE) and SPOOL
+- `sqlcl-scripting.md` — JavaScript automation via the `script` command
+- `sqlcl-data-loading.md` — `LOAD` command for CSV and JSON ingestion
+- `sqlcl-ddl-generation.md` — `DDL` command and `DBMS_METADATA` for schema extraction
+- `sqlcl-liquibase.md` — Built-in Liquibase (`lb`) for changelog-based schema migrations
+- `sqlcl-awr.md` — AWR report generation for performance monitoring
+- `sqlcl-background-jobs.md` — Running commands asynchronously with `background` and `jobs`
+- `sqlcl-scheduler-daemon.md` — Scheduling recurring SQL jobs with the SQLcl daemon
 - `security/privilege-management.md` — Oracle user creation and least-privilege setup
 - `monitoring/top-sql-queries.md` — Identifying AI-generated SQL via V$SQL tagging
 

--- a/db/sqlcl/sqlcl-scheduler-daemon.md
+++ b/db/sqlcl/sqlcl-scheduler-daemon.md
@@ -1,0 +1,373 @@
+# SQLcl Scheduler Daemon
+
+## Overview
+
+The SQLcl Scheduler Daemon runs SQLcl jobs automatically on a cron-based schedule, without requiring an active interactive session. It operates as a background process, reads job definitions from a YAML configuration file, and executes SQL, PL/SQL, or SQLcl commands against saved database connections.
+
+Use the scheduler daemon for:
+- Recurring reports run nightly or hourly
+- Scheduled data loads or exports
+- Periodic maintenance tasks (statistics gathering, purges, health checks)
+- Automated schema validation or monitoring queries
+
+The daemon is distinct from Oracle's `DBMS_SCHEDULER` — it runs at the OS level inside SQLcl, not inside the database. No database privilege is required for the scheduler itself, only for the SQL it executes.
+
+---
+
+## Prerequisites
+
+- **SQLcl 25.2 or later**
+- **JRE 17 or 21**
+- Database connections pre-saved with `conn -save -savepwd` (see Step 1 of `sqlcl-mcp-server.md` or `sqlcl-basics.md`)
+
+---
+
+## Managing the Daemon
+
+All daemon lifecycle operations use the `-daemon` flag with the `sql` command.
+
+### Start
+
+```shell
+sql -daemon start
+```
+
+Output:
+```
+Starting SQLcl daemon...
+INFO Mon Jun  9 00:09:38 +01 2025: Daemon started with PID 1666
+```
+
+### Stop
+
+```shell
+sql -daemon stop
+```
+
+### Restart
+
+Stops and starts in one operation. Use after changes that do not support live reload (e.g., changing the JVM options):
+
+```shell
+sql -daemon restart
+```
+
+### Status
+
+```shell
+sql -daemon status
+```
+
+Output:
+```
+INFO Mon Jun  9 00:15:39 +01 2025: Daemon is running (PID 2464)
+```
+
+Only one daemon instance per OS user can run at a time.
+
+---
+
+## Configuration File
+
+The daemon reads job definitions from:
+
+```
+~/.dbtools/schedules/scheduler.yaml
+```
+
+This file is created automatically with a commented-out sample job the first time the daemon starts. Edit it to add your jobs.
+
+### File Structure
+
+```yaml
+jobs:
+  - name: job-example
+    cron: 0/2 * * * * ? *
+    connection: named-conn-example
+    payload: "@/path/to/script.sql arg1 arg2 arg3"
+```
+
+### Job Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique job name; also used as the log file name |
+| `cron` | Yes | Quartz-compatible cron expression (7 fields: seconds to year) |
+| `connection` | No | Saved SQLcl connection name; defaults to `/ as sysdba` if omitted |
+| `payload` | Yes | SQL statement, PL/SQL block, SQLcl command, or `@script.sql` reference |
+
+---
+
+## Cron Syntax
+
+The daemon uses **Quartz cron format** (7 fields), not standard 5-field Unix cron:
+
+```
+┌─────────────── second (0-59)
+│ ┌───────────── minute (0-59)
+│ │ ┌─────────── hour (0-23)
+│ │ │ ┌───────── day of month (1-31)
+│ │ │ │ ┌─────── month (1-12 or JAN-DEC)
+│ │ │ │ │ ┌───── day of week (1-7 or SUN-SAT)
+│ │ │ │ │ │ ┌── year (optional)
+│ │ │ │ │ │ │
+* * * * * ? *
+```
+
+Common expressions:
+
+| Expression | Meaning |
+|------------|---------|
+| `0 0 6 * * ?` | Every day at 6:00 AM |
+| `0 30 8 ? * MON-FRI` | Weekdays at 8:30 AM |
+| `0 0/15 * * * ?` | Every 15 minutes |
+| `0 15 10 ? * *` | Every day at 10:15 AM |
+| `0 0 0 1 * ?` | First day of every month at midnight |
+| `0 0 22 ? * FRI` | Every Friday at 10:00 PM |
+| `0 0/5 14,18 * * ?` | Every 5 min, 2:00–2:55 PM and 6:00–6:55 PM |
+
+Use `?` in the day-of-month or day-of-week field (not both) when the other is specified.
+
+---
+
+## Payload Examples
+
+### Inline SQL
+
+```yaml
+jobs:
+  - name: daily-count
+    cron: 0 0 7 * * ?
+    connection: my_prod_db
+    payload: SELECT COUNT(*) FROM orders WHERE order_date = TRUNC(SYSDATE);
+```
+
+### SQLcl Command
+
+```yaml
+jobs:
+  - name: daily-ddl-snapshot
+    cron: 0 0 2 * * ?
+    connection: my_prod_db
+    payload: desc employees
+```
+
+### Script File with Arguments
+
+```yaml
+jobs:
+  - name: monthly-report
+    cron: 0 0 6 1 * ?
+    connection: my_reporting_db
+    payload: "@/opt/scripts/monthly_report.sql 2024 Q1"
+```
+
+### Inline PL/SQL Block
+
+```yaml
+jobs:
+  - name: nightly-purge
+    cron: 0 0 1 * * ?
+    connection: my_prod_db
+    payload: |
+      BEGIN
+        DELETE FROM audit_log WHERE log_date < SYSDATE - 90;
+        COMMIT;
+        DBMS_OUTPUT.PUT_LINE('Purge complete: ' || SQL%ROWCOUNT || ' rows deleted');
+      END;
+      /
+```
+
+### Multiple Statements
+
+```yaml
+jobs:
+  - name: stats-gather
+    cron: 0 0 22 * * ?
+    connection: my_prod_db
+    payload: |
+      BEGIN
+        DBMS_STATS.GATHER_SCHEMA_STATS(
+          ownname          => 'HR',
+          estimate_percent => DBMS_STATS.AUTO_SAMPLE_SIZE,
+          method_opt       => 'FOR ALL COLUMNS SIZE AUTO',
+          degree           => 4
+        );
+      END;
+      /
+```
+
+---
+
+## Live Reload
+
+The daemon monitors `scheduler.yaml` for changes using a checksum. When the file is modified:
+
+- New jobs are added automatically
+- Modified jobs are rescheduled
+- Removed jobs are cancelled
+
+**No restart is required.** Changes take effect within seconds of saving the file.
+
+---
+
+## Log Files
+
+All logs are stored under `~/.dbtools/schedules/`:
+
+```
+~/.dbtools/schedules/
+├── logs/
+│   ├── jobs.log              # All job scheduling events
+│   └── job-<name>.log        # Per-job execution output
+├── scheduler.log             # Daemon lifecycle events
+├── scheduler.yaml            # Job definitions
+└── pid                       # Daemon PID file
+```
+
+### scheduler.log — Daemon Lifecycle
+
+Records when the daemon starts, stops, or fails to start:
+
+```
+[2025-06-09T06:00:00] - [STARTED] - [MESSAGE: Daemon started successfully]
+[2025-06-09T22:15:00] - [STOPPED] - [MESSAGE: Daemon stopped]
+```
+
+### jobs.log — Job Scheduling Events
+
+Records events that affect all jobs — file loads, validation errors, and scheduling:
+
+```
+[2025-06-09T06:00:01] - [SCHEDULE_FILE_LOADED] - [SCHEDULE_FILE: /home/user/.dbtools/schedules/scheduler.yaml]
+[2025-06-09T06:00:01] - [SCHEDULE_JOB] - [JOB: nightly-purge] - [JOB_LOG: /home/user/.dbtools/schedules/logs/job-nightly-purge.log]
+```
+
+### job-\<name\>.log — Per-Job Output
+
+Records each execution of a specific job:
+
+```
+[2025-06-09T01:00:00] - [RUNNING] - [MESSAGE: Job started]
+[2025-06-09T01:00:02] - [COMPLETED] - [JOB_RESULT: Purge complete: 1423 rows deleted]
+[2025-06-09T01:00:02] - [FAILED] - [ERROR: ORA-00942: table or view does not exist]
+```
+
+Log files are not rotated automatically — monitor file sizes for long-running daemons.
+
+---
+
+## Unix Service (systemd)
+
+When SQLcl is installed via the RPM package, a `sql-scheduler` systemd service is included:
+
+```shell
+# Start the service (as root)
+systemctl start sql-scheduler
+
+# Enable on boot
+systemctl enable sql-scheduler
+
+# Check service status
+systemctl status sql-scheduler
+```
+
+The systemd service manages daemons for all users in a designated Unix group, providing centralized daemon management without requiring each user to start their own.
+
+---
+
+## Full Example: Nightly Report Workflow
+
+### 1. Save a database connection
+
+```sql
+sql /nolog
+conn -save reporting_db -savepwd reporter/SecurePass@//dbhost:1521/REPORTPDB
+```
+
+### 2. Create the report script
+
+```sql
+-- /opt/scripts/nightly_sales.sql
+SET SQLFORMAT CSV
+SET FEEDBACK OFF
+SET HEADING ON
+SPOOL /var/reports/sales_{{date}}.csv
+SELECT order_id, customer_id, total_amount, order_date
+FROM orders
+WHERE order_date = TRUNC(SYSDATE - 1);
+SPOOL OFF
+EXIT
+```
+
+### 3. Add the job to scheduler.yaml
+
+```yaml
+jobs:
+  - name: nightly-sales-report
+    cron: 0 5 6 * * ?
+    connection: reporting_db
+    payload: "@/opt/scripts/nightly_sales.sql"
+```
+
+### 4. Start the daemon
+
+```shell
+sql -daemon start
+sql -daemon status
+```
+
+### 5. Monitor
+
+```shell
+tail -f ~/.dbtools/schedules/logs/job-nightly-sales-report.log
+```
+
+---
+
+## Best Practices
+
+- Give each job a descriptive `name` — it becomes the log file name and makes troubleshooting easier.
+- Always pre-save connections with `-savepwd`. The daemon has no way to prompt for passwords.
+- Use absolute paths in `payload` script references — the daemon's working directory may not be what you expect.
+- Test scripts interactively with `sql -S connection @script.sql` before scheduling them.
+- Monitor log file sizes. Log rotation is not built in; add a separate cron job or logrotate config for long-lived daemons.
+- For scripts that produce output files, include the date in the filename to avoid overwriting previous runs.
+- Use `sql -daemon status` in monitoring scripts to alert when the daemon is unexpectedly stopped.
+
+---
+
+## Common Mistakes and How to Avoid Them
+
+**Mistake: Job silently not running**
+Check `jobs.log` first. If the job was never scheduled, the YAML has a syntax error or an invalid cron expression. Validate the YAML structure and check `scheduler.log` for `SCHEDULE_FILE_ERROR`.
+
+**Mistake: Connection not found**
+The daemon uses the same `~/.dbtools` connection store as interactive SQLcl. If the connection name in `connection:` does not match an entry in `~/.dbtools`, the job fails. Run `sql /nolog` and `conn -list` to see available saved connections.
+
+**Mistake: Password not saved**
+If the connection was saved without `-savepwd`, the daemon cannot connect. Re-save with `conn -save <name> -savepwd user/pass@service`.
+
+**Mistake: Cron expression in 5-field Unix format**
+The daemon uses Quartz 7-field cron format. A 5-field cron expression like `0 6 * * *` will fail. Add the seconds field at the start: `0 0 6 * * ?`.
+
+**Mistake: Log files growing without bound**
+There is no built-in log rotation. Add a `logrotate` config or a separate cleanup job for `~/.dbtools/schedules/logs/`.
+
+---
+
+## Related Skills
+
+- `sqlcl-basics.md` — Saving connections with `-save` and `-savepwd`
+- `sqlcl-cicd.md` — Non-interactive SQLcl execution patterns
+- `sqlcl-scripting.md` — JavaScript automation scripts usable as daemon payloads
+- `sqlcl-liquibase.md` — Schedule Liquibase deployments via daemon jobs
+
+---
+
+## Sources
+
+- [Running SQLcl as a Scheduler Daemon](https://docs.oracle.com/en/database/oracle/sql-developer-command-line/25.4/sqcug/running-sqlcl-scheduler-daemon.html)
+- [Managing the Scheduler Daemon](https://docs.oracle.com/en/database/oracle/sql-developer-command-line/25.4/sqcug/managing-scheduler-daemon.html)
+- [Scheduling Daemon Jobs](https://docs.oracle.com/en/database/oracle/sql-developer-command-line/25.4/sqcug/scheduling-daemon-jobs.html)
+- [Monitoring with Log Files](https://docs.oracle.com/en/database/oracle/sql-developer-command-line/25.4/sqcug/monitoring-log-files.html)


### PR DESCRIPTION
## Summary

Significant expansion of the SQLcl skill set based on a review of the Oracle SQLcl 25.4 documentation. Three new skill files cover previously undocumented features, and two existing files receive important additions.

## New Skill Files

### `sqlcl-scheduler-daemon.md`
Full coverage of the SQLcl daemon for cron-based background job scheduling:
- Daemon lifecycle: `sql -daemon start/stop/restart/status`
- `scheduler.yaml` format with all job fields (`name`, `cron`, `connection`, `payload`)
- Quartz 7-field cron syntax with common expression examples
- Payload types: inline SQL, PL/SQL blocks, script files with arguments, multiline blocks
- Live reload (no restart required on config change)
- Log file structure: `scheduler.log`, `jobs.log`, `job-<name>.log` with format reference
- systemd integration for RPM installs

### `sqlcl-awr.md`
Full coverage of the `awr` command for AWR report generation:
- `awr list snapshots` / `awr list snap`
- `awr create snapshot` with flush levels (bestfit/lite/typical/all)
- `awr create html|text <begin-id> <end-id>` and default (last interval) behavior
- Bracket-a-workload pattern (snapshot before/after a test)
- Key AWR report sections and what to look for in each
- Scheduling via the daemon and non-interactive use

### `sqlcl-background-jobs.md`
Full coverage of async task execution:
- `background`/`bg` with `-taskname` and `-wait4` options
- `jobs`/`jb` subcommands: list, logs, cancel, delete (`-finished`, `-all`)
- `wait4`/`w4` with `-delay` for polling interval control
- Dependency chaining pattern (`-wait4 task1,task2`)
- Parallel execution examples (parallel exports, parallel AWR reports)
- Job status reference table

## Updates to Existing Files

### `sqlcl-mcp-server.md`
- Added direct download permalink for SQLcl zip
- Added manual install steps (macOS/Linux zip, Windows winget)
- Added `where sql` for Windows alongside `which sql`
- Added multiple connections explanation
- Added full **Common Use Cases** section: natural language queries, schema exploration, report generation, query tuning/debugging, schema migrations, DDL extraction, data loading via LOAD, formatted output (SET SQLFORMAT), Liquibase operations, JavaScript automation
- Added three Oracle-documented use cases: transaction review before commit, multi-environment comparison, performance monitoring with optimization advice
- Added **Limitations** table
- Expanded **Common Mistakes** into a full **Troubleshooting** section with subsections: MCP not appearing, connection failures, missing log table, Java not found, non-ASCII encoding fix
- Updated Related Skills to reference all skill files in the directory

### `sqlcl-basics.md`
- **ARGUMENT command**: named typed script parameters, difference from positional `&1`/`&2`, type declaration, call syntax
- **STARTUP/SHUTDOWN**: all modes with descriptions, local OS auth pattern

### `db/SKILL.md`
- Updated sqlcl routing row to mention scheduler daemon, AWR, background jobs
- Added MCP multi-step flow: `sqlcl-basics` → `security/privilege-management` → `sqlcl-mcp-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)