### PR TITLE
docs(sqlcl): keep passwords off the SQLcl command line

### DIFF
--- a/db/sqlcl/sqlcl-basics.md
+++ b/db/sqlcl/sqlcl-basics.md
@@ -46,30 +46,36 @@ java -version
 
 ## Connecting to Oracle Database
 
-### Basic Username/Password
+> **Do not put passwords on the SQLcl command line.** The examples below omit the password so SQLcl prompts for it, or use a wallet so no password is needed at all. See [Discouraged: Passwords on the Command Line](#discouraged-passwords-on-the-command-line) for the leak surfaces this avoids.
+
+### Basic Connection (Password Prompt)
+
+Omit the password from the connect string. SQLcl prompts for it without echoing input:
 
 ```shell
-sql username/password@hostname:port/service_name
+sql username@hostname:port/service_name
 ```
 
 Example:
 
 ```shell
-sql hr/hr@localhost:1521/FREEPDB1
+sql hr@localhost:1521/FREEPDB1
 ```
+
+SQLcl prompts: `Password? (**********?)`
 
 ### Easy Connect Syntax (EZConnect)
 
 Easy Connect is the most portable connection method and does not require a `tnsnames.ora` file:
 
 ```shell
-sql username/password@//hostname:port/service_name
+sql username@//hostname:port/service_name
 ```
 
 You can also use EZConnect Plus syntax (Oracle 19c+) for additional options:
 
 ```shell
-sql hr/hr@"(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=myhost)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=MYPDB)))"
+sql hr@"(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=myhost)(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=MYPDB)))"
 ```
 
 ### TNS Alias
@@ -77,14 +83,14 @@ sql hr/hr@"(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=myhost)(PORT=1521))(CONNECT
 If `$TNS_ADMIN` or `$ORACLE_HOME/network/admin/tnsnames.ora` is configured:
 
 ```shell
-sql username/password@MY_TNS_ALIAS
+sql username@MY_TNS_ALIAS
 ```
 
 Set the TNS admin directory explicitly:
 
 ```shell
 export TNS_ADMIN=/path/to/wallet_or_tns
-sql hr/hr@MY_SERVICE
+sql hr@MY_SERVICE
 ```
 
 ### Oracle Cloud (Autonomous Database) Wallet
@@ -95,35 +101,45 @@ Download the wallet ZIP from the Oracle Cloud Console, then unzip it to a local 
 unzip Wallet_MyDB.zip -d /path/to/wallet
 ```
 
-Connect using the wallet:
+Connect using the wallet (SQLcl prompts for the password):
 
 ```shell
-sql username/password@"(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=adb.us-ashburn-1.oraclecloud.com)(PORT=1522))(CONNECT_DATA=(SERVICE_NAME=myadb_high.adb.oraclecloud.com))(SECURITY=(MY_WALLET_DIRECTORY=/path/to/wallet)))"
+sql username@"(DESCRIPTION=(ADDRESS=(PROTOCOL=tcps)(HOST=adb.us-ashburn-1.oraclecloud.com)(PORT=1522))(CONNECT_DATA=(SERVICE_NAME=myadb_high.adb.oraclecloud.com))(SECURITY=(MY_WALLET_DIRECTORY=/path/to/wallet)))"
 ```
 
 Alternatively, set `TNS_ADMIN` to the wallet directory and use the pre-defined TNS aliases it contains:
 
 ```shell
 export TNS_ADMIN=/path/to/wallet
-sql admin/MyPassword123@myadb_high
+sql admin@myadb_high
 ```
 
-### Prompting for Password (Secure)
-
-Omit the password to be prompted (avoids password in shell history):
-
-```shell
-sql hr@localhost:1521/FREEPDB1
-```
-
-SQLcl will prompt: `Password? (**********?)`
+For non-interactive automation, store the database password in an Oracle Secure External Password Store (SEPS) wallet and connect with the `/@alias` form so no password ever appears on the command line or in scripts. See the SQLcl CI/CD skill (`db/sqlcl/sqlcl-cicd.md`) and the Oracle Database Security Guide for SEPS setup.
 
 ### SYSDBA / SYSOPER Connections
 
+Prefer OS authentication for local SYSDBA work — no password is required:
+
 ```shell
-sql sys/password@localhost:1521/ORCL as sysdba
 sql / as sysdba
 ```
+
+For a remote SYSDBA connection, omit the password to be prompted:
+
+```shell
+sql sys@localhost:1521/ORCL as sysdba
+```
+
+### Discouraged: Passwords on the Command Line
+
+Embedding the password in the connect string (`sql user/password@service`) is **discouraged** and should not appear in scripts, documentation, training material, or shared commands. The credential is exposed to:
+
+- Other local users via `ps -ef`, `/proc/<pid>/cmdline`, and Windows process listings.
+- Shell history files such as `~/.bash_history`, `~/.zsh_history`, and PowerShell `ConsoleHost_history.txt`.
+- Terminal scrollback buffers and screen recordings.
+- CI/CD job logs, container logs, and audit pipelines that capture command lines.
+
+If a workflow truly cannot be reorganized to use a prompt, a wallet, or SEPS, treat the inline-password form as a temporary, isolated exception and rotate the credential afterwards.
 
 ### Starting Up and Shutting Down a Database
 
@@ -166,10 +182,10 @@ STARTUP
 
 ### Connecting from Within SQLcl
 
-Use the `CONNECT` command to switch connections without restarting:
+Use the `CONNECT` command to switch connections without restarting. Omit the password so SQLcl prompts:
 
 ```sql
-CONNECT hr/hr@localhost:1521/FREEPDB1
+CONNECT hr@localhost:1521/FREEPDB1
 CONNECT admin@myadb_high
 ```
 
@@ -325,10 +341,10 @@ ARGUMENT output_format VARCHAR2 "Output format: CSV or JSON"
 SELECT * FROM employees WHERE department_id = &department_id;
 ```
 
-Call the script and pass values positionally:
+Call the script and pass values positionally (omit the password so SQLcl prompts):
 
 ```shell
-sql user/pass@service @my_report.sql 90 CSV
+sql user@service @my_report.sql 90 CSV
 ```
 
 Arguments are matched by position to the order they are declared in the script. They support basic types (`NUMBER`, `VARCHAR2`, `DATE`) and an optional description string used by `HELP` within the script.
@@ -497,3 +513,4 @@ After migrating to SQLcl, update your scripts and aliases to use `sql` instead o
 - [Starting and Leaving SQLcl — startup flags and version flag](https://docs.oracle.com/en/database/oracle/sql-developer-command-line/25.2/sqcug/startup-sqlcl-settings.html)
 - [SQLcl Release Notes 25.2](https://www.oracle.com/tools/sqlcl/sqlcl-relnotes-25.2.html)
 - [SQLcl Release Notes 25.2.1 — Java 17/21 requirement confirmed](https://www.oracle.com/tools/sqlcl/sqlcl-relnotes-25.2.1.html)
+- [Oracle Database Security Guide 19c — Configuring Authentication (Secure External Password Store)](https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/configuring-authentication.html)

--- a/db/sqlcl/sqlcl-cicd.md
+++ b/db/sqlcl/sqlcl-cicd.md
@@ -16,47 +16,76 @@ This guide covers:
 
 ## Running SQLcl Non-Interactively
 
+> **Do not pass passwords on the SQLcl command line in CI/CD.** Connect from a SEPS wallet (`sql -S /@alias`) or from stdin via `/nolog` + `CONNECT`. See [Keep Credentials Out of the Command Line](#keep-credentials-out-of-the-command-line) for the rationale and the full Good/Bad comparison.
+
 ### Basic Headless Execution
 
-The `-S` (silent) flag suppresses the SQLcl banner and all interactive prompts:
+The `-S` (silent) flag suppresses the SQLcl banner and all interactive prompts.
+
+The recommended pattern for CI is to start SQLcl with `/nolog` and issue `CONNECT` from stdin so credentials are not exposed as command arguments. The CI runtime injects `DB_USER`, `DB_PASS`, and `DB_SERVICE` from masked secret variables.
 
 ```shell
-sql -S username/password@service @deploy.sql
+sql -S /nolog <<EOF
+CONNECT ${DB_USER}/"${DB_PASS}"@${DB_SERVICE}
+WHENEVER SQLERROR EXIT SQL.SQLCODE
+@deploy.sql
+EXIT 0
+EOF
 ```
 
-The `@deploy.sql` script is executed and SQLcl exits when the script completes or when an `EXIT` command is reached.
+If the runner has access to a SEPS (Secure External Password Store) wallet, prefer the password-less form — the wallet stores the credential keyed to the TNS alias:
+
+```shell
+export TNS_ADMIN=/path/to/seps-wallet
+sql -S /@DB_ALIAS @deploy.sql
+```
+
+The script (`@deploy.sql` or anything inside the heredoc) is executed and SQLcl exits when the script completes or when an `EXIT` command is reached.
 
 ### Passing Commands via stdin
 
-```shell
-echo "SELECT COUNT(*) FROM employees; EXIT;" | sql -S username/password@service
-```
-
-Or using a heredoc (preferred for multi-line scripts):
+Combine `/nolog` connect with the inline commands:
 
 ```shell
-sql -S username/password@service <<'EOF'
+sql -S /nolog <<EOF
+CONNECT ${DB_USER}/"${DB_PASS}"@${DB_SERVICE}
 SET FEEDBACK ON
 SELECT COUNT(*) FROM employees;
 EXIT
 EOF
 ```
 
+Or with SEPS (no credentials in the script at all):
+
+```shell
+sql -S /@DB_ALIAS <<'EOF'
+SET FEEDBACK ON
+SELECT COUNT(*) FROM employees;
+EXIT
+EOF
+```
+
+Note: use `<<EOF` (unquoted) when the heredoc must expand shell variables such as `${DB_USER}`; use `<<'EOF'` (quoted) when the body should be passed to SQLcl literally, for example to keep `&substitution` variables intact.
+
 ### Running a Script File
 
 ```shell
-sql -S username/password@service @/path/to/script.sql
+sql -S /nolog <<EOF
+CONNECT ${DB_USER}/"${DB_PASS}"@${DB_SERVICE}
+@/path/to/script.sql
+EXIT 0
+EOF
+```
+
+Or with SEPS:
+
+```shell
+sql -S /@DB_ALIAS @/path/to/script.sql
 ```
 
 ### Command-line -c Flag (Inline Command)
 
-The official SQLcl startup flags documentation does not include a `-c` option for inline SQL commands. Use stdin or a script file instead.
-
-```shell
-# Preferred: use stdin or a script file
-echo "SELECT SYSDATE FROM DUAL; EXIT;" | sql -S username/password@service
-sql -S username/password@service @script.sql
-```
+The official SQLcl startup flags documentation does not include a `-c` option for inline SQL commands. Use stdin or a script file with the patterns above.
 
 ---
 
@@ -93,7 +122,10 @@ EXIT 0
 ### Checking Exit Code in Shell
 
 ```shell
-sql -S user/pass@service @deploy.sql
+sql -S /nolog <<EOF
+CONNECT ${DB_USER}/"${DB_PASS}"@${DB_SERVICE}
+@deploy.sql
+EOF
 EXIT_CODE=$?
 
 if [ $EXIT_CODE -ne 0 ]; then
@@ -166,17 +198,29 @@ SSL_SERVER_DN_MATCH=yes
 ### Connecting
 
 ```shell
-# Use the TNS alias defined in the wallet's tnsnames.ora
-sql -S "${DB_USER}/${DB_PASSWORD}@${DB_SERVICE_NAME}" @deploy.sql
+# Use the TNS alias defined in the wallet's tnsnames.ora; password comes from CI secret
+sql -S /nolog <<EOF
+CONNECT ${DB_USER}/"${DB_PASS}"@${DB_SERVICE_NAME}
+@deploy.sql
+EOF
 ```
 
 Where `DB_SERVICE_NAME` is one of the aliases defined in the wallet's `tnsnames.ora` (e.g., `myatp_high`, `myatp_medium`, `myatp_low`).
 
-### Full Cloud Connection Example
+For fully password-less automation, configure a Secure External Password Store (SEPS) and connect with `/@alias`:
 
 ```shell
 export TNS_ADMIN=/tmp/wallet
-sql -S admin/MyPassword123@myatp_high <<'EOF'
+sql -S /@${DB_SERVICE_NAME} @deploy.sql
+```
+
+### Full Cloud Connection Example
+
+With SEPS the heredoc can stay quoted, no shell-side escapes needed:
+
+```shell
+export TNS_ADMIN=/tmp/wallet
+sql -S /@myatp_high <<'EOF'
 WHENEVER SQLERROR EXIT SQL.SQLCODE
 SELECT instance_name, status FROM v$instance;
 EXIT 0
@@ -200,21 +244,25 @@ PROMPT Deploying version &APP_VER to environment &ENV
 SELECT 'Deploying to: ' || '&ENV' AS info FROM DUAL;
 ```
 
-Pass arguments from the command line:
+Pass arguments from the command line (credentials still go through `/nolog` + `CONNECT`, not argv):
 
 ```shell
-sql -S user/pass@service @deploy_env.sql PROD v2.5.1
+sql -S /nolog <<EOF
+CONNECT ${DB_USER}/"${DB_PASS}"@${DB_SERVICE}
+@deploy_env.sql PROD v2.5.1
+EOF
 ```
 
 ### Using Shell Variable Expansion
 
-For environment variables from the shell, use the shell's own variable substitution in the heredoc:
+For environment variables from the shell, use the shell's own variable substitution in the heredoc. Keep credentials out of the `sql` command line by issuing `CONNECT` from inside the heredoc:
 
 ```shell
 export APP_VERSION="2.5.1"
 export DEPLOY_ENV="production"
 
-sql -S "${DB_USER}/${DB_PASSWORD}@${DB_SERVICE}" <<EOF
+sql -S /nolog <<EOF
+CONNECT ${DB_USER}/"${DB_PASS}"@${DB_SERVICE}
 WHENEVER SQLERROR EXIT SQL.SQLCODE
 
 INSERT INTO deployment_log (version, environment, deployed_at)
@@ -297,9 +345,14 @@ jobs:
           echo "${{ secrets.WALLET_ZIP_B64 }}" | base64 -d | unzip -q -d /tmp/wallet -
 
       - name: Validate changelog status
+        env:
+          DB_USER: ${{ secrets.DB_USER }}
+          DB_PASS: ${{ secrets.DB_PASS }}
+          DB_SERVICE: ${{ secrets.DB_SERVICE }}
         run: |
           cd db
-          sql -S "${{ secrets.DB_USER }}/${{ secrets.DB_PASS }}@${{ secrets.DB_SERVICE }}" <<'EOF'
+          sql -S /nolog <<EOF
+          CONNECT ${DB_USER}/"${DB_PASS}"@${DB_SERVICE}
           WHENEVER SQLERROR EXIT SQL.SQLCODE
           lb status -changelog-file controller.xml
           EXIT 0
@@ -333,19 +386,29 @@ jobs:
           echo "${{ secrets.WALLET_ZIP_B64 }}" | base64 -d | unzip -q -d /tmp/wallet -
 
       - name: Tag pre-deployment state
+        env:
+          DB_USER: ${{ secrets.DB_USER }}
+          DB_PASS: ${{ secrets.DB_PASS }}
+          DB_SERVICE: ${{ secrets.DB_SERVICE }}
         run: |
           cd db
           VERSION="${{ github.sha }}"
-          sql -S "${{ secrets.DB_USER }}/${{ secrets.DB_PASS }}@${{ secrets.DB_SERVICE }}" <<EOF
+          sql -S /nolog <<EOF
+          CONNECT ${DB_USER}/"${DB_PASS}"@${DB_SERVICE}
           WHENEVER SQLERROR EXIT SQL.SQLCODE
           lb tag -tag pre-${VERSION}
           EXIT 0
           EOF
 
       - name: Apply Liquibase changes
+        env:
+          DB_USER: ${{ secrets.DB_USER }}
+          DB_PASS: ${{ secrets.DB_PASS }}
+          DB_SERVICE: ${{ secrets.DB_SERVICE }}
         run: |
           cd db
-          sql -S "${{ secrets.DB_USER }}/${{ secrets.DB_PASS }}@${{ secrets.DB_SERVICE }}" <<'EOF'
+          sql -S /nolog <<EOF
+          CONNECT ${DB_USER}/"${DB_PASS}"@${DB_SERVICE}
           WHENEVER SQLERROR EXIT SQL.SQLCODE ROLLBACK
           SET ECHO ON
           lb update -changelog-file controller.xml
@@ -353,9 +416,16 @@ jobs:
           EOF
 
       - name: Run post-deployment validation
+        env:
+          DB_USER: ${{ secrets.DB_USER }}
+          DB_PASS: ${{ secrets.DB_PASS }}
+          DB_SERVICE: ${{ secrets.DB_SERVICE }}
         run: |
           cd db
-          sql -S "${{ secrets.DB_USER }}/${{ secrets.DB_PASS }}@${{ secrets.DB_SERVICE }}" @validate_schema.sql
+          sql -S /nolog <<EOF
+          CONNECT ${DB_USER}/"${DB_PASS}"@${DB_SERVICE}
+          @validate_schema.sql
+          EOF
 
       - name: Upload deployment log on failure
         if: failure()
@@ -405,8 +475,15 @@ jobs:
           echo "${{ secrets.WALLET_ZIP_B64 }}" | base64 -d | unzip -q -d /tmp/wallet -
           echo "TNS_ADMIN=/tmp/wallet" >> $GITHUB_ENV
       - name: Execute SQLcl script
+        env:
+          DB_USER: ${{ secrets.DB_USER }}
+          DB_PASS: ${{ secrets.DB_PASS }}
+          DB_SERVICE: ${{ secrets.DB_SERVICE }}
         run: |
-          sql -S "${{ secrets.DB_USER }}/${{ secrets.DB_PASS }}@${{ secrets.DB_SERVICE }}" @${{ inputs.script }}
+          sql -S /nolog <<EOF
+          CONNECT ${DB_USER}/"${DB_PASS}"@${DB_SERVICE}
+          @${{ inputs.script }}
+          EOF
 ```
 
 ---
@@ -439,7 +516,8 @@ validate_changes:
   script:
     - cd db
     - |
-      sql -S "${DB_USER}/${DB_PASS}@${DB_SERVICE}" <<'SQLEOF'
+      sql -S /nolog <<SQLEOF
+      CONNECT ${DB_USER}/"${DB_PASS}"@${DB_SERVICE}
       WHENEVER SQLERROR EXIT SQL.SQLCODE
       lb status -changelog-file controller.xml
       EXIT 0
@@ -454,7 +532,8 @@ deploy_db:
   script:
     - cd db
     - |
-      sql -S "${DB_USER}/${DB_PASS}@${DB_SERVICE}" <<'SQLEOF'
+      sql -S /nolog <<SQLEOF
+      CONNECT ${DB_USER}/"${DB_PASS}"@${DB_SERVICE}
       WHENEVER SQLERROR EXIT SQL.SQLCODE ROLLBACK
       SET ECHO ON
       lb tag -tag pre-${CI_COMMIT_SHORT_SHA}
@@ -472,10 +551,16 @@ verify_deployment:
   <<: *sqlcl_setup
   script:
     - cd db
-    - sql -S "${DB_USER}/${DB_PASS}@${DB_SERVICE}" @validate_schema.sql
+    - |
+      sql -S /nolog <<SQLEOF
+      CONNECT ${DB_USER}/"${DB_PASS}"@${DB_SERVICE}
+      @validate_schema.sql
+      SQLEOF
   rules:
     - if: '$CI_COMMIT_BRANCH == "main"'
 ```
+
+`DB_USER`, `DB_PASS`, and `DB_SERVICE` should be defined as masked, protected CI/CD variables in GitLab so they are injected into the runner environment but never echoed to the job log. Avoid `set -x` or `set -v` in pipeline steps that handle credentials, even via stdin.
 
 ---
 
@@ -484,8 +569,13 @@ verify_deployment:
 ### Capturing All SQLcl Output
 
 ```shell
-# Redirect both stdout and stderr to a log file
-sql -S user/pass@service @deploy.sql 2>&1 | tee /tmp/deploy.log
+# Redirect both stdout and stderr to a log file. Credentials come from masked
+# CI variables (${DB_USER}, ${DB_PASS}, ${DB_SERVICE}) and are passed via stdin
+# so they never appear in the process list.
+sql -S /nolog <<EOF 2>&1 | tee /tmp/deploy.log
+CONNECT ${DB_USER}/"${DB_PASS}"@${DB_SERVICE}
+@deploy.sql
+EOF
 
 # Check exit code (tee preserves the pipeline, PIPESTATUS captures it)
 EXIT_CODE=${PIPESTATUS[0]}
@@ -573,10 +663,14 @@ EXIT 0
 If validation fails, the `WHENEVER SQLERROR EXIT ... ROLLBACK` triggers DML rollback. To roll back Liquibase schema changes, add a shell-level rollback step:
 
 ```shell
-sql -S user/pass@service @deploy_with_rollback.sql "$CI_COMMIT_SHORT_SHA"
+sql -S /nolog <<EOF
+CONNECT ${DB_USER}/"${DB_PASS}"@${DB_SERVICE}
+@deploy_with_rollback.sql "$CI_COMMIT_SHORT_SHA"
+EOF
 if [ $? -ne 0 ]; then
     echo "Deployment failed, rolling back Liquibase changes..."
-    sql -S user/pass@service <<EOF
+    sql -S /nolog <<EOF
+    CONNECT ${DB_USER}/"${DB_PASS}"@${DB_SERVICE}
     lb rollback -tag pre-deploy-${CI_COMMIT_SHORT_SHA} -changelog-file controller.xml
     EXIT
 EOF
@@ -588,17 +682,26 @@ fi
 
 ## Security Best Practices in CI/CD
 
-### Never Hardcode Credentials
+### Keep Credentials Out of the Command Line
 
-Always use CI/CD secret variables for credentials:
+Pass credentials through `/nolog` + stdin or a SEPS wallet so they never appear as process arguments. With SEPS the password is not present at all; with `/nolog` it travels on fd 0 instead of argv.
 
 ```shell
-# Good: credentials from environment variables
-sql -S "${DB_USER}/${DB_PASS}@${DB_SERVICE}" @deploy.sql
+# SEPS wallet — no password on the command line or in stdin
+export TNS_ADMIN=/path/to/seps-wallet
+sql -S /@DB_ALIAS @deploy.sql
 
-# Bad: hardcoded credentials
-sql -S admin/MyPassword123@myatp_high @deploy.sql
+# /nolog + stdin — password from a masked CI variable, not visible in `ps`
+sql -S /nolog <<EOF
+CONNECT ${DB_USER}/"${DB_PASS}"@${DB_SERVICE}
+@deploy.sql
+EOF
+
+# Avoid: credentials interpolated as process arguments
+sql -S "${DB_USER}/${DB_PASS}@${DB_SERVICE}" @deploy.sql
 ```
+
+Do not enable shell tracing (`set -x`, `set -v`, `bash -x`) in steps that handle the stdin connect — tracing prints the expanded `CONNECT` line to the job log.
 
 ### Wallet as Base64 Secret
 
@@ -649,6 +752,7 @@ COMMIT;
 
 ## Best Practices
 
+- Never put credentials on the SQLcl command line. Use SEPS (`/@alias`) or `/nolog` + a `CONNECT` on stdin. See [Keep Credentials Out of the Command Line](#keep-credentials-out-of-the-command-line).
 - Always use `WHENEVER SQLERROR EXIT SQL.SQLCODE ROLLBACK` at the top of every CI/CD SQL script. Without it, SQLcl will continue executing after a SQL error and exit with code 0 even if statements failed.
 - Use the `-S` (silent) flag for all CI/CD invocations. Without it, the SQLcl banner and connection messages will appear in your pipeline log and may confuse log parsers.
 - Keep the wallet directory out of your repository. Store it as a base64-encoded CI/CD secret and decode it at pipeline runtime. Never commit wallet files (`.sso`, `.jks`, `.p12`, `ewallet.p12`) to version control.
@@ -686,3 +790,6 @@ Using a DBA or ADMIN account for routine deployments is a security risk and make
 - [Oracle SQLcl 25.2 User's Guide](https://docs.oracle.com/en/database/oracle/sql-developer-command-line/25.2/sqcug/oracle-sqlcl-users-guide.pdf)
 - [SQLcl Release Notes 25.2](https://www.oracle.com/tools/sqlcl/sqlcl-relnotes-25.2.html)
 - [Oracle SQLcl Releases index](https://docs.oracle.com/en/database/oracle/sql-developer-command-line/index.html)
+- [Oracle Database Security Guide 19c — Configuring Authentication (Secure External Password Store)](https://docs.oracle.com/en/database/oracle/oracle-database/19/dbseg/configuring-authentication.html)
+- [GitHub Docs — Using secrets in GitHub Actions](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions)
+- [GitLab Docs — CI/CD variables, masking, and protected variables](https://docs.gitlab.com/ee/ci/variables/)


### PR DESCRIPTION
Closes #32

## Summary

Restructure the SQLcl basics and CI/CD skills so the primary examples never put a database password on the command line. Connection strings passed as argv (`user/password@service`) are visible to other processes via `ps`/`/proc/<pid>/cmdline`, are recorded in shell history (bash, zsh, PowerShell), and are captured in terminal scrollback and CI job log retention.

## Changes

### `db/sqlcl/sqlcl-basics.md`

- Lead the *Connecting to Oracle Database* section with a short security warning that points to the new Discouraged subsection.
- Replace the first credentialed examples (Basic, EZConnect, TNS Alias, Cloud Wallet, SYSDBA, in-session `CONNECT`) with prompted-password or wallet forms.
- Replace the literal `admin/MyPassword123@myadb_high` example called out in the issue.
- Add a `### Discouraged: Passwords on the Command Line` subsection that explicitly marks the inline-password pattern as a discouraged anti-pattern and lists the leak surfaces (`ps`/`/proc`, shell history, scrollback, CI logs).
- Note SEPS (Secure External Password Store) as the password-less option from the Cloud Wallet section, with a Sources reference to the Oracle Database Security Guide.

### `db/sqlcl/sqlcl-cicd.md`

- Add a one-line security warning at the top of *Running SQLcl Non-Interactively* that points to the dedicated security section.
- Replace every `sql -S user/pass@service` / `sql -S "${DB_USER}/${DB_PASS}@${DB_SERVICE}"` pattern with `sql -S /nolog` followed by a `CONNECT` line issued from stdin via heredoc. The credential reaches SQLcl on fd 0, not as a process argument.
- Document the SEPS form (`sql -S /@alias`) as the password-less alternative for runners that can carry a wallet.
- Update the GitHub Actions workflow to inject masked secrets through each step's `env:` block and reference them inside the heredoc, so secrets are not interpolated directly into the `sql` argument.
- Update the GitLab CI workflow similarly, switching the heredocs from `<<'SQLEOF'` (quoted) to `<<SQLEOF` (unquoted) so the shell can expand the protected/masked CI variables inside the `CONNECT` line.
- Add a *Keep Credentials Out of the Command Line* section with side-by-side SEPS, `/nolog`, and *avoid* examples, plus a warning against enabling `set -x` / `set -v` in steps that handle the stdin connect.
- Add references to the Oracle Database Security Guide (SEPS), GitHub Actions secrets docs, and GitLab CI/CD variables docs.

## Acceptance criteria from the issue

- [x] The first SQLcl login examples do not include a literal password in the command.
- [x] CI examples avoid displaying credentials in command-line arguments.
- [x] Inline-password usage is clearly marked as discouraged.

## Validation

- No remaining `sql -S user/pass@service`-style invocations in the primary path of either file. The only `user/password@service` strings that remain are the explicit Discouraged / avoid examples and the surrounding warning prose.
- The markdown anchors `#discouraged-passwords-on-the-command-line` and `#keep-credentials-out-of-the-command-line` resolve to the new headings under GitHub-flavored Markdown rules.
- YAML pipe-literal indentation in the GitHub Actions and GitLab CI examples puts each `EOF`/`SQLEOF` terminator at column 0 of the executed shell script after the common indent is stripped.