### PR TITLE
ai(db): update description for Oracle Database skills

### DIFF
--- a/db/SKILL.md
+++ b/db/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: db
-description: Oracle Database skills for administration, SQL and PL/SQL development, performance tuning, security, ORDS, SQLcl, migrations, frameworks, Oracle Container Registry guidance, and agent-safe database workflows.
+description: Oracle Database guidance for SQL, PL/SQL, SQLcl, ORDS, administration, app development, performance, security, migrations, and agent-safe database workflows. Use when the user asks to write, edit, rewrite, review, format, debug, tune, or explain SQL; create or refactor PL/SQL; use SQLcl, Liquibase, ORDS, JDBC, node-oracledb, Python, Java, .NET, or database frameworks; troubleshoot queries, sessions, locks, waits, indexes, optimizer plans, AWR, ASH, migrations, schemas, users, roles, privileges, backup, recovery, Data Guard, RAC, multitenant, containers, monitoring, auditing, encryption, VPD, or safe agent database operations.
 ---
 
 # Oracle Database Skills


### PR DESCRIPTION
Refined the description for Oracle Database skills to enhance clarity and detail. This skill is handling a lot of aread but agents may ignore it when user's use prose because triggers are unclear. I'm adding to the triggers so agents can better manage the use of the skill.

This skill could be split for better triggering but if the intent is to ship all db knowledge this is fine, however, the tradeoff is that agents may trigger it inconsistently.

The skill complies with https://agentskills.io/specification and https://developers.openai.com/codex/skills however, it may be clearer to put the now top folders into a references folder as expected by the specification. That would make the structure better fitted to the spec but it would work fine as it is now 