### PR TITLE
Claude Code plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-marketplace.json",
+  "name": "oracle-skills",
+  "owner": {
+    "name": "Oracle",
+    "url": "https://github.com/oracle/skills"
+  },
+  "metadata": {
+    "description": "Oracle Skills marketplace — installable, source-backed skills for Oracle technologies. Each top-level domain folder is published as its own plugin.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "apex",
+      "source": "./apex",
+      "description": "Oracle APEX skills for Oracle APEX application development, including the APEXlang router with deterministic local-context discovery and compact machine-readable contracts.",
+      "category": "oracle",
+      "keywords": ["oracle", "apex", "apexlang", "low-code", "application-development"]
+    },
+    {
+      "name": "db",
+      "source": "./db",
+      "description": "Oracle Database guidance for SQL, PL/SQL, SQLcl, ORDS, administration, app development, performance, security, migrations, and agent-safe database workflows. Use when the user asks to write, edit, rewrite, review, format, debug, tune, or explain SQL; create or refactor PL/SQL; use SQLcl, Liquibase, ORDS, JDBC, node-oracledb, Python, Java, .NET, or database frameworks; troubleshoot queries, sessions, locks, waits, indexes, optimizer plans, AWR, ASH, migrations, schemas, users, roles, privileges, backup, recovery, Data Guard, RAC, multitenant, containers, monitoring, auditing, encryption, VPD, or safe agent database operations.",
+      "category": "oracle",
+      "keywords": ["oracle", "database", "sql", "plsql", "sqlcl", "ords", "performance", "security", "migrations"]
+    },
+    {
+      "name": "fusion",
+      "source": "./fusion",
+      "description": "Oracle Fusion domain. Placeholder for future Oracle Fusion skills.",
+      "category": "oracle",
+      "keywords": ["oracle", "fusion"]
+    },
+    {
+      "name": "graal",
+      "source": "./graal",
+      "description": "Build, configure, and troubleshoot GraalVM Native Image applications. Use this skill for native-image CLI builds, Maven or Gradle Native Build Tools, reachability metadata, and build or run time issue diagnosis.",
+      "category": "oracle",
+      "keywords": ["oracle", "graalvm", "native-image", "maven", "gradle"]
+    },
+    {
+      "name": "oci",
+      "source": "./oci",
+      "description": "Oracle Cloud Infrastructure domain. Placeholder for future OCI skills.",
+      "category": "oracle",
+      "keywords": ["oracle", "oci", "cloud-infrastructure"]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,29 @@ npx skills add oracle/skills/graal
 ...
 ```
 
+### Install in Claude Code
+
+This repository also ships as a Claude Code plugin marketplace (`.claude-plugin/marketplace.json`), where each domain folder (`apex`, `db`, `fusion`, `graal`, `oci`) is published as its own plugin.
+
+Register the marketplace, then install the domain plugins you need:
+
+```bash
+# Register this repo as a marketplace
+/plugin marketplace add oracle/skills
+
+# Install one or more domain plugins
+/plugin install db@oracle-skills
+/plugin install graal@oracle-skills
+```
+
+Already cloned the repo locally? Point the marketplace at the local path instead:
+
+```bash
+/plugin marketplace add ./
+```
+
+Browse and toggle installed plugins anytime with `/plugin`. Enabled plugins are tracked in `.claude/settings.json` under `enabledPlugins`.
+
 ## Repository Goals
 
 - Provide Oracle-wide skills in one repository.


### PR DESCRIPTION
## What this does

Ships this repository as a [Claude Code](https://docs.claude.com/en/docs/claude-code) **plugin marketplace**, so users can register it and install Oracle skills directly from within Claude Code — complementing the existing `npx skills add` flow.

### Changes

- **`.claude-plugin/marketplace.json`** (new): defines the `oracle-skills` marketplace and publishes each top-level domain folder as its own plugin:
  - `apex`, `db`, `fusion`, `graal`, `oci` — each with a description, `oracle` category, and keywords.
- **`README.md`**: adds an *"Install in Claude Code"* section documenting how to register the marketplace and install domain plugins, alongside the existing `npx` instructions.

### How to validate

1. Register the marketplace:
   - From GitHub: `/plugin marketplace add oracle/skills`
   - From a local clone: `/plugin marketplace add ./`
2. Install a domain plugin: `/plugin install db@oracle-skills`
3. Run `/plugin` to list and toggle installed plugins.

The marketplace file validates against the official schema (`https://json.schemastore.org/claude-code-plugin-marketplace.json`).

Closes #66

