### PR TITLE
Add OCI Functions skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .claude/settings.local.json
-apex/apexlang/.DS_Store
-apex/.DS_Store
+.DS_Store
+.idea
+.oca
+*.log

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Browse and toggle installed plugins anytime with `/plugin`. Enabled plugins are 
 ## Domains
 
 - `db/` is the active Oracle Database domain and includes database, ORDS, SQLcl, framework, container, and agent workflow skills.
-- `oci/` contains Oracle Cloud Infrastructure skills, including OCI Kubernetes Engine cluster design and troubleshooting, OCI IoT Platform digital twin workflows, plus Enterprise AI guidance for OCI Generative AI, agents, RAG, governance, model endpoints, Autonomous Database, APEX, and integrations.
+- `oci/` contains Oracle Cloud Infrastructure skills, including OCI Functions deployment and troubleshooting, OCI Kubernetes Engine cluster design and troubleshooting, OCI IoT Platform digital twin workflows, plus Enterprise AI guidance for OCI Generative AI, agents, RAG, governance, model endpoints, Autonomous Database, APEX, and integrations.
 - `fusion/` is the root for future Oracle Fusion skills.
 - `apex/` is the root for future Oracle APEX skills.
 - `graal/` contains GraalVM skills, starting with Native Image.
@@ -103,6 +103,9 @@ Browse and toggle installed plugins anytime with `/plugin`. Enabled plugins are 
     │   ├── data/
     │   ├── cost/
     │   └── integrations/
+    ├── functions/
+    │   ├── oci-functions-deploy/
+    │   └── oci-functions-troubleshoot/
     ├── iot-platform/
     │   ├── SKILL.md
     │   ├── agents/

--- a/oci/SKILL.md
+++ b/oci/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: oci
-description: Oracle Cloud Infrastructure guidance for designing, operating, and troubleshooting OCI services, including OCI Kubernetes Engine (OKE), OCI Internet of Things Platform, and Enterprise AI workflows for OCI Generative AI models, Responses API agents, RAG, cost estimation, governance, private endpoints, hosted agentic applications, and Oracle platform integrations. Use when the user asks about OKE cluster design, Terraform or Resource Manager planning, OKE incident troubleshooting, Generic VNIC Attachment, Multus, pod networking, node pools, add-ons, ingress, load balancers, OCIR image pulls, Workload Identity, Kubernetes workloads on OCI, OCI IoT domains or digital twins, device publish flows, OCI Generative AI, Enterprise AI Models, Enterprise AI Agents, governed GenAI applications, agentic workflows, RAG on Oracle Cloud, or OCI Generative AI pricing.
+description: Oracle Cloud Infrastructure guidance for designing, operating, and troubleshooting OCI services, including OCI Kubernetes Engine (OKE), OCI Internet of Things Platform, OCI Functions deployment and troubleshooting, and Enterprise AI workflows for OCI Generative AI models, Responses API agents, RAG, cost estimation, governance, private endpoints, hosted agentic applications, and Oracle platform integrations. Use when the user asks about OKE cluster design, Terraform or Resource Manager planning, OKE incident troubleshooting, Generic VNIC Attachment, Multus, pod networking, node pools, add-ons, ingress, load balancers, OCIR image pulls, Workload Identity, Kubernetes workloads on OCI, OCI IoT domains or digital twins, device publish flows, OCI Functions setup, deployment, invocation, or troubleshooting, OCI Generative AI, Enterprise AI Models, Enterprise AI Agents, governed GenAI applications, agentic workflows, RAG on Oracle Cloud, or OCI Generative AI pricing.
 ---
 
 # Oracle Cloud Infrastructure Skills
 
-Use this domain for practical Oracle Cloud Infrastructure guidance. Current content covers OCI Kubernetes Engine (OKE): cluster design, operational troubleshooting, Generic VNIC Attachment (GVA), and Multus multi-interface pod validation. It covers OCI Internet of Things Platform resource discovery, digital twin lifecycle workflows, device publish flows, and optional MCP-assisted operation. It also covers Enterprise AI because that work is built around OCI Generative AI, OCI networking, IAM, cost estimation, hosted applications, and OCI platform integrations.
+Use this domain for practical Oracle Cloud Infrastructure guidance. Current content covers OCI Kubernetes Engine (OKE): cluster design, operational troubleshooting, Generic VNIC Attachment (GVA), and Multus multi-interface pod validation. It covers OCI Internet of Things Platform resource discovery, digital twin lifecycle workflows, device publish flows, and optional MCP-assisted operation. It covers OCI Functions local deployment and diagnosis-first troubleshooting. It also covers Enterprise AI because that work is built around OCI Generative AI, OCI networking, IAM, cost estimation, hosted applications, and OCI platform integrations.
 
 ## How to Use This Domain
 
@@ -28,6 +28,17 @@ oci/
 │   ├── data/
 │   ├── cost/
 │   └── integrations/
+├── functions/
+│   ├── oci-functions-deploy/
+│   │   ├── SKILL.md
+│   │   ├── agents/
+│   │   ├── references/
+│   │   ├── scripts/
+│   │   └── tests/
+│   └── oci-functions-troubleshoot/
+│       ├── SKILL.md
+│       ├── agents/
+│       └── references/
 ├── iot-platform/
 │   ├── SKILL.md
 │   ├── agents/
@@ -56,6 +67,8 @@ oci/
 | Troubleshoot OKE workloads, pods, services, DNS, add-ons, ingress, load balancers, image pulls, storage, Workload Identity, or cluster access | Start with `oci/oke/troubleshooting.md`, then load `oci/oke/skills/oke-troubleshooter/SKILL.md` |
 | Configure OKE managed node pools with Generic VNIC Attachment secondary VNIC profiles and Application Resources | Start with `oci/oke/gva-node-pools.md`, then load `oci/oke/skills/oke-gva-deployer/SKILL.md` |
 | Deploy or validate Multus NetworkAttachmentDefinitions and multi-interface pods on OKE | Start with `oci/oke/multus-multihome.md`, then load `oci/oke/skills/oke-multihome-deployer/SKILL.md` |
+| Deploy an OCI Function from a local macOS or Linux workstation | `oci/functions/oci-functions-deploy/SKILL.md` |
+| Troubleshoot OCI Functions setup, deployment, invocation, or observability | `oci/functions/oci-functions-troubleshoot/SKILL.md` |
 | OCI IoT domains, domain groups, digital twin models, adapters, instances, relationships, raw commands, Data API access, or HTTPS publish flows | `oci/iot-platform/SKILL.md` |
 | OCI Generative AI models, custom/imported models, endpoints, or private endpoints | `oci/enterprise-ai/SKILL.md` |
 | OCI Responses API agents, tools, memory, File Search, Code Interpreter, MCP, or SQL Search | `oci/enterprise-ai/SKILL.md` |
@@ -68,6 +81,10 @@ oci/
 - `oci/oke/troubleshooting.md`
 - `oci/oke/gva-node-pools.md`
 - `oci/oke/multus-multihome.md`
+- `oci/functions/oci-functions-deploy/SKILL.md`
+- `oci/functions/oci-functions-troubleshoot/SKILL.md`
+- `oci/functions/oci-functions-deploy/references/oci-functions-quickstart.md`
+- `oci/functions/oci-functions-troubleshoot/references/error-patterns.md`
 - `oci/iot-platform/SKILL.md`
 - `oci/iot-platform/references/cli-workflows.md`
 - `oci/iot-platform/references/mcp-optional-use.md`
@@ -96,6 +113,9 @@ The OKE operational skills include deterministic helper tools under `oci/oke/scr
 | Build a node pool with workload-specific secondary VNIC profiles | `oke/gva-node-pools.md` -> `oke/multus-multihome.md` if pods need multiple interfaces |
 | Validate Multus pod networking on GVA-enabled nodes | `oke/multus-multihome.md` -> `oke/troubleshooting.md` if symptoms remain |
 | Investigate OKE workload access to OCI APIs | `oke/troubleshooting.md` |
+| Deploy a local function | `functions/oci-functions-deploy/SKILL.md` -> preflight -> Fn context validation -> OCIR auth check -> app selection -> scaffold -> deploy |
+| Troubleshoot a failed function deploy | `functions/oci-functions-troubleshoot/SKILL.md` -> `functions/oci-functions-troubleshoot/references/error-patterns.md` -> `functions/oci-functions-troubleshoot/references/deploy.md` |
+| Troubleshoot function invocation failures | `functions/oci-functions-troubleshoot/SKILL.md` -> `functions/oci-functions-troubleshoot/references/invoke.md` -> logs, traces, metrics, and limits |
 | Explore or update OCI IoT digital twin resources | `iot-platform/SKILL.md` -> `iot-platform/references/cli-workflows.md` -> `iot-platform/references/resilience-guidance.md` |
 | Publish test telemetry to an OCI IoT twin | `iot-platform/SKILL.md` -> `iot-platform/references/cli-workflows.md` -> `iot-platform/templates/publish-curl.template.sh` |
 | Build a governed enterprise assistant | `enterprise-ai/SKILL.md` -> `enterprise-ai/agent-workflows/agent-tools.md` -> `enterprise-ai/data/rag-and-search.md` -> `enterprise-ai/governance/private-endpoints-and-governance.md` |
@@ -118,3 +138,7 @@ The OKE operational skills include deterministic helper tools under `oci/oke/scr
 - https://github.com/oracle-samples/oci-iot-samples
 - https://docs.oracle.com/en-us/iaas/Content/generative-ai/overview.htm
 - https://docs.oracle.com/en-us/iaas/Content/generative-ai/home.htm
+- https://docs.oracle.com/en-us/iaas/Content/Functions/home.htm
+- https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionsquickstartlocalhost.htm
+- https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionscreatingapps.htm
+- https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionstroubleshooting.htm

--- a/oci/functions/oci-functions-deploy/SKILL.md
+++ b/oci/functions/oci-functions-deploy/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: oci-functions-deploy
+description: Build, configure, scaffold, and deploy OCI Functions from a local machine using a dependency-first, Fn-context-guided flow with argv-safe mutation execution, nonce-scoped confirmations, and a canonical lowercase machine-readable contract. Use when asked to validate/install Fn, OCI CLI, and Docker, configure or create Fn contexts, validate OCI session and Docker registry auth from Fn context values, choose or create a Functions application, scaffold Java, Python, or Node functions, and deploy them. Network creation is supported only as an explicit advanced branch.
+---
+
+# OCI Functions Deploy
+
+## Overview
+
+Use this skill for **local macOS/Linux OCI Functions workstations**. Windows automation is out of scope for this skill and should be handled manually. OCI Cloud Shell is also out of scope for the current workflow; if the user is in Cloud Shell, do not reuse this local automation flow blindly.
+
+This skill supports **Java, Python, and Node** scaffolding and deploy automation. OCI Functions supports additional runtimes, but they are not scaffolded or deployed automatically by this skill.
+
+Resolve deployment values with this precedence everywhere in the flow:
+- explicit user-provided values collected in chat or passed as script flags
+- active Fn context values
+- derived values from already-resolved inputs
+- OCI/CLI defaults
+
+Execution modes:
+- `interactive`: confirmations are gathered via terminal prompts for mutating actions.
+- `agent-mediated`: confirmations are per-command and single-use. Approval must include `CONFIRM_RESPONSE=yes`, a matching `CONFIRM_ACTION_ID`, and the nonce emitted for that exact mutation in `CONFIRM_NONCE`.
+
+## Read vs Mutate Policy
+
+- `read`: dependency checks, context inspection, OCI session validation, Docker auth inspection, application listing, dry-run validation. Run without confirmation.
+- `mutate`: install/start, create/update contexts, Docker login, app creation, advanced network creation, `fn init`, and `fn deploy`. Require confirmation.
+- If a command is ambiguous, treat it as mutating and confirm it.
+
+### Gating Table
+
+| Step | Classification | Confirmation |
+|---|---|---|
+| dependency availability checks | `read` | not required |
+| Fn context inspection | `read` | not required |
+| OCI session validation and security-token retry check | `read` | not required |
+| Docker registry auth inspection | `read` | not required |
+| install missing `fn` / `oci` / `docker` | `mutate` | required |
+| start Docker daemon | `mutate` | required |
+| create or update Fn context | `mutate` | required |
+| Docker login to Fn registry | `mutate` | required |
+| create Functions app | `mutate` | required |
+| advanced network creation (`ensure_network.sh`) | `mutate` | required |
+| scaffold function with `fn init` | `mutate` | required |
+| deploy with `fn deploy` | `mutate` | required |
+
+## Confirm Interface
+
+Mutating scripts must use the structured confirmation interface:
+
+`confirm_gate.sh --description <text> [--display <text>] [--cwd <path>] [--stdin-env <env>] [--nonce <nonce>] [--machine-readable] -- <argv...>`
+
+Rules:
+- Execute argv directly, not through `bash -c`.
+- Use `--cwd` instead of embedding `cd ... && ...`.
+- Use `--stdin-env` for commands like `docker login --password-stdin`.
+- Agent-mediated approvals are single-use. Replaying the same action id and nonce after a successful mutation is invalid.
+- Interactive prompts mint a fresh 128-bit nonce from `/dev/urandom` for each mutation prompt so the same command can be approved again later through a new prompt.
+- Confirmation descriptions and caller-supplied display text are shell-escaped for review; execution still uses only the original argv array.
+- Linux Fn installation resolves the latest non-draft, non-prerelease GitHub release before confirmation. The approved action is bound to that release's canonical asset URL and GitHub-provided SHA-256 digest. The installer revalidates the metadata, digest, and reported binary version before privileged installation and never executes a downloaded shell installer.
+- The verified Linux Fn install path requires `curl`, `python3`, and either `sha256sum` or `shasum`; if one is unavailable, install that prerequisite first or install Fn manually.
+- Verified latest-release installation still trusts the official `fnproject/cli` repository, GitHub release metadata, and the upstream release publisher.
+
+## Function Name Rules
+
+- Treat a function name as `provided` only when the user explicitly names it.
+- Explicit naming includes phrases like `name it ...`, `call it ...`, `function name is ...`, or a structured flag such as `--function-name`.
+- Descriptive phrases such as `hello world function`, `sample function`, `test function`, or `python function` describe intent only and must not be converted into a function name automatically.
+- Never slugify a descriptive phrase into a function name without asking the user.
+- It is acceptable to suggest a name derived from intent, but the user must explicitly confirm it before it is used.
+
+### Function Name Contract
+
+- `function_name_state=missing`: no explicit or prompted function name exists yet.
+- `function_name_state=explicit`: the user explicitly named the function in chat or via `--function-name` with `--function-name-source explicit`.
+- `function_name_state=prompted`: the name was gathered or confirmed via an explicit prompt.
+- Only pass `--function-name` into `build_and_deploy.sh` when the state is `explicit` or `prompted`.
+- If a likely name was inferred from prose, keep the state as `missing` and ask for the function name instead of forwarding it.
+
+## Workflow
+
+1. **Dependency availability**
+- Run `scripts/preflight_check.sh --runtime <java|python|node>` to detect whether `fn`, `oci`, and `docker` are installed.
+- If `fn` or `oci` is missing, prompt and run `scripts/install_missing.sh --tool <fn|oci>`.
+- If Docker is missing, prompt and run `scripts/install_missing.sh --tool docker`.
+- If Docker exists but the daemon is stopped, prompt and run `scripts/install_missing.sh --tool docker-daemon`.
+
+2. **Fn context validation**
+- Use `fn inspect context` as the primary source of `oracle.profile`, `oracle.compartment-id`, `api-url`, and `registry`.
+- Precedence is always: explicit user-provided values and script flags, then the active Fn context, then derived values, then OCI/CLI defaults.
+- If the active Fn context is missing or incomplete, collect only missing values and run `scripts/configure_context.sh`.
+- `scripts/configure_context.sh` is the deliberate mutation path for applying explicit user-provided overrides to the active context.
+- Support optional `oracle.image-compartment-id` only when the user explicitly provides it or when an existing context already carries it.
+
+3. **OCI CLI validation**
+- Validate OCI session using the profile from Fn context.
+- If validation fails with a retryable security-token style error, prompt the user and retry validation with `security_token` auth before surfacing failure.
+- Stop the flow if OCI auth remains invalid.
+- Any OCI CLI nonzero exit is `error` unless the command succeeded and positively proved absence through an empty result.
+
+4. **Docker registry validation**
+- Derive registry host from Fn context `registry`.
+- Use a live, non-mutating registry probe before claiming auth is valid.
+- Treat cached Docker credentials as `cached`, not `valid`, when the registry probe cannot safely confirm them.
+- If Docker auth is `missing` or still insufficient after the probe, prompt for OCIR credentials and run `scripts/configure_context.sh --ocir-username ... --ocir-auth-token ...` or an equivalent Docker login step.
+
+5. **Application selection**
+- Run `scripts/discover_state.sh` after prerequisites are valid.
+- Use the Fn context compartment to list available Functions applications.
+- If apps exist, explicitly ask whether to reuse an existing app or create a new one.
+- If reusing, keep the selected app name/id for later deploy.
+- Resolve user-selected resource names by fetching OCI JSON and comparing `display-name` values exactly. Never interpolate names into JMESPath expressions, and stop on duplicate exact matches instead of selecting an arbitrary resource.
+- If creating, gather required details and run `scripts/ensure_app.sh`.
+- If `app_name` matches an existing application but `app_choice` was never stated, prompt in interactive mode and fail in non-interactive mode; never silently reuse.
+- Application creation supports `1-3` subnet OCIDs, optional application shape (`GENERIC_X86`, `GENERIC_ARM`, or `GENERIC_X86_ARM`), and optional NSG attachment.
+- Shape and NSG inputs are create-only. Do not silently ignore them on a reuse path.
+- Do not infer VCN/subnet creation from ordinary app selection.
+- Only enter the advanced network branch when the user explicitly asks for network setup, or when app/network prerequisites are missing and the user explicitly opts into infrastructure creation.
+- Non-interactive network creation requires an explicit branch flag and explicit topology, names, and CIDRs.
+- Do not claim to auto-validate registry/subnet regional alignment. If the user is mixing explicit network inputs and an existing registry, surface region alignment as a manual check instead of guessing.
+
+6. **Function prompts and scaffolding**
+- Ask for the function name unless the user has explicitly named it.
+- Do not treat descriptive intent phrases as the function name.
+- Ask for runtime if it is not already explicit.
+- This skill's runtime scope is `java`, `python`, or `node`.
+- Run `scripts/build_and_deploy.sh --runtime <runtime> --app <app-name> --function-dir <path> --function-name <name> --function-name-source <explicit|prompted>`.
+- The script scaffolds `func.yaml` and starter code with `fn init` only after prerequisites and app choice are complete.
+- If the function directory is not provided, derive the default suggestion only after the function name has been explicitly confirmed.
+- If the requested function directory already exists, is not empty, and does not contain `func.yaml`, stop and ask for a different directory instead of running `fn init` in place.
+
+7. **Deploy**
+- Run `fn deploy` only after successful scaffolding.
+- If scaffold or deploy fails, surface the failure and stop; do not rewrite image references automatically.
+- If deploy fails while pushing to OCIR, surface repository-compartment and repository-auto-create edge cases explicitly. Recommend pre-creating the repository or setting `oracle.image-compartment-id` before retrying when the failure output points that way.
+
+## Confirmation Rules
+
+- Use `scripts/confirm_gate.sh` for all mutating commands only.
+- Read-only validation and listing steps run automatically.
+- In non-interactive runs, mutating actions proceed only with explicit per-command approval (`CONFIRM_RESPONSE=yes`, matching `CONFIRM_ACTION_ID`, and matching `CONFIRM_NONCE`).
+- `CONFIRM_RESPONSE=yes` without a matching action id and nonce is invalid.
+
+## Input Collection Order
+
+Only prompt for missing values after discovery:
+
+1. Missing dependency install/start approvals
+2. Missing Fn context values
+3. OCI security-token retry approval, if applicable
+4. OCIR login inputs, only if Docker is not logged into the Fn registry
+5. Application decision (`reuse` vs `create`) when existing apps are found
+6. Application inputs, only if app creation is needed
+7. Advanced network branch approval and inputs, only if the user explicitly opts into infrastructure creation
+8. Function name and runtime, only if not already provided
+9. Preserve function-name provenance (`explicit` vs `prompted`) when calling the scaffold script
+
+## Machine-Readable Contract
+
+Use lowercase snake_case only.
+
+All user-facing helper scripts in this skill accept `--machine-readable`. In that mode:
+- stdout must contain only lowercase `key=value` lines
+- human logs move to stderr
+- downstream parsers must rely on documented keys only
+- keys are validated as lowercase snake case, and values containing control characters are rejected rather than emitted
+
+Canonical state families:
+- `dependency_fn_state`, `dependency_oci_state`, `dependency_docker_state`, `dependency_java_state`, `dependency_mvn_state`, `dependency_python3_state`, `dependency_node_state`, `dependency_npm_state`: `found|missing`
+- `docker_daemon_state`: `running|stopped|missing|error`
+- `fn_context_state`: `found|missing|incomplete|error`
+- `apps_state`, `vcns_state`: `found|empty|error`
+- `app_state`: `found|missing|incomplete|error`
+- `oci_cli_state`, `compartment_state`, `discovery_state`, `network_state`: `found|missing|error`
+- `oci_auth_state`, `docker_registry_auth_state`, `ocir_auth_state`: `valid|cached|missing|error`
+- `docker_registry_auth_probe_state`: `valid|cached|missing|error`
+- `confirm_state`: `approved|skipped|error`
+- `app_action`, `deploy_action`: `reuse|create|deploy|skip|error`
+- `deploy_preflight_state`: `passed|skipped`
+- `install_state`: `success|error`
+- `function_name_state`: `explicit|prompted|missing`
+
+Companion fields:
+- `*_error_reason`: one of `auth_or_permission`, `runtime_or_cli`, `network_or_transport`, or a more specific documented reason
+- `oci_auth_error`
+- `fn_context_missing_keys`
+- `confirm_action_id`
+- `confirm_nonce`
+- `oci_auth_mode`
+- `oci_auth_retry_state`
+- `oci_profile`
+- `oci_profile_source`
+- `docker_registry_host`
+- `fn_context_name`
+- `fn_context_provider`
+- `fn_context_profile`
+- `fn_context_compartment_id`
+- `fn_context_api_url`
+- `fn_context_registry`
+- `fn_context_image_compartment_id`
+- `region`
+- `compartment_id`
+- `profile`
+- `app_id`
+- `app_name`
+- `apps_count`
+- `app_item_<n>`
+- `vcn_id`
+- `subnet_id`
+- `install_method`
+- `function_name`
+
+Hard rules:
+- Do not emit uppercase env-style keys.
+- Do not use `unknown` in the canonical contract.
+- Successful empty collections must be `empty`.
+- Failed CLI/runtime operations must be `error`.
+
+## Decision Table
+
+Use the following deterministic behavior after discovery:
+
+| Target | `found` | `missing` or `empty` | `error` |
+|---|---|---|---|
+| VCN / Subnet | Reuse existing app/network resources only when the user explicitly enters the advanced network branch | Stay out of the default deploy flow; collect inputs only after explicit advanced-branch approval | Stop and escalate (credentials/IAM/permissions) |
+| Functions App | If apps exist, require explicit reuse-vs-create decision before proceeding | Create after collecting app/subnet inputs with confirmation; support 1-3 subnet IDs plus optional shape and NSGs only on create | Stop and escalate |
+| Fn Context | Reuse active Oracle Fn context values unless explicit user-provided values intentionally override them through `configure_context.sh` | Create or fill missing values with confirmation | Stop and escalate |
+| OCI Session | Validate using `oracle.profile` from Fn context | Retry with `security_token` only after user approval, then stop if still invalid | Stop and escalate |
+| OCIR Login | Reuse only after a successful live probe, or report `cached` if credentials exist but were not confirmed | Prompt for username/token only if needed, then confirm login | Stop and escalate |
+| OCIR Repository / Compartment | Reuse existing settings when deploy succeeds | If push fails, surface repository auto-create and `oracle.image-compartment-id` possibilities explicitly | Stop and escalate |
+| Function Name | Reuse only when explicitly named by the user | Ask and confirm before scaffolding; do not infer from descriptive prose | Stop and ask again |
+
+## Advanced Network Guidance (OCI Functions)
+
+Only use this branch after explicit user approval to create or repair OCI networking for Functions.
+
+When creating network resources for OCI Functions:
+
+- Prefer a private-first topology by default as a security baseline, not as an OCI requirement.
+- Ensure subnets are regional and private for function execution.
+- Use service gateway routing to Oracle Services Network for OCIR access in private topology.
+- For public topology, use an internet gateway route (`0.0.0.0/0`).
+- Accept any egress rule shape that genuinely permits required OCI registry/service access; do not rewrite a broader valid rule into a narrower one unnecessarily.
+- Consider CIDR sizing using OCI Functions guidance before creating new subnets. Treat it as sizing guidance, not as an exact pass/fail requirement.
+
+See:
+- `references/functions-vcn-requirements.md`
+- `references/cidr-sizing.md`
+- `references/oci-functions-quickstart.md`
+
+## Runtime Matrix
+
+OCI Functions supports more runtimes than this skill handles automatically. This skill only automates:
+- `java`: requires `java`, `mvn`
+- `python`: requires `python3`
+- `node`: requires `node`, `npm`
+
+Use `scripts/preflight_check.sh` to validate dependency availability, Fn context completeness, OCI session state, and Docker registry auth state before scaffolding.
+
+## Deploy Guardrail
+
+- Before scaffold/deploy, run strict preflight checks.
+- `--skip-preflight` must still pass a confirmation gate with high-risk warning text.
+- In `--machine-readable` mode, emit lowercase machine-readable state lines only on stdout.
+- Emit `function_name_state` and `function_name` before scaffolding so inferred-name bugs are visible in logs.
+
+## Sources
+
+- [Functions QuickStart on Local Host](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionsquickstartlocalhost.htm)
+- [Creating Applications](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionscreatingapps.htm)
+- [OCI CLI Command Reference: oci fn application create](https://docs.oracle.com/en-us/iaas/tools/oci-cli/latest/oci_cli_docs/cmdref/fn/application/create.html)
+- [Creating the VCN and Subnets to Use with OCI Functions](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionscreatingvcn.htm)
+- [CIDR Blocks and OCI Functions](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionscidrblocks.htm)
+- [OCI CLI Command Reference: oci network vcn create](https://docs.oracle.com/en-us/iaas/tools/oci-cli/latest/oci_cli_docs/cmdref/network/vcn/create.html)
+- [Pushing Images Using the Docker CLI](https://docs.oracle.com/en-us/iaas/Content/Registry/Tasks/registrypushingimagesusingthedockercli.htm)

--- a/oci/functions/oci-functions-deploy/agents/openai.yaml
+++ b/oci/functions/oci-functions-deploy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "OCI Functions Deploy"
+  short_description: "Local Fn-context-guided OCI Functions deploy with optional advanced networking"
+  default_prompt: "Use $oci-functions-deploy to validate local prerequisites, resolve Fn context values, and deploy an OCI Function. Only enter networking setup if explicitly requested."

--- a/oci/functions/oci-functions-deploy/references/cidr-sizing.md
+++ b/oci/functions/oci-functions-deploy/references/cidr-sizing.md
@@ -1,0 +1,21 @@
+# CIDR Sizing Guidance for OCI Functions
+
+When creating new subnets for OCI Functions, account for projected scale.
+
+Reference heuristic from OCI Functions docs:
+
+`required_ips ~= 3 * subnet_count + total_concurrency_memory_gb / 14`
+
+Where:
+- `subnet_count`: number of subnets attached to the application
+- `total_concurrency_memory_gb`: total memory provisioned by concurrent executions
+
+Operational rule in this skill:
+- Prompt for expected concurrency and memory whenever a new subnet is about to be created, even if the VCN already exists.
+- Warn when the selected subnet CIDR is likely too small.
+- Treat the result as OCI sizing guidance rather than a hard pass/fail rule.
+- Continue only after explicit user confirmation.
+
+## Sources
+
+- [CIDR Blocks and OCI Functions](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionscidrblocks.htm)

--- a/oci/functions/oci-functions-deploy/references/functions-vcn-requirements.md
+++ b/oci/functions/oci-functions-deploy/references/functions-vcn-requirements.md
@@ -1,0 +1,37 @@
+# OCI Functions VCN and Subnet Requirements
+
+Use this reference only when the user explicitly opts into the advanced network branch or when existing OCI networking must be repaired with explicit approval.
+
+Primary references:
+- https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionscreatingvcn.htm
+- https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionscidrblocks.htm
+
+Key requirements to enforce in this skill:
+
+- Recommend private-first topology for Functions runtime subnets as a security default, not as a platform requirement.
+- Use regional subnet(s) for Functions applications.
+- For private subnet routing, create service gateway access to Oracle Services Network and route appropriately.
+- For public topology, create internet gateway with `0.0.0.0/0` routing.
+- Ensure security list or NSG egress rules required for registry access are in place. Accept broader valid rules when they already allow the required service access.
+- Do not silently convert an existing reuse path into network creation. Network changes stay behind the explicit advanced branch.
+
+Topology prompt guidance:
+- `private` (recommended): private subnet + service gateway route.
+- `public`: public subnet + internet gateway route.
+- `mixed`: support both, but use private subnet for Functions app by default.
+
+Creation order:
+1. VCN
+2. Gateways and route table(s)
+3. Subnet(s)
+4. Functions application referencing subnet OCID(s)
+
+Operational caveats:
+- OCI Functions applications can attach to `1-3` subnets.
+- Registry/subnet regional alignment should be checked deliberately when the registry and networking inputs come from different sources.
+
+## Sources
+
+- [Creating the VCN and Subnets to Use with OCI Functions](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionscreatingvcn.htm)
+- [CIDR Blocks and OCI Functions](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionscidrblocks.htm)
+- [Creating Applications](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionscreatingapps.htm)

--- a/oci/functions/oci-functions-deploy/references/oci-functions-quickstart.md
+++ b/oci/functions/oci-functions-deploy/references/oci-functions-quickstart.md
@@ -1,0 +1,38 @@
+# OCI Functions Local Quickstart Notes
+
+Use this as the operational baseline for local setup and deploy:
+
+1. Ensure local tools are installed (`fn`, `oci`, `docker`, runtime toolchain).
+2. Ensure Docker daemon is running.
+3. Configure or validate the active Oracle Fn context first.
+4. Ensure OCI CLI profile and auth are valid, including `security_token` retry only when needed.
+5. Validate Docker auth for the Fn registry and refresh login only if needed.
+6. Choose or create the Functions application.
+7. When creating an application, collect `1-3` subnet OCIDs and only add shape or NSGs when the user explicitly asks for them.
+8. Initialize function (`fn init --runtime <runtime>`).
+9. Stop if the target directory already exists, is not empty, and does not contain `func.yaml`.
+10. Deploy (`fn -v deploy --app <app-name>`).
+11. Run strict preflight before deploy unless explicitly user-approved to bypass.
+
+Fn context values typically include:
+- `oracle.compartment-id`
+- `oracle.profile`
+- `api-url` (`https://functions.<region>.oci.oraclecloud.com`)
+- `registry` (`<region-key>.ocir.io/<namespace>/<repo>`)
+- `oracle.image-compartment-id` (optional, only when the OCIR repository is in another compartment)
+
+Discovery-first expectation:
+- Detect and reuse existing values first.
+- Ask only for missing values.
+- Confirm every mutating command before execution.
+- On discovery auth/permission failures, stop and remediate before create/update actions.
+- Treat networking as an advanced opt-in branch rather than part of the default deploy flow.
+- Treat registry/subnet regional alignment as a manual check; do not guess the OCIR region key mapping.
+- If deploy fails while pushing to OCIR, consider repository auto-create policy and image-compartment settings before retrying.
+- This skill is for local macOS/Linux workflows. Windows is manual-only, and Cloud Shell is out of scope for this automation path.
+
+## Sources
+
+- [Functions QuickStart on Local Host](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionsquickstartlocalhost.htm)
+- [Creating Applications](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionscreatingapps.htm)
+- [Pushing Images Using the Docker CLI](https://docs.oracle.com/en-us/iaas/Content/Registry/Tasks/registrypushingimagesusingthedockercli.htm)

--- a/oci/functions/oci-functions-deploy/scripts/build_and_deploy.sh
+++ b/oci/functions/oci-functions-deploy/scripts/build_and_deploy.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIRM="$SCRIPT_DIR/confirm_gate.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/common.sh"
+
+RUNTIME=""
+APP=""
+FUNCTION_DIR=""
+FUNCTION_NAME=""
+FUNCTION_NAME_SOURCE=""
+SKIP_PREFLIGHT="false"
+MACHINE_READABLE="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --runtime)
+      RUNTIME="${2:-}"
+      shift 2
+      ;;
+    --app)
+      APP="${2:-}"
+      shift 2
+      ;;
+    --function-dir)
+      FUNCTION_DIR="${2:-}"
+      shift 2
+      ;;
+    --function-name)
+      FUNCTION_NAME="${2:-}"
+      shift 2
+      ;;
+    --function-name-source)
+      FUNCTION_NAME_SOURCE="${2:-}"
+      shift 2
+      ;;
+    --skip-preflight)
+      SKIP_PREFLIGHT="true"
+      shift
+      ;;
+    --machine-readable)
+      # Used by common.sh:is_machine_readable after argument parsing.
+      # shellcheck disable=SC2034
+      MACHINE_READABLE="true"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+prompt_if_missing() {
+  local current_value="$1"
+  local prompt="$2"
+  local out_var="$3"
+  local value="$current_value"
+
+  if [[ -z "$value" ]]; then
+    if ! is_interactive; then
+      echo "[ERROR] Missing required input: $prompt" >&2
+      echo "[HINT] Supply the missing flag when running non-interactively." >&2
+      exit 2
+    fi
+    read -r -p "$prompt" value
+  fi
+
+  printf -v "$out_var" "%s" "$value"
+}
+
+prompt_with_default() {
+  local current_value="$1"
+  local prompt="$2"
+  local default_value="$3"
+  local out_var="$4"
+  local value="$current_value"
+
+  if [[ -z "$value" ]]; then
+    if ! is_interactive; then
+      echo "[ERROR] Missing required input: $prompt" >&2
+      echo "[HINT] Supply the missing flag when running non-interactively." >&2
+      exit 2
+    fi
+    read -r -p "$prompt" value
+    if [[ -z "$value" ]]; then
+      value="$default_value"
+    fi
+  fi
+
+  printf -v "$out_var" "%s" "$value"
+}
+
+sanitize_dir_component() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/-{2,}/-/g'
+}
+
+resolve_function_name() {
+  if [[ -n "$FUNCTION_NAME" ]]; then
+    case "$FUNCTION_NAME_SOURCE" in
+      explicit|prompted)
+        FUNCTION_NAME_STATE="$FUNCTION_NAME_SOURCE"
+        ;;
+      "")
+        if ! is_interactive; then
+          emit_kv function_name_state missing
+          echo "[ERROR] Function name was provided without provenance." >&2
+          echo "[HINT] Pass --function-name-source explicit or --function-name-source prompted when supplying --function-name non-interactively." >&2
+          exit 2
+        fi
+        log_warn "Function name '$FUNCTION_NAME' was provided without explicit provenance."
+        read -r -p "Use this function name? [y/N]: " reply
+        case "$(normalize_reply "$reply")" in
+          y|yes)
+            FUNCTION_NAME_STATE="prompted"
+            ;;
+          *)
+            FUNCTION_NAME=""
+            prompt_if_missing "$FUNCTION_NAME" "Function name: " FUNCTION_NAME
+            FUNCTION_NAME_STATE="prompted"
+            ;;
+        esac
+        ;;
+      *)
+        emit_kv function_name_state missing
+        echo "[ERROR] Invalid --function-name-source '$FUNCTION_NAME_SOURCE'." >&2
+        echo "[HINT] Use --function-name-source explicit or --function-name-source prompted." >&2
+        exit 2
+        ;;
+    esac
+  else
+    prompt_if_missing "$FUNCTION_NAME" "Function name: " FUNCTION_NAME
+    FUNCTION_NAME_STATE="prompted"
+  fi
+}
+
+contains_fnproject_pull_error() {
+  local text="${1:-}"
+  grep -Eiq 'fnproject/.+|oraclefunctionsdevelopm/fnproject|pull access denied|manifest unknown|failed to resolve|error pulling image|not found' <<<"$text"
+}
+
+contains_ocir_repository_error() {
+  local text="${1:-}"
+  grep -Eiq 'repository .* not found|auto[- ]create.*disabled|create.*repository|not authorized.*repository|denied: requested access to the resource is denied|name unknown' <<<"$text"
+}
+
+emit_deploy_failure_hints() {
+  local text="${1:-}"
+  if contains_fnproject_pull_error "$text"; then
+    echo "[HINT] Function initialization or deploy failed while resolving base images. This skill does not rewrite fnproject image references automatically; inspect generated Dockerfile/func.yaml or choose a compatible template manually." >&2
+  fi
+  if contains_ocir_repository_error "$text"; then
+    echo "[HINT] Deploy failed while pushing to OCIR. If repository auto-create is disabled or the repository lives in another compartment, pre-create the repository or set oracle.image-compartment-id in the Fn context before retrying." >&2
+  fi
+}
+
+guard_function_dir() {
+  while true; do
+    if [[ ! -d "$FUNCTION_DIR" || -f "$FUNCTION_DIR/func.yaml" ]]; then
+      return 0
+    fi
+
+    if [[ -z "$(find "$FUNCTION_DIR" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]]; then
+      return 0
+    fi
+
+    if ! is_interactive; then
+      echo "[ERROR] Function directory '$FUNCTION_DIR' already exists, is not empty, and does not contain func.yaml." >&2
+      echo "[HINT] Choose an empty directory or an existing function directory before retrying." >&2
+      exit 2
+    fi
+
+    echo "[WARN] Function directory '$FUNCTION_DIR' exists, is not empty, and does not contain func.yaml." >&2
+    read -r -p "Enter a different function directory path, or leave blank to stop: " replacement_dir
+    if [[ -z "$replacement_dir" ]]; then
+      echo "[ERROR] Stopped before initializing inside a non-empty directory." >&2
+      exit 2
+    fi
+    FUNCTION_DIR="$replacement_dir"
+  done
+}
+
+run_confirmed_command_with_capture() {
+  local description="$1"
+  local display_text="$2"
+  local workdir="$3"
+  local stdin_env="$4"
+  local stdout_var="$5"
+  local stderr_var="$6"
+  local status_var="$7"
+  shift 7
+
+  local nonce
+  local stdout_file
+  local stderr_file
+  local status
+  local confirm_args=()
+  nonce="$(next_confirm_nonce)"
+  stdout_file="$(mktemp)"
+  stderr_file="$(mktemp)"
+  if is_machine_readable; then
+    confirm_args+=(--machine-readable)
+  fi
+
+  if [[ -n "$workdir" && -n "$stdin_env" ]]; then
+    if "$CONFIRM" --description "$description" --display "$display_text" --cwd "$workdir" --stdin-env "$stdin_env" "${confirm_args[@]}" --nonce "$nonce" -- "$@" >"$stdout_file" 2>"$stderr_file"; then
+      status=0
+    else
+      status=$?
+    fi
+  elif [[ -n "$workdir" ]]; then
+    if "$CONFIRM" --description "$description" --display "$display_text" --cwd "$workdir" "${confirm_args[@]}" --nonce "$nonce" -- "$@" >"$stdout_file" 2>"$stderr_file"; then
+      status=0
+    else
+      status=$?
+    fi
+  elif [[ -n "$stdin_env" ]]; then
+    if "$CONFIRM" --description "$description" --display "$display_text" --stdin-env "$stdin_env" "${confirm_args[@]}" --nonce "$nonce" -- "$@" >"$stdout_file" 2>"$stderr_file"; then
+      status=0
+    else
+      status=$?
+    fi
+  else
+    if "$CONFIRM" --description "$description" --display "$display_text" "${confirm_args[@]}" --nonce "$nonce" -- "$@" >"$stdout_file" 2>"$stderr_file"; then
+      status=0
+    else
+      status=$?
+    fi
+  fi
+
+  printf -v "$stdout_var" "%s" "$(cat "$stdout_file")"
+  printf -v "$stderr_var" "%s" "$(cat "$stderr_file")"
+  printf -v "$status_var" "%s" "$status"
+  rm -f "$stdout_file" "$stderr_file"
+}
+
+prompt_if_missing "$APP" "Functions application name: " APP
+resolve_function_name
+emit_kv function_name_state "$FUNCTION_NAME_STATE"
+emit_kv function_name "$FUNCTION_NAME"
+prompt_if_missing "$RUNTIME" "Function runtime (java/python/node): " RUNTIME
+
+suggested_function_dir="./$(sanitize_dir_component "$FUNCTION_NAME")"
+prompt_with_default "$FUNCTION_DIR" "Function directory path [$suggested_function_dir]: " "$suggested_function_dir" FUNCTION_DIR
+guard_function_dir
+
+case "$RUNTIME" in
+  java|python|node) ;;
+  *)
+    echo "Unsupported runtime: $RUNTIME" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$SKIP_PREFLIGHT" != "true" ]]; then
+  if is_machine_readable; then
+    "$SCRIPT_DIR/preflight_check.sh" --runtime "$RUNTIME" --strict --machine-readable
+  else
+    "$SCRIPT_DIR/preflight_check.sh" --runtime "$RUNTIME" --strict
+  fi
+  emit_kv deploy_preflight_state passed
+else
+  skip_stdout=""
+  skip_stderr=""
+  skip_status=""
+  run_confirmed_command_with_capture \
+    "Skip strict preflight checks before deploy (high risk)" \
+    "printf '[AUDIT] preflight skipped by explicit user-approved override\n'" \
+    "" \
+    "" \
+    skip_stdout \
+    skip_stderr \
+    skip_status \
+    printf '[AUDIT] preflight skipped for runtime %s by explicit user-approved override\n' "$RUNTIME"
+  [[ -n "$skip_stdout" ]] && printf '%s\n' "$skip_stdout"
+  [[ -n "$skip_stderr" ]] && printf '%s\n' "$skip_stderr" >&2
+  if [[ "$skip_status" -ne 0 ]]; then
+    exit "$skip_status"
+  fi
+  emit_kv deploy_preflight_state skipped
+fi
+
+if [[ ! -d "$FUNCTION_DIR" ]]; then
+  mkdir_stdout=""
+  mkdir_stderr=""
+  mkdir_status=""
+  run_confirmed_command_with_capture \
+    "Create function directory '$FUNCTION_DIR'" \
+    "mkdir -p '$FUNCTION_DIR'" \
+    "" \
+    "" \
+    mkdir_stdout \
+    mkdir_stderr \
+    mkdir_status \
+    mkdir -p "$FUNCTION_DIR"
+  [[ -n "$mkdir_stdout" ]] && printf '%s\n' "$mkdir_stdout"
+  [[ -n "$mkdir_stderr" ]] && printf '%s\n' "$mkdir_stderr" >&2
+  if [[ "$mkdir_status" -ne 0 ]]; then
+    exit "$mkdir_status"
+  fi
+fi
+
+if [[ ! -f "$FUNCTION_DIR/func.yaml" ]]; then
+  init_stdout=""
+  init_stderr=""
+  init_status=""
+  run_confirmed_command_with_capture \
+    "Initialize function '$FUNCTION_NAME' in '$FUNCTION_DIR'" \
+    "fn init --runtime '$RUNTIME' --name '$FUNCTION_NAME'" \
+    "$FUNCTION_DIR" \
+    "" \
+    init_stdout \
+    init_stderr \
+    init_status \
+    fn init --runtime "$RUNTIME" --name "$FUNCTION_NAME"
+  [[ -n "$init_stdout" ]] && printf '%s\n' "$init_stdout"
+  [[ -n "$init_stderr" ]] && printf '%s\n' "$init_stderr" >&2
+  if [[ "$init_status" -ne 0 ]]; then
+    emit_deploy_failure_hints "$init_stdout"$'\n'"$init_stderr"
+    exit "$init_status"
+  fi
+fi
+
+deploy_stdout=""
+deploy_stderr=""
+deploy_status=""
+run_confirmed_command_with_capture \
+  "Deploy function from '$FUNCTION_DIR' to app '$APP'" \
+  "fn -v deploy --app '$APP'" \
+  "$FUNCTION_DIR" \
+  "" \
+  deploy_stdout \
+  deploy_stderr \
+  deploy_status \
+  fn -v deploy --app "$APP"
+[[ -n "$deploy_stdout" ]] && printf '%s\n' "$deploy_stdout"
+[[ -n "$deploy_stderr" ]] && printf '%s\n' "$deploy_stderr" >&2
+
+if [[ "$deploy_status" -ne 0 ]]; then
+  emit_deploy_failure_hints "$deploy_stdout"$'\n'"$deploy_stderr"
+  exit "$deploy_status"
+fi
+
+emit_kv deploy_action deploy

--- a/oci/functions/oci-functions-deploy/scripts/common.sh
+++ b/oci/functions/oci-functions-deploy/scripts/common.sh
@@ -1,0 +1,458 @@
+#!/usr/bin/env bash
+
+is_interactive() {
+  [[ -t 0 ]]
+}
+
+is_machine_readable() {
+  [[ "${MACHINE_READABLE:-false}" == "true" ]]
+}
+
+human_out() {
+  if is_machine_readable; then
+    printf '%s\n' "$*" >&2
+  else
+    printf '%s\n' "$*"
+  fi
+}
+
+log_section() {
+  human_out "== $* =="
+}
+
+log_info() {
+  human_out "[INFO] $*"
+}
+
+log_warn() {
+  human_out "[WARN] $*"
+}
+
+log_ok() {
+  human_out "[OK] $*"
+}
+
+log_missing() {
+  human_out "[MISSING] $*"
+}
+
+log_skip() {
+  human_out "[SKIP] $*"
+}
+
+log_hint() {
+  human_out "[HINT] $*"
+}
+
+emit_kv() {
+  local key="${1:-}"
+  local value="${2:-}"
+  local LC_ALL=C
+
+  if [[ ! "$key" =~ ^[a-z][a-z0-9_]*$ ]]; then
+    printf '[ERROR] Refusing invalid machine-readable key.\n' >&2
+    return 1
+  fi
+  if [[ "$value" =~ [[:cntrl:]] ]]; then
+    printf '[ERROR] Refusing control characters in machine-readable value for key %s.\n' "$key" >&2
+    return 1
+  fi
+
+  printf '%s=%s\n' "$key" "$value"
+}
+
+normalize_reply() {
+  printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]'
+}
+
+read_confirm_nonce_bytes() {
+  od -An -N16 -tx1 /dev/urandom 2>/dev/null
+}
+
+next_confirm_nonce() {
+  local raw=""
+  local nonce=""
+
+  raw="$(read_confirm_nonce_bytes)" || {
+    printf '[ERROR] Secure confirmation nonce generation failed.\n' >&2
+    return 1
+  }
+  nonce="$(printf '%s' "$raw" | tr -d '[:space:]')"
+  if [[ ! "$nonce" =~ ^[0-9a-f]{32}$ ]]; then
+    printf '[ERROR] Secure confirmation nonce generation returned invalid data.\n' >&2
+    return 1
+  fi
+
+  printf '%s' "$nonce"
+}
+
+find_unique_resource_id_by_display_name() {
+  local payload="$1"
+  local display_name="$2"
+
+  printf '%s' "$payload" | python3 -c '
+import json
+import sys
+
+name = sys.argv[1]
+try:
+    payload = json.load(sys.stdin)
+except (TypeError, ValueError) as exc:
+    print(f"invalid OCI JSON: {exc}", file=sys.stderr)
+    raise SystemExit(2)
+
+items = payload.get("data", []) if isinstance(payload, dict) else []
+matches = [item for item in items if isinstance(item, dict) and item.get("display-name") == name]
+if len(matches) > 1:
+    print(f"ambiguous display name: {name!r} matched {len(matches)} resources", file=sys.stderr)
+    raise SystemExit(3)
+if not matches:
+    raise SystemExit(0)
+
+resource_id = matches[0].get("id")
+if not isinstance(resource_id, str) or not resource_id:
+    print("matched resource has no valid id", file=sys.stderr)
+    raise SystemExit(2)
+print(resource_id)
+' "$display_name"
+}
+
+extract_safe_display_names() {
+  local payload="$1"
+
+  printf '%s' "$payload" | python3 -c '
+import json
+import sys
+
+try:
+    payload = json.load(sys.stdin)
+except (TypeError, ValueError) as exc:
+    print(f"invalid OCI JSON: {exc}", file=sys.stderr)
+    raise SystemExit(2)
+
+items = payload.get("data", []) if isinstance(payload, dict) else []
+for item in items:
+    if not isinstance(item, dict):
+        continue
+    name = item.get("display-name")
+    if not isinstance(name, str):
+        continue
+    if any(ord(char) < 32 or ord(char) == 127 for char in name):
+        print("resource display name contains control characters", file=sys.stderr)
+        raise SystemExit(3)
+    print(name)
+'
+}
+
+run_oci_display_name_lookup() {
+  local __out_var="$1"
+  local __err_var="$2"
+  local display_name="$3"
+  shift 3
+
+  local payload=""
+  local command_error=""
+  local matched_id=""
+  local lookup_status=0
+
+  if ! run_oci_capture payload command_error "$@" --output json; then
+    printf -v "$__out_var" '%s' ""
+    printf -v "$__err_var" '%s' "$command_error"
+    return 1
+  fi
+
+  matched_id="$(find_unique_resource_id_by_display_name "$payload" "$display_name")" || lookup_status=$?
+  if [[ "$lookup_status" -ne 0 ]]; then
+    printf -v "$__out_var" '%s' ""
+    printf -v "$__err_var" '%s' "display-name lookup failed with status $lookup_status"
+    return "$lookup_status"
+  fi
+
+  printf -v "$__out_var" '%s' "$matched_id"
+  printf -v "$__err_var" '%s' ""
+}
+
+run_oci_display_name_list() {
+  local __out_var="$1"
+  local __err_var="$2"
+  shift 2
+
+  local payload=""
+  local command_error=""
+  local names=""
+  local parse_status=0
+
+  if ! run_oci_capture payload command_error "$@" --output json; then
+    printf -v "$__out_var" '%s' ""
+    printf -v "$__err_var" '%s' "$command_error"
+    return 1
+  fi
+
+  names="$(extract_safe_display_names "$payload")" || parse_status=$?
+  if [[ "$parse_status" -ne 0 ]]; then
+    printf -v "$__out_var" '%s' ""
+    printf -v "$__err_var" '%s' "display-name list parsing failed with status $parse_status"
+    return "$parse_status"
+  fi
+
+  printf -v "$__out_var" '%s' "$names"
+  printf -v "$__err_var" '%s' ""
+}
+
+resolve_latest_fn_linux_release() {
+  local __version_var="$1"
+  local __url_var="$2"
+  local __digest_var="$3"
+  local metadata=""
+  local parsed=""
+  local resolved_version=""
+  local resolved_asset_url=""
+  local resolved_digest=""
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    printf '[ERROR] python3 is required to validate Fn CLI release metadata.\n' >&2
+    return 1
+  fi
+
+  metadata="$(curl \
+    --proto '=https' \
+    --proto-redir '=https' \
+    --tlsv1.2 \
+    --fail \
+    --silent \
+    --show-error \
+    --location \
+    --connect-timeout 10 \
+    --max-time 30 \
+    --retry 2 \
+    --header 'Accept: application/vnd.github+json' \
+    --header 'X-GitHub-Api-Version: 2022-11-28' \
+    'https://api.github.com/repos/fnproject/cli/releases/latest')" || {
+      printf '[ERROR] Unable to resolve the latest Fn CLI release from GitHub.\n' >&2
+      return 1
+    }
+
+  parsed="$(printf '%s' "$metadata" | python3 -c '
+import json
+import re
+import sys
+
+try:
+    release = json.load(sys.stdin)
+except (TypeError, ValueError) as exc:
+    print(f"invalid GitHub release metadata: {exc}", file=sys.stderr)
+    raise SystemExit(2)
+
+tag = release.get("tag_name")
+if release.get("draft") is not False or release.get("prerelease") is not False:
+    print("latest Fn release is draft or prerelease", file=sys.stderr)
+    raise SystemExit(3)
+if not isinstance(tag, str) or not re.fullmatch(r"v?[0-9]+\.[0-9]+\.[0-9]+", tag):
+    print("latest Fn release has an invalid semantic version tag", file=sys.stderr)
+    raise SystemExit(3)
+
+assets = [asset for asset in release.get("assets", []) if isinstance(asset, dict) and asset.get("name") == "fn_linux"]
+if len(assets) != 1:
+    print("latest Fn release must contain exactly one fn_linux asset", file=sys.stderr)
+    raise SystemExit(3)
+
+asset = assets[0]
+url = asset.get("browser_download_url")
+digest = asset.get("digest")
+expected_url = f"https://github.com/fnproject/cli/releases/download/{tag}/fn_linux"
+if asset.get("state") != "uploaded" or not isinstance(asset.get("size"), int) or asset.get("size", 0) <= 0:
+    print("latest Fn Linux asset is not fully uploaded", file=sys.stderr)
+    raise SystemExit(3)
+if url != expected_url:
+    print("latest Fn Linux asset URL is not canonical", file=sys.stderr)
+    raise SystemExit(3)
+if not isinstance(digest, str) or not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+    print("latest Fn Linux asset has no valid SHA-256 digest", file=sys.stderr)
+    raise SystemExit(3)
+
+print(tag, url, digest, sep="\t")
+')" || {
+    printf '[ERROR] Latest Fn CLI release metadata failed validation.\n' >&2
+    return 1
+  }
+
+  IFS=$'\t' read -r resolved_version resolved_asset_url resolved_digest <<<"$parsed"
+  if [[ -z "$resolved_version" || -z "$resolved_asset_url" || -z "$resolved_digest" ]]; then
+    printf '[ERROR] Latest Fn CLI release metadata was incomplete.\n' >&2
+    return 1
+  fi
+
+  printf -v "$__version_var" '%s' "$resolved_version"
+  printf -v "$__url_var" '%s' "$resolved_asset_url"
+  printf -v "$__digest_var" '%s' "$resolved_digest"
+}
+
+resolve_preferred_value() {
+  local candidate=""
+  for candidate in "$@"; do
+    if [[ -n "$candidate" ]]; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+extract_region_from_api_url() {
+  local url="$1"
+  sed -n 's#https://functions\.\([^.]*-[^.]*-[0-9]*\)\.oci\.oraclecloud\.com#\1#p' <<<"$url"
+}
+
+classify_oci_error_reason() {
+  local text="${1:-}"
+  if grep -Eiq 'NotAuthenticated|NotAuthorized|NotAuthorizedOrNotFound|401|403|auth|permission|insufficient|profile.*not found|user.*missing' <<<"$text"; then
+    printf 'auth_or_permission'
+    return 0
+  fi
+  if grep -Eiq 'timeout|timed out|temporary failure|connection reset|connection refused|name or service not known|unable to resolve|network|transport|TLS|SSL|certificate|proxy|host unreachable' <<<"$text"; then
+    printf 'network_or_transport'
+    return 0
+  fi
+  printf 'runtime_or_cli'
+}
+
+run_oci_capture() {
+  local __out_var="$1"
+  local __err_var="$2"
+  shift 2
+
+  local out_file
+  local err_file
+  out_file="$(mktemp)"
+  err_file="$(mktemp)"
+
+  if oci "$@" >"$out_file" 2>"$err_file"; then
+    printf -v "$__out_var" "%s" "$(cat "$out_file")"
+    printf -v "$__err_var" "%s" "$(cat "$err_file")"
+    rm -f "$out_file" "$err_file"
+    return 0
+  fi
+
+  printf -v "$__out_var" "%s" "$(cat "$out_file")"
+  printf -v "$__err_var" "%s" "$(cat "$err_file")"
+  rm -f "$out_file" "$err_file"
+  return 1
+}
+
+docker_registry_auth_probe() {
+  local host="$1"
+  local cfg="$HOME/.docker/config.json"
+
+  if [[ ! -f "$cfg" ]]; then
+    printf 'missing'
+    return 0
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    printf 'error'
+    return 0
+  fi
+
+  python3 - <<'PY' "$cfg" "$host"
+import base64
+import json
+import shutil
+import socket
+import ssl
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+cfg_path, host = sys.argv[1], sys.argv[2]
+
+def emit(value: str) -> None:
+    print(value)
+    raise SystemExit(0)
+
+try:
+    with open(cfg_path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+except Exception:
+    emit("error")
+
+auths = data.get("auths") or {}
+cred_helpers = data.get("credHelpers") or {}
+creds_store = data.get("credsStore")
+candidates = [host, f"https://{host}", f"http://{host}"]
+
+entry = None
+for candidate in candidates:
+    if candidate in auths:
+        entry = auths[candidate]
+        break
+
+helper_name = None
+for candidate in candidates:
+    if candidate in cred_helpers:
+        helper_name = cred_helpers[candidate]
+        break
+if helper_name is None and creds_store:
+    helper_name = creds_store
+
+resolved_username = None
+resolved_secret = None
+
+if entry and entry.get("auth"):
+    try:
+        decoded = base64.b64decode(entry["auth"]).decode("utf-8")
+        if ":" in decoded:
+            resolved_username, resolved_secret = decoded.split(":", 1)
+    except Exception:
+        emit("error")
+
+if helper_name:
+    helper_bin = shutil.which(f"docker-credential-{helper_name}")
+    if helper_bin is None:
+        emit("error")
+    try:
+        proc = subprocess.run(
+            [helper_bin, "get"],
+            input=host.encode("utf-8"),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except Exception:
+        emit("error")
+
+    if proc.returncode == 0:
+        try:
+            payload = json.loads(proc.stdout.decode("utf-8"))
+            username = payload.get("Username")
+            secret = payload.get("Secret")
+            if username and secret:
+                resolved_username = username
+                resolved_secret = secret
+        except Exception:
+            emit("error")
+    elif not entry:
+        emit("cached")
+
+if not resolved_secret:
+    if entry or helper_name:
+      emit("cached")
+    emit("missing")
+
+auth_value = base64.b64encode(f"{resolved_username}:{resolved_secret}".encode("utf-8")).decode("ascii")
+request = urllib.request.Request(f"https://{host}/v2/")
+request.add_header("Authorization", f"Basic {auth_value}")
+
+try:
+    with urllib.request.urlopen(request, timeout=5) as response:
+        code = getattr(response, "status", response.getcode())
+        if 200 <= int(code) < 300:
+            emit("valid")
+        emit("cached")
+except urllib.error.HTTPError as exc:
+    if exc.code in (401, 403):
+        emit("cached")
+    emit("cached")
+except (urllib.error.URLError, socket.timeout, ssl.SSLError, OSError):
+    emit("cached")
+PY
+}

--- a/oci/functions/oci-functions-deploy/scripts/configure_context.sh
+++ b/oci/functions/oci-functions-deploy/scripts/configure_context.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIRM="$SCRIPT_DIR/confirm_gate.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/common.sh"
+
+CONTEXT_NAME=""
+REGION=""
+API_URL=""
+COMPARTMENT_ID=""
+PROFILE=""
+REGISTRY=""
+IMAGE_COMPARTMENT_ID=""
+OCIR_USERNAME=""
+OCIR_AUTH_TOKEN=""
+MACHINE_READABLE="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --context-name)
+      CONTEXT_NAME="${2:-}"
+      shift 2
+      ;;
+    --region)
+      REGION="${2:-}"
+      shift 2
+      ;;
+    --api-url)
+      API_URL="${2:-}"
+      shift 2
+      ;;
+    --compartment)
+      COMPARTMENT_ID="${2:-}"
+      shift 2
+      ;;
+    --profile)
+      PROFILE="${2:-}"
+      shift 2
+      ;;
+    --registry)
+      REGISTRY="${2:-}"
+      shift 2
+      ;;
+    --image-compartment-id)
+      IMAGE_COMPARTMENT_ID="${2:-}"
+      shift 2
+      ;;
+    --ocir-username)
+      OCIR_USERNAME="${2:-}"
+      shift 2
+      ;;
+    --ocir-auth-token)
+      OCIR_AUTH_TOKEN="${2:-}"
+      shift 2
+      ;;
+    --machine-readable)
+      # Used by common.sh:is_machine_readable after argument parsing.
+      # shellcheck disable=SC2034
+      MACHINE_READABLE="true"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+run_confirmed() {
+  local description="$1"
+  local display="$2"
+  local stdin_env="$3"
+  shift 3
+
+  local nonce
+  local confirm_args=()
+  nonce="$(next_confirm_nonce)"
+  if is_machine_readable; then
+    confirm_args+=(--machine-readable)
+  fi
+  if [[ -n "$stdin_env" ]]; then
+    "$CONFIRM" --description "$description" --display "$display" "${confirm_args[@]}" --stdin-env "$stdin_env" --nonce "$nonce" -- "$@"
+  else
+    "$CONFIRM" --description "$description" --display "$display" "${confirm_args[@]}" --nonce "$nonce" -- "$@"
+  fi
+}
+
+prompt_if_missing() {
+  local current_value="$1"
+  local prompt="$2"
+  local out_var="$3"
+  local value="$current_value"
+
+  if [[ -z "$value" ]]; then
+    if ! is_interactive; then
+      echo "[ERROR] Missing required input: $prompt" >&2
+      echo "[HINT] Supply the corresponding flag when running non-interactively." >&2
+      exit 2
+    fi
+    read -r -p "$prompt" value
+  fi
+
+  printf -v "$out_var" "%s" "$value"
+}
+
+parse_fn_context() {
+  CURRENT_CONTEXT_NAME=""
+  CURRENT_PROVIDER=""
+  CURRENT_PROFILE=""
+  CURRENT_COMPARTMENT_ID=""
+  CURRENT_API_URL=""
+  CURRENT_REGISTRY=""
+  CURRENT_IMAGE_COMPARTMENT_ID=""
+
+  local context_out
+  context_out="$(fn inspect context 2>/dev/null || true)"
+  [[ -n "$context_out" ]] || return 1
+
+  CURRENT_CONTEXT_NAME="$(awk -F': ' '/^Current context:/ {print $2; exit}' <<<"$context_out" || true)"
+  CURRENT_PROVIDER="$(awk -F': ' '/^provider:/ {print $2; exit}' <<<"$context_out" || true)"
+  CURRENT_PROFILE="$(awk -F': ' '/^oracle.profile:/ {print $2; exit}' <<<"$context_out" || true)"
+  CURRENT_COMPARTMENT_ID="$(awk -F': ' '/^oracle.compartment-id:/ {print $2; exit}' <<<"$context_out" || true)"
+  CURRENT_API_URL="$(awk -F': ' '/^api-url:/ {print $2; exit}' <<<"$context_out" || true)"
+  CURRENT_REGISTRY="$(awk -F': ' '/^registry:/ {print $2; exit}' <<<"$context_out" || true)"
+  CURRENT_IMAGE_COMPARTMENT_ID="$(awk -F': ' '/^oracle.image-compartment-id:/ {print $2; exit}' <<<"$context_out" || true)"
+  return 0
+}
+
+build_api_url() {
+  local region="$1"
+  printf 'https://functions.%s.oci.oraclecloud.com' "$region"
+}
+
+CURRENT_CONTEXT_NAME=""
+CURRENT_PROVIDER=""
+CURRENT_PROFILE=""
+CURRENT_COMPARTMENT_ID=""
+CURRENT_API_URL=""
+CURRENT_REGISTRY=""
+CURRENT_IMAGE_COMPARTMENT_ID=""
+parse_fn_context || true
+
+if [[ -z "$CONTEXT_NAME" ]]; then
+  CONTEXT_NAME="$CURRENT_CONTEXT_NAME"
+fi
+if [[ -z "$PROFILE" ]]; then
+  PROFILE="$CURRENT_PROFILE"
+fi
+if [[ -z "$COMPARTMENT_ID" ]]; then
+  COMPARTMENT_ID="$CURRENT_COMPARTMENT_ID"
+fi
+if [[ -z "$API_URL" ]]; then
+  API_URL="$CURRENT_API_URL"
+fi
+if [[ -z "$REGISTRY" ]]; then
+  REGISTRY="$CURRENT_REGISTRY"
+fi
+if [[ -z "$IMAGE_COMPARTMENT_ID" ]]; then
+  IMAGE_COMPARTMENT_ID="$CURRENT_IMAGE_COMPARTMENT_ID"
+fi
+if [[ -z "$REGION" && -n "$API_URL" ]]; then
+  REGION="$(extract_region_from_api_url "$API_URL")"
+fi
+if [[ -z "$API_URL" && -n "$REGION" ]]; then
+  API_URL="$(build_api_url "$REGION")"
+fi
+
+needs_oracle_context="no"
+if [[ -z "$CURRENT_CONTEXT_NAME" || -z "$CURRENT_PROVIDER" || "$CURRENT_PROVIDER" != "oracle" ]]; then
+  needs_oracle_context="yes"
+fi
+
+if [[ "$needs_oracle_context" == "yes" ]]; then
+  if [[ -n "$CURRENT_CONTEXT_NAME" && "$CURRENT_PROVIDER" != "oracle" && "$CONTEXT_NAME" == "$CURRENT_CONTEXT_NAME" ]]; then
+    CONTEXT_NAME="${CURRENT_CONTEXT_NAME}-oracle"
+  fi
+  prompt_if_missing "$CONTEXT_NAME" "Fn context name to create/use: " CONTEXT_NAME
+  prompt_if_missing "$REGION" "OCI region (for example eu-frankfurt-1): " REGION
+  if [[ -z "$API_URL" ]]; then
+    API_URL="$(build_api_url "$REGION")"
+  fi
+  prompt_if_missing "$REGISTRY" "OCI registry (for example fra.ocir.io/namespace/repo): " REGISTRY
+
+  run_confirmed "Create Oracle Fn context '$CONTEXT_NAME'" "fn create context --provider oracle --api-url '$API_URL' --registry '$REGISTRY' '$CONTEXT_NAME'" "" fn create context --provider oracle --api-url "$API_URL" --registry "$REGISTRY" "$CONTEXT_NAME"
+  run_confirmed "Use Fn context '$CONTEXT_NAME'" "fn use context '$CONTEXT_NAME'" "" fn use context "$CONTEXT_NAME"
+
+  CURRENT_CONTEXT_NAME="$CONTEXT_NAME"
+  CURRENT_PROVIDER="oracle"
+  CURRENT_API_URL="$API_URL"
+  CURRENT_REGISTRY="$REGISTRY"
+fi
+
+prompt_if_missing "$PROFILE" "OCI CLI profile name for Fn context: " PROFILE
+prompt_if_missing "$COMPARTMENT_ID" "Compartment OCID for Functions app lookup/deploy: " COMPARTMENT_ID
+if [[ -z "$REGION" && -n "$CURRENT_API_URL" ]]; then
+  REGION="$(extract_region_from_api_url "$CURRENT_API_URL")"
+fi
+if [[ -z "$REGION" ]]; then
+  prompt_if_missing "$REGION" "OCI region (for example eu-frankfurt-1): " REGION
+fi
+if [[ -z "$API_URL" ]]; then
+  API_URL="$(build_api_url "$REGION")"
+fi
+prompt_if_missing "$REGISTRY" "OCI registry (for example fra.ocir.io/namespace/repo): " REGISTRY
+
+if [[ "$CURRENT_COMPARTMENT_ID" != "$COMPARTMENT_ID" ]]; then
+  run_confirmed "Set Fn context oracle.compartment-id" "fn update context oracle.compartment-id '$COMPARTMENT_ID'" "" fn update context oracle.compartment-id "$COMPARTMENT_ID"
+fi
+if [[ "$CURRENT_PROFILE" != "$PROFILE" ]]; then
+  run_confirmed "Set Fn context oracle.profile" "fn update context oracle.profile '$PROFILE'" "" fn update context oracle.profile "$PROFILE"
+fi
+if [[ "$CURRENT_API_URL" != "$API_URL" ]]; then
+  run_confirmed "Set Fn context api-url" "fn update context api-url '$API_URL'" "" fn update context api-url "$API_URL"
+fi
+if [[ "$CURRENT_REGISTRY" != "$REGISTRY" ]]; then
+  run_confirmed "Set Fn context registry" "fn update context registry '$REGISTRY'" "" fn update context registry "$REGISTRY"
+fi
+if [[ -n "$IMAGE_COMPARTMENT_ID" && "$CURRENT_IMAGE_COMPARTMENT_ID" != "$IMAGE_COMPARTMENT_ID" ]]; then
+  run_confirmed "Set Fn context oracle.image-compartment-id" "fn update context oracle.image-compartment-id '$IMAGE_COMPARTMENT_ID'" "" fn update context oracle.image-compartment-id "$IMAGE_COMPARTMENT_ID"
+fi
+
+emit_kv fn_context_state found
+emit_kv fn_context_name "${CURRENT_CONTEXT_NAME:-$CONTEXT_NAME}"
+emit_kv fn_context_profile "$PROFILE"
+emit_kv fn_context_compartment_id "$COMPARTMENT_ID"
+emit_kv fn_context_api_url "$API_URL"
+emit_kv fn_context_registry "$REGISTRY"
+emit_kv fn_context_image_compartment_id "${IMAGE_COMPARTMENT_ID:-}"
+
+registry_host="${REGISTRY%%/*}"
+emit_kv docker_registry_host "$registry_host"
+registry_auth_state="$(docker_registry_auth_probe "$registry_host")"
+emit_kv docker_registry_auth_probe_state "$registry_auth_state"
+
+if [[ "${FORCE_OCIR_LOGIN:-}" != "yes" ]]; then
+  case "$registry_auth_state" in
+    valid)
+      log_info "Existing docker auth for '$registry_host' was validated live."
+      emit_kv docker_registry_auth_state valid
+      emit_kv ocir_auth_state valid
+      exit 0
+      ;;
+    cached)
+      if [[ -z "$OCIR_USERNAME" ]]; then
+        log_info "Cached docker auth exists for '$registry_host', but live validation did not confirm it."
+        emit_kv docker_registry_auth_state cached
+        emit_kv ocir_auth_state cached
+        exit 0
+      fi
+      ;;
+    error)
+      emit_kv docker_registry_auth_state error
+      emit_kv docker_registry_auth_error_reason runtime_or_cli
+      emit_kv ocir_auth_state error
+      exit 4
+      ;;
+    *)
+      ;;
+  esac
+fi
+
+if [[ -n "$OCIR_USERNAME" ]]; then
+  if [[ -z "$OCIR_AUTH_TOKEN" ]]; then
+    if ! is_interactive; then
+      echo "[ERROR] OCIR auth token is required in non-interactive mode when login is requested." >&2
+      exit 2
+    fi
+    read -r -s -p "OCIR auth token for $OCIR_USERNAME: " OCIR_AUTH_TOKEN
+    printf '\n' >&2
+  fi
+  export OCIR_AUTH_TOKEN
+  run_confirmed "Login to OCIR registry '$registry_host'" "printf '[REDACTED]' | docker login '$registry_host' -u '$OCIR_USERNAME' --password-stdin" "OCIR_AUTH_TOKEN" docker login "$registry_host" -u "$OCIR_USERNAME" --password-stdin
+  emit_kv docker_registry_auth_state valid
+  emit_kv ocir_auth_state valid
+else
+  log_info "Docker is not logged into '$registry_host'. Prompt for OCIR credentials before deploy."
+  emit_kv docker_registry_auth_state missing
+  emit_kv ocir_auth_state missing
+fi

--- a/oci/functions/oci-functions-deploy/scripts/confirm_gate.sh
+++ b/oci/functions/oci-functions-deploy/scripts/confirm_gate.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/common.sh"
+
+DESCRIPTION=""
+DISPLAY=""
+WORKDIR=""
+STDIN_ENV=""
+NONCE=""
+MACHINE_READABLE="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --description)
+      DESCRIPTION="${2:-}"
+      shift 2
+      ;;
+    --display)
+      DISPLAY="${2:-}"
+      shift 2
+      ;;
+    --cwd)
+      WORKDIR="${2:-}"
+      shift 2
+      ;;
+    --stdin-env)
+      STDIN_ENV="${2:-}"
+      shift 2
+      ;;
+    --nonce)
+      NONCE="${2:-}"
+      shift 2
+      ;;
+    --machine-readable)
+      # Used by common.sh:is_machine_readable after argument parsing.
+      # shellcheck disable=SC2034
+      MACHINE_READABLE="true"
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      echo "Usage: $0 --description <text> [--display <text>] [--cwd <path>] [--stdin-env <env>] [--nonce <nonce>] [--machine-readable] -- <argv...>" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$DESCRIPTION" || $# -eq 0 ]]; then
+  echo "Usage: $0 --description <text> [--display <text>] [--cwd <path>] [--stdin-env <env>] [--nonce <nonce>] [--machine-readable] -- <argv...>" >&2
+  exit 1
+fi
+
+ARGV=("$@")
+DISPLAY_WAS_PROVIDED="true"
+if [[ -z "$DISPLAY" ]]; then
+  DISPLAY="$(printf '%q ' "${ARGV[@]}")"
+  DISPLAY="${DISPLAY% }"
+  DISPLAY_WAS_PROVIDED="false"
+fi
+
+printf -v SAFE_DESCRIPTION '%q' "$DESCRIPTION"
+if [[ "$DISPLAY_WAS_PROVIDED" == "true" ]]; then
+  printf -v SAFE_DISPLAY '%q' "$DISPLAY"
+else
+  SAFE_DISPLAY="$DISPLAY"
+fi
+
+if is_interactive && [[ -z "$NONCE" ]]; then
+  NONCE="$(next_confirm_nonce)"
+fi
+
+if ! is_interactive && [[ -z "$NONCE" ]]; then
+  emit_kv confirm_state error
+  emit_kv confirm_error_reason missing_nonce
+  echo "[ERROR] Non-interactive confirmation requires --nonce." >&2
+  exit 2
+fi
+
+if [[ ! "$NONCE" =~ ^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$ ]]; then
+  emit_kv confirm_state error
+  emit_kv confirm_error_reason invalid_nonce
+  echo "[ERROR] Confirmation nonce contains unsupported characters." >&2
+  exit 2
+fi
+
+argv_payload="$(printf '%q\n' "${ARGV[@]}")"
+payload="$DESCRIPTION"$'\n'"$DISPLAY"$'\n'"$WORKDIR"$'\n'"$STDIN_ENV"$'\n'"$NONCE"$'\n'"$argv_payload"
+if command -v shasum >/dev/null 2>&1; then
+  ACTION_ID="$(printf '%s' "$payload" | shasum -a 256 | awk '{print $1}')"
+elif command -v sha256sum >/dev/null 2>&1; then
+  ACTION_ID="$(printf '%s' "$payload" | sha256sum | awk '{print $1}')"
+else
+  emit_kv confirm_state error
+  emit_kv confirm_error_reason missing_sha256_tool
+  echo "[ERROR] shasum or sha256sum is required for confirmation action IDs." >&2
+  exit 2
+fi
+
+ledger_root="${TMPDIR:-/tmp}/codex-confirm-used"
+ledger_dir="$ledger_root/${NONCE:-interactive}"
+ledger_file="$ledger_dir/$ACTION_ID"
+
+if [[ -f "$ledger_file" ]]; then
+  emit_kv confirm_state error
+  emit_kv confirm_action_id "$ACTION_ID"
+  emit_kv confirm_nonce "${NONCE:-interactive}"
+  emit_kv confirm_error_reason already_consumed
+  echo "[ERROR] This approval has already been used." >&2
+  exit 4
+fi
+
+approved="no"
+if is_interactive; then
+  human_out ""
+  human_out "[ACTION_ID] $ACTION_ID"
+  human_out "[CONFIRM] $SAFE_DESCRIPTION"
+  human_out "[COMMAND] $SAFE_DISPLAY"
+  read -r -p "Proceed? [y/N]: " reply
+  case "$(normalize_reply "$reply")" in
+    y|yes|true|approved|approve)
+      approved="yes"
+      ;;
+  esac
+else
+  human_out ""
+  human_out "[ACTION_ID] $ACTION_ID"
+  human_out "[CONFIRM-NONINTERACTIVE] $SAFE_DESCRIPTION"
+  human_out "[COMMAND] $SAFE_DISPLAY"
+  if [[ "$(normalize_reply "${CONFIRM_RESPONSE:-}")" == "yes" && "${CONFIRM_ACTION_ID:-}" == "$ACTION_ID" && "${CONFIRM_NONCE:-}" == "$NONCE" ]]; then
+    approved="yes"
+  elif [[ "$(normalize_reply "${CONFIRM_RESPONSE:-}")" =~ ^(y|yes|true|approved|approve)$ && "${CONFIRM_ACTION_ID:-}" == "$ACTION_ID" && "${CONFIRM_NONCE:-}" == "$NONCE" ]]; then
+    approved="yes"
+  fi
+fi
+
+if [[ "$approved" != "yes" ]]; then
+  emit_kv confirm_state skipped
+  emit_kv confirm_action_id "$ACTION_ID"
+  emit_kv confirm_nonce "${NONCE:-interactive}"
+  log_skip "Command not approved by user."
+  log_hint "Set CONFIRM_RESPONSE=yes, CONFIRM_ACTION_ID=$ACTION_ID, and CONFIRM_NONCE=${NONCE:-interactive} after explicit user approval."
+  exit 3
+fi
+
+mkdir -p "$ledger_dir"
+
+run_command() {
+  if [[ -n "$WORKDIR" ]]; then
+    cd "$WORKDIR"
+  fi
+
+  if [[ -n "$STDIN_ENV" ]]; then
+    local stdin_value="${!STDIN_ENV:-}"
+    if is_machine_readable; then
+      printf '%s' "$stdin_value" | "${ARGV[@]}" >&2
+    else
+      printf '%s' "$stdin_value" | "${ARGV[@]}"
+    fi
+  else
+    if is_machine_readable; then
+      "${ARGV[@]}" >&2
+    else
+      "${ARGV[@]}"
+    fi
+  fi
+}
+
+if run_command; then
+  : >"$ledger_file"
+  emit_kv confirm_state approved
+  emit_kv confirm_action_id "$ACTION_ID"
+  emit_kv confirm_nonce "${NONCE:-interactive}"
+  exit 0
+fi
+
+emit_kv confirm_state error
+emit_kv confirm_action_id "$ACTION_ID"
+emit_kv confirm_nonce "${NONCE:-interactive}"
+emit_kv confirm_error_reason command_failed
+exit 5

--- a/oci/functions/oci-functions-deploy/scripts/discover_state.sh
+++ b/oci/functions/oci-functions-deploy/scripts/discover_state.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/common.sh"
+
+REGION=""
+COMPARTMENT_ID=""
+APP_NAME=""
+PROFILE=""
+DISCOVERY_ERROR=0
+MACHINE_READABLE="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --region)
+      REGION="${2:-}"
+      shift 2
+      ;;
+    --compartment-id)
+      COMPARTMENT_ID="${2:-}"
+      shift 2
+      ;;
+    --app-name)
+      APP_NAME="${2:-}"
+      shift 2
+      ;;
+    --profile)
+      PROFILE="${2:-}"
+      shift 2
+      ;;
+    --machine-readable)
+      # Used by common.sh:is_machine_readable after argument parsing.
+      # shellcheck disable=SC2034
+      MACHINE_READABLE="true"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+parse_fn_context() {
+  FN_CONTEXT_NAME=""
+  FN_CONTEXT_PROVIDER=""
+  FN_CONTEXT_PROFILE=""
+  FN_CONTEXT_COMPARTMENT_ID=""
+  FN_CONTEXT_API_URL=""
+  FN_CONTEXT_REGISTRY=""
+  FN_CONTEXT_IMAGE_COMPARTMENT_ID=""
+
+  local context_out
+  context_out="$(fn inspect context 2>/dev/null || fn list context 2>/dev/null || true)"
+  [[ -n "$context_out" ]] || return 1
+
+  FN_CONTEXT_NAME="$(awk -F': ' '/^Current context:/ {print $2; exit}' <<<"$context_out" || true)"
+  FN_CONTEXT_PROVIDER="$(awk -F': ' '/^provider:/ {print $2; exit}' <<<"$context_out" || true)"
+  FN_CONTEXT_PROFILE="$(awk -F': ' '/^oracle.profile:/ {print $2; exit}' <<<"$context_out" || true)"
+  FN_CONTEXT_COMPARTMENT_ID="$(awk -F': ' '/^oracle.compartment-id:/ {print $2; exit}' <<<"$context_out" || true)"
+  FN_CONTEXT_API_URL="$(awk -F': ' '/^api-url:/ {print $2; exit}' <<<"$context_out" || true)"
+  FN_CONTEXT_REGISTRY="$(awk -F': ' '/^registry:/ {print $2; exit}' <<<"$context_out" || true)"
+  FN_CONTEXT_IMAGE_COMPARTMENT_ID="$(awk -F': ' '/^oracle.image-compartment-id:/ {print $2; exit}' <<<"$context_out" || true)"
+  return 0
+}
+
+log_section "Fn context discovery"
+FN_CONTEXT_NAME=""
+FN_CONTEXT_PROVIDER=""
+FN_CONTEXT_PROFILE=""
+FN_CONTEXT_COMPARTMENT_ID=""
+FN_CONTEXT_API_URL=""
+FN_CONTEXT_REGISTRY=""
+FN_CONTEXT_IMAGE_COMPARTMENT_ID=""
+if command -v fn >/dev/null 2>&1 && parse_fn_context; then
+  missing_fn_keys=()
+  [[ -n "$FN_CONTEXT_COMPARTMENT_ID" ]] || missing_fn_keys+=("oracle.compartment-id")
+  [[ -n "$FN_CONTEXT_PROFILE" ]] || missing_fn_keys+=("oracle.profile")
+  [[ -n "$FN_CONTEXT_API_URL" ]] || missing_fn_keys+=("api-url")
+  [[ -n "$FN_CONTEXT_REGISTRY" ]] || missing_fn_keys+=("registry")
+
+  if [[ -n "$FN_CONTEXT_NAME" && "$FN_CONTEXT_PROVIDER" == "oracle" && ${#missing_fn_keys[@]} -eq 0 ]]; then
+    emit_kv fn_context_state found
+  elif [[ -n "$FN_CONTEXT_NAME" || -n "$FN_CONTEXT_PROVIDER" || -n "$FN_CONTEXT_PROFILE" || -n "$FN_CONTEXT_COMPARTMENT_ID" || -n "$FN_CONTEXT_API_URL" || -n "$FN_CONTEXT_REGISTRY" ]]; then
+    emit_kv fn_context_state incomplete
+    emit_kv fn_context_missing_keys "${missing_fn_keys[*]:-provider}"
+  else
+    emit_kv fn_context_state missing
+  fi
+  emit_kv fn_context_name "${FN_CONTEXT_NAME:-}"
+  emit_kv fn_context_provider "${FN_CONTEXT_PROVIDER:-}"
+  emit_kv fn_context_profile "${FN_CONTEXT_PROFILE:-}"
+  emit_kv fn_context_compartment_id "${FN_CONTEXT_COMPARTMENT_ID:-}"
+  emit_kv fn_context_api_url "${FN_CONTEXT_API_URL:-}"
+  emit_kv fn_context_registry "${FN_CONTEXT_REGISTRY:-}"
+  emit_kv fn_context_image_compartment_id "${FN_CONTEXT_IMAGE_COMPARTMENT_ID:-}"
+else
+  emit_kv fn_context_state missing
+fi
+
+resolved_profile=""
+resolved_compartment_id=""
+resolved_region=""
+
+if [[ -n "$PROFILE" ]]; then
+  resolved_profile="$PROFILE"
+elif [[ -n "$FN_CONTEXT_PROFILE" ]]; then
+  resolved_profile="$FN_CONTEXT_PROFILE"
+fi
+
+if [[ -n "$COMPARTMENT_ID" ]]; then
+  resolved_compartment_id="$COMPARTMENT_ID"
+elif [[ -n "$FN_CONTEXT_COMPARTMENT_ID" ]]; then
+  resolved_compartment_id="$FN_CONTEXT_COMPARTMENT_ID"
+fi
+
+if [[ -n "$REGION" ]]; then
+  resolved_region="$REGION"
+elif [[ -n "$FN_CONTEXT_API_URL" ]]; then
+  resolved_region="$(extract_region_from_api_url "${FN_CONTEXT_API_URL:-}")"
+fi
+
+PROFILE="$resolved_profile"
+COMPARTMENT_ID="$resolved_compartment_id"
+REGION="$resolved_region"
+
+emit_kv region "${REGION:-}"
+emit_kv compartment_id "${COMPARTMENT_ID:-}"
+emit_kv profile "${PROFILE:-}"
+
+human_out ""
+log_section "OCI discovery"
+if ! command -v oci >/dev/null 2>&1; then
+  emit_kv oci_cli_state missing
+  emit_kv discovery_state missing
+  exit 0
+fi
+emit_kv oci_cli_state found
+
+if [[ -n "$REGION" ]]; then
+  export OCI_CLI_REGION="$REGION"
+fi
+if [[ -n "$PROFILE" ]]; then
+  export OCI_CLI_PROFILE="$PROFILE"
+fi
+
+if [[ -z "$COMPARTMENT_ID" ]]; then
+  emit_kv compartment_state missing
+  emit_kv apps_state empty
+  emit_kv apps_count 0
+  emit_kv discovery_state missing
+  exit 0
+fi
+emit_kv compartment_state found
+
+app_raw=""
+app_err=""
+if run_oci_display_name_list app_raw app_err fn application list --compartment-id "$COMPARTMENT_ID" --all; then
+  app_names="$(sed '/^$/d' <<<"$app_raw")"
+  if [[ -n "$app_names" ]]; then
+    emit_kv apps_state found
+    app_count="$(wc -l <<<"$app_names" | tr -d ' ')"
+    emit_kv apps_count "$app_count"
+    idx=0
+    while IFS= read -r name; do
+      [[ -z "$name" ]] && continue
+      idx=$((idx + 1))
+      emit_kv "app_item_${idx}" "$name"
+    done <<<"$app_names"
+  else
+    emit_kv apps_state empty
+    emit_kv apps_count 0
+  fi
+else
+  emit_kv apps_state error
+  emit_kv apps_error_reason "$(classify_oci_error_reason "$app_err")"
+  DISCOVERY_ERROR=1
+fi
+
+if [[ -n "$APP_NAME" ]]; then
+  app_match_raw=""
+  app_match_err=""
+  if run_oci_display_name_lookup app_match_raw app_match_err "$APP_NAME" fn application list --compartment-id "$COMPARTMENT_ID" --all; then
+    if [[ -n "$app_match_raw" && "$app_match_raw" != "null" && "$app_match_raw" != "None" ]]; then
+      emit_kv app_state found
+      emit_kv app_id "$app_match_raw"
+    else
+      emit_kv app_state missing
+    fi
+  else
+    emit_kv app_state error
+    emit_kv app_error_reason "$(classify_oci_error_reason "$app_match_err")"
+    DISCOVERY_ERROR=1
+  fi
+fi
+
+if [[ "$DISCOVERY_ERROR" -eq 1 ]]; then
+  emit_kv discovery_state error
+  exit 4
+fi
+
+emit_kv discovery_state found

--- a/oci/functions/oci-functions-deploy/scripts/ensure_app.sh
+++ b/oci/functions/oci-functions-deploy/scripts/ensure_app.sh
@@ -1,0 +1,402 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIRM="$SCRIPT_DIR/confirm_gate.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/common.sh"
+
+REGION=""
+COMPARTMENT_ID=""
+APP_NAME=""
+APP_CHOICE=""
+SUBNET_IDS=""
+PROFILE=""
+APP_SHAPE=""
+NSG_IDS=""
+MACHINE_READABLE="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --region)
+      REGION="${2:-}"
+      shift 2
+      ;;
+    --compartment-id)
+      COMPARTMENT_ID="${2:-}"
+      shift 2
+      ;;
+    --profile)
+      PROFILE="${2:-}"
+      shift 2
+      ;;
+    --app-name)
+      APP_NAME="${2:-}"
+      shift 2
+      ;;
+    --app-choice)
+      APP_CHOICE="${2:-}"
+      shift 2
+      ;;
+    --subnet-ids)
+      SUBNET_IDS="${2:-}"
+      shift 2
+      ;;
+    --shape)
+      APP_SHAPE="${2:-}"
+      shift 2
+      ;;
+    --nsg-ids)
+      NSG_IDS="${2:-}"
+      shift 2
+      ;;
+    --machine-readable)
+      # Used by common.sh:is_machine_readable after argument parsing.
+      # shellcheck disable=SC2034
+      MACHINE_READABLE="true"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+run_confirmed() {
+  local description="$1"
+  local display="$2"
+  shift 2
+
+  local nonce
+  local confirm_args=()
+  nonce="$(next_confirm_nonce)"
+  if is_machine_readable; then
+    confirm_args+=(--machine-readable)
+  fi
+  "$CONFIRM" --description "$description" --display "$display" "${confirm_args[@]}" --nonce "$nonce" -- "$@"
+}
+
+normalize_csv_lines() {
+  python3 - <<'PY' "$1"
+import sys
+items = [item.strip() for item in sys.argv[1].split(",") if item.strip()]
+for item in items:
+    print(item)
+PY
+}
+
+json_array_from_csv() {
+  python3 - <<'PY' "$1"
+import json
+import sys
+items = [item.strip() for item in sys.argv[1].split(",") if item.strip()]
+print(json.dumps(items))
+PY
+}
+
+read_with_default_or_error() {
+  local prompt="$1"
+  local default_value="$2"
+  local out_var="$3"
+  local value=""
+
+  if is_interactive; then
+    read -r -p "$prompt" value
+    if [[ -z "$value" ]]; then
+      value="$default_value"
+    fi
+  else
+    if [[ -z "$default_value" ]]; then
+      echo "[ERROR] Missing required input in non-interactive mode: $prompt" >&2
+      echo "[HINT] Provide the required flag explicitly." >&2
+      exit 2
+    fi
+    value="$default_value"
+    log_info "Non-interactive mode: using default for '$prompt' -> $default_value"
+  fi
+
+  printf -v "$out_var" "%s" "$value"
+}
+
+parse_fn_context() {
+  FN_CONTEXT_PROFILE=""
+  FN_CONTEXT_COMPARTMENT_ID=""
+  FN_CONTEXT_API_URL=""
+
+  local context_out
+  context_out="$(fn inspect context 2>/dev/null || true)"
+  [[ -n "$context_out" ]] || return 1
+
+  FN_CONTEXT_PROFILE="$(awk -F': ' '/^oracle.profile:/ {print $2; exit}' <<<"$context_out" || true)"
+  FN_CONTEXT_COMPARTMENT_ID="$(awk -F': ' '/^oracle.compartment-id:/ {print $2; exit}' <<<"$context_out" || true)"
+  FN_CONTEXT_API_URL="$(awk -F': ' '/^api-url:/ {print $2; exit}' <<<"$context_out" || true)"
+  return 0
+}
+
+FN_CONTEXT_PROFILE=""
+FN_CONTEXT_COMPARTMENT_ID=""
+FN_CONTEXT_API_URL=""
+parse_fn_context || true
+
+if [[ -z "$PROFILE" ]]; then
+  PROFILE="$FN_CONTEXT_PROFILE"
+fi
+if [[ -z "$COMPARTMENT_ID" ]]; then
+  COMPARTMENT_ID="$FN_CONTEXT_COMPARTMENT_ID"
+fi
+if [[ -z "$REGION" ]]; then
+  REGION="$(extract_region_from_api_url "$FN_CONTEXT_API_URL")"
+fi
+
+if [[ -z "$REGION" || -z "$COMPARTMENT_ID" ]]; then
+  echo "Usage: $0 --region <region> --compartment-id <ocid> [--profile <profile>] [--app-name <name>] [--app-choice <reuse|create>] [--subnet-ids <comma-separated-ocids>] [--shape <GENERIC_X86|GENERIC_ARM|GENERIC_X86_ARM>] [--nsg-ids <comma-separated-ocids>] [--machine-readable]" >&2
+  echo "[HINT] When omitted, region/profile/compartment are resolved from the active Fn context." >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  emit_kv app_state error
+  emit_kv app_error_reason runtime_or_cli
+  echo "[ERROR] python3 is required for JSON argument generation." >&2
+  exit 1
+fi
+
+export OCI_CLI_REGION="$REGION"
+if [[ -n "$PROFILE" ]]; then
+  export OCI_CLI_PROFILE="$PROFILE"
+fi
+
+all_apps_out=""
+all_apps_err=""
+if ! run_oci_display_name_list all_apps_out all_apps_err fn application list --compartment-id "$COMPARTMENT_ID" --all; then
+  emit_kv apps_state error
+  emit_kv apps_error_reason "$(classify_oci_error_reason "$all_apps_err")"
+  emit_kv app_state error
+  emit_kv app_error_reason "$(classify_oci_error_reason "$all_apps_err")"
+  echo "[ERROR] Cannot inspect Functions applications." >&2
+  exit 4
+fi
+
+existing_apps=()
+while IFS= read -r app_name; do
+  [[ -z "$app_name" ]] && continue
+  existing_apps+=("$app_name")
+done <<<"$(sed '/^$/d' <<<"$all_apps_out")"
+if [[ ${#existing_apps[@]} -gt 0 ]]; then
+  emit_kv apps_state found
+  emit_kv apps_count "${#existing_apps[@]}"
+  idx=0
+  for item in "${existing_apps[@]}"; do
+    idx=$((idx + 1))
+    emit_kv "app_item_${idx}" "$item"
+  done
+else
+  emit_kv apps_state empty
+  emit_kv apps_count 0
+fi
+
+if [[ ${#existing_apps[@]} -gt 0 && -z "$APP_CHOICE" ]]; then
+  if is_interactive; then
+    human_out "Existing Functions applications found:"
+    idx=0
+    for item in "${existing_apps[@]}"; do
+      idx=$((idx + 1))
+      human_out "  $idx) $item"
+    done
+    read -r -p "Reuse an existing app or create new? [reuse/create]: " APP_CHOICE
+  else
+    emit_kv app_state error
+    emit_kv app_error_reason runtime_or_cli
+    echo "[ERROR] Existing applications are available, but --app-choice was not supplied." >&2
+    echo "[HINT] Pass --app-choice reuse or --app-choice create explicitly." >&2
+    exit 2
+  fi
+fi
+
+if [[ ${#existing_apps[@]} -gt 0 && -n "$APP_CHOICE" ]]; then
+  human_out "Existing Functions applications found:"
+  idx=0
+  for item in "${existing_apps[@]}"; do
+    idx=$((idx + 1))
+    human_out "  $idx) $item"
+  done
+
+  case "$APP_CHOICE" in
+    reuse)
+      if [[ -n "$APP_NAME" ]]; then
+        :
+      elif is_interactive; then
+        read -r -p "Choose application number to reuse: " pick
+        if [[ ! "$pick" =~ ^[0-9]+$ ]]; then
+          emit_kv app_state error
+          emit_kv app_error_reason runtime_or_cli
+          echo "[ERROR] Invalid application selection: expected a number." >&2
+          exit 1
+        fi
+        if [[ "$pick" -lt 1 || "$pick" -gt "${#existing_apps[@]}" ]]; then
+          emit_kv app_state error
+          emit_kv app_error_reason runtime_or_cli
+          echo "[ERROR] Invalid application selection." >&2
+          exit 1
+        fi
+        APP_NAME="${existing_apps[$((pick - 1))]}"
+      else
+        echo "[ERROR] Non-interactive reuse requires --app-name." >&2
+        exit 2
+      fi
+      ;;
+    create)
+      if [[ -z "$APP_NAME" ]]; then
+        read_with_default_or_error "New Functions application display name: " "" APP_NAME
+      fi
+      ;;
+    *)
+      emit_kv app_state error
+      emit_kv app_error_reason runtime_or_cli
+      echo "[ERROR] app choice must be 'reuse' or 'create'." >&2
+      exit 1
+      ;;
+  esac
+fi
+
+case "$APP_SHAPE" in
+  ""|GENERIC_X86|GENERIC_ARM|GENERIC_X86_ARM) ;;
+  *)
+    emit_kv app_state error
+    emit_kv app_error_reason runtime_or_cli
+    echo "[ERROR] Unsupported application shape '$APP_SHAPE'." >&2
+    echo "[HINT] Use GENERIC_X86, GENERIC_ARM, or GENERIC_X86_ARM." >&2
+    exit 2
+    ;;
+esac
+
+if [[ -z "$APP_NAME" ]]; then
+  read_with_default_or_error "Functions application display name: " "" APP_NAME
+fi
+
+app_id=""
+app_lookup_out=""
+app_lookup_err=""
+if run_oci_display_name_lookup app_lookup_out app_lookup_err "$APP_NAME" fn application list --compartment-id "$COMPARTMENT_ID" --all; then
+  app_id="$app_lookup_out"
+else
+  emit_kv app_state error
+  emit_kv app_error_reason "$(classify_oci_error_reason "$app_lookup_err")"
+  echo "[ERROR] Cannot inspect the requested Functions application." >&2
+  exit 4
+fi
+
+if [[ -n "$app_id" && "$app_id" != "null" && "$app_id" != "None" ]]; then
+  if [[ -z "$APP_CHOICE" ]]; then
+    if is_interactive; then
+      read -r -p "Application '$APP_NAME' exists. Reuse it or create a new one? [reuse/create]: " APP_CHOICE
+    else
+      emit_kv app_state error
+      emit_kv app_error_reason runtime_or_cli
+      echo "[ERROR] --app-name matched an existing application but --app-choice was not supplied." >&2
+      exit 2
+    fi
+  fi
+  if [[ "$APP_CHOICE" != "reuse" ]]; then
+    if ! is_interactive; then
+      emit_kv app_state error
+      emit_kv app_error_reason runtime_or_cli
+      echo "[ERROR] Application '$APP_NAME' already exists, but create was requested." >&2
+      echo "[HINT] Choose a new application name or switch to --app-choice reuse." >&2
+      exit 2
+    fi
+    while [[ -n "$app_id" && "$app_id" != "null" && "$app_id" != "None" ]]; do
+      read_with_default_or_error "Application '$APP_NAME' exists. New Functions application display name: " "" APP_NAME
+      if run_oci_display_name_lookup app_lookup_out app_lookup_err "$APP_NAME" fn application list --compartment-id "$COMPARTMENT_ID" --all; then
+        app_id="$app_lookup_out"
+      else
+        emit_kv app_state error
+        emit_kv app_error_reason "$(classify_oci_error_reason "$app_lookup_err")"
+        echo "[ERROR] Cannot inspect the requested Functions application." >&2
+        exit 4
+      fi
+    done
+  else
+    if [[ -n "$APP_SHAPE" || -n "$NSG_IDS" ]]; then
+      emit_kv app_state error
+      emit_kv app_error_reason runtime_or_cli
+      echo "[ERROR] --shape and --nsg-ids apply only when creating a new application." >&2
+      exit 2
+    fi
+    emit_kv app_state found
+    emit_kv app_name "$APP_NAME"
+    emit_kv app_id "$app_id"
+    emit_kv app_action reuse
+    exit 0
+  fi
+fi
+
+if [[ "$APP_CHOICE" == "reuse" ]]; then
+  emit_kv app_state missing
+  echo "[ERROR] Requested app reuse but application '$APP_NAME' was not found." >&2
+  echo "[HINT] Choose an existing app name or switch to --app-choice create." >&2
+  exit 4
+fi
+emit_kv app_state missing
+
+if [[ -z "$SUBNET_IDS" ]]; then
+  read_with_default_or_error "Subnet OCID(s) for the application (comma-separated, 1-3): " "" SUBNET_IDS
+fi
+
+if [[ -z "$SUBNET_IDS" ]]; then
+  emit_kv app_state error
+  emit_kv app_error_reason runtime_or_cli
+  echo "[ERROR] subnet IDs are required to create the application" >&2
+  exit 1
+fi
+
+subnet_lines="$(normalize_csv_lines "$SUBNET_IDS")"
+subnet_count="$(sed '/^$/d' <<<"$subnet_lines" | wc -l | tr -d ' ')"
+if [[ "$subnet_count" -lt 1 || "$subnet_count" -gt 3 ]]; then
+  emit_kv app_state error
+  emit_kv app_error_reason runtime_or_cli
+  echo "[ERROR] OCI Functions applications require between 1 and 3 subnet OCIDs." >&2
+  exit 2
+fi
+subnet_json="$(json_array_from_csv "$SUBNET_IDS")"
+
+create_args=(oci fn application create --compartment-id "$COMPARTMENT_ID" --display-name "$APP_NAME" --subnet-ids "$subnet_json")
+create_display="oci fn application create --compartment-id '$COMPARTMENT_ID' --display-name '$APP_NAME' --subnet-ids '$subnet_json'"
+
+if [[ -n "$APP_SHAPE" ]]; then
+  create_args+=(--shape "$APP_SHAPE")
+  create_display="$create_display --shape '$APP_SHAPE'"
+fi
+
+if [[ -n "$NSG_IDS" ]]; then
+  nsg_json="$(json_array_from_csv "$NSG_IDS")"
+  create_args+=(--network-security-group-ids "$nsg_json")
+  create_display="$create_display --network-security-group-ids '$nsg_json'"
+fi
+
+run_confirmed "Create Functions application '$APP_NAME'" "$create_display" "${create_args[@]}"
+
+app_id=""
+app_lookup_out=""
+app_lookup_err=""
+if run_oci_display_name_lookup app_lookup_out app_lookup_err "$APP_NAME" fn application list --compartment-id "$COMPARTMENT_ID" --all; then
+  app_id="$app_lookup_out"
+else
+  emit_kv app_state error
+  emit_kv app_error_reason "$(classify_oci_error_reason "$app_lookup_err")"
+  echo "[ERROR] Application was not resolvable after create." >&2
+  exit 4
+fi
+
+if [[ -z "$app_id" || "$app_id" == "null" || "$app_id" == "None" ]]; then
+  emit_kv app_state error
+  emit_kv app_error_reason runtime_or_cli
+  echo "[ERROR] Application was not resolvable after create." >&2
+  exit 4
+fi
+emit_kv app_state found
+emit_kv app_name "$APP_NAME"
+emit_kv app_id "$app_id"
+emit_kv app_action create
+exit 0

--- a/oci/functions/oci-functions-deploy/scripts/ensure_network.sh
+++ b/oci/functions/oci-functions-deploy/scripts/ensure_network.sh
@@ -1,0 +1,570 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIRM="$SCRIPT_DIR/confirm_gate.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/common.sh"
+
+REGION=""
+COMPARTMENT_ID=""
+TOPOLOGY=""
+VCN_NAME=""
+VCN_CIDR=""
+SUBNET_NAME=""
+SUBNET_CIDR=""
+ALLOW_NETWORK_CREATE=""
+MACHINE_READABLE="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --region)
+      REGION="${2:-}"
+      shift 2
+      ;;
+    --compartment-id)
+      COMPARTMENT_ID="${2:-}"
+      shift 2
+      ;;
+    --topology)
+      TOPOLOGY="${2:-}"
+      shift 2
+      ;;
+    --vcn-name)
+      VCN_NAME="${2:-}"
+      shift 2
+      ;;
+    --vcn-cidr)
+      VCN_CIDR="${2:-}"
+      shift 2
+      ;;
+    --subnet-name)
+      SUBNET_NAME="${2:-}"
+      shift 2
+      ;;
+    --subnet-cidr)
+      SUBNET_CIDR="${2:-}"
+      shift 2
+      ;;
+    --allow-network-create)
+      ALLOW_NETWORK_CREATE="${2:-}"
+      shift 2
+      ;;
+    --machine-readable)
+      # Used by common.sh:is_machine_readable after argument parsing.
+      # shellcheck disable=SC2034
+      MACHINE_READABLE="true"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$REGION" || -z "$COMPARTMENT_ID" ]]; then
+  echo "Usage: $0 --region <region> --compartment-id <ocid> --allow-network-create yes [--topology private|public|mixed] [--vcn-name ...] [--vcn-cidr ...] [--subnet-name ...] [--subnet-cidr ...] [--machine-readable]" >&2
+  exit 1
+fi
+
+run_confirmed() {
+  local description="$1"
+  local display="$2"
+  shift 2
+
+  local nonce
+  local confirm_args=()
+  nonce="$(next_confirm_nonce)"
+  if is_machine_readable; then
+    confirm_args+=(--machine-readable)
+  fi
+  "$CONFIRM" --description "$description" --display "$display" "${confirm_args[@]}" --nonce "$nonce" -- "$@"
+}
+
+read_with_default() {
+  local prompt="$1"
+  local default_value="$2"
+  local out_var="$3"
+  local value=""
+
+  if is_interactive; then
+    read -r -p "$prompt" value
+    value="${value:-$default_value}"
+  else
+    value="$default_value"
+    log_info "Non-interactive mode: using default for '$prompt' -> $default_value"
+  fi
+
+  printf -v "$out_var" "%s" "$value"
+}
+
+is_nonempty_id() {
+  local val="${1:-}"
+  [[ -n "$val" && "$val" != "null" && "$val" != "None" ]]
+}
+
+resolve_id_with_retry() {
+  local __out_var="$1"
+  local retries="${2:-5}"
+  local delay_sec="${3:-2}"
+  local display_name="$4"
+  shift 4
+  local value=""
+  local out=""
+  local err=""
+
+  for ((i=1; i<=retries; i++)); do
+    if run_oci_display_name_lookup out err "$display_name" "$@"; then
+      value="$out"
+    else
+      value=""
+    fi
+    if is_nonempty_id "$value"; then
+      printf -v "$__out_var" "%s" "$value"
+      return
+    fi
+    sleep "$delay_sec"
+  done
+
+  if [[ -n "$err" ]]; then
+    log_warn "Resource lookup retry ended with: $err"
+  fi
+  printf -v "$__out_var" "%s" "$value"
+}
+
+emit_subnet_sizing_guidance() {
+  local subnet_cidr="$1"
+  local est_concurrency=""
+  local est_mem_mb=""
+  local sizing_output=""
+
+  read_with_default "Expected max concurrent requests (default 20): " "20" est_concurrency
+  read_with_default "Memory per request in MB (default 256): " "256" est_mem_mb
+
+  sizing_output="$(python3 - <<'PY' "$subnet_cidr" "$est_concurrency" "$est_mem_mb"
+import ipaddress
+import math
+import sys
+cidr, conc, mem = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+net = ipaddress.ip_network(cidr, strict=False)
+usable = max(net.num_addresses - 2, 0)
+required = math.ceil(3 * 1 + ((conc * (mem / 1024)) / 14))
+print(f"[INFO] Estimated required IPs: {required}, usable IPs in subnet: {usable}")
+if usable < required:
+    print("[WARN] Subnet may be undersized for projected concurrency. OCI publishes this as sizing guidance rather than a hard requirement.")
+PY
+)"
+
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    human_out "$line"
+  done <<<"$sizing_output"
+}
+
+if ! command -v oci >/dev/null 2>&1; then
+  emit_kv network_state error
+  emit_kv network_error_reason runtime_or_cli
+  echo "[ERROR] oci CLI is required." >&2
+  exit 1
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  emit_kv network_state error
+  emit_kv network_error_reason runtime_or_cli
+  echo "[ERROR] python3 is required for JSON processing." >&2
+  exit 1
+fi
+
+if [[ "$ALLOW_NETWORK_CREATE" != "yes" ]]; then
+  emit_kv network_state error
+  emit_kv network_error_reason missing_opt_in
+  echo "[ERROR] Network creation/repair is an explicit advanced branch." >&2
+  echo "[HINT] Re-run with --allow-network-create yes after the user explicitly opts in." >&2
+  exit 2
+fi
+
+if ! is_interactive; then
+  for required_flag in TOPOLOGY VCN_NAME VCN_CIDR SUBNET_NAME SUBNET_CIDR; do
+    if [[ -z "${!required_flag:-}" ]]; then
+      emit_kv network_state error
+      emit_kv network_error_reason missing_required_input
+      echo "[ERROR] Non-interactive network creation requires explicit topology, names, and CIDRs." >&2
+      exit 2
+    fi
+  done
+fi
+
+export OCI_CLI_REGION="$REGION"
+
+if [[ -z "$VCN_NAME" ]]; then
+  read_with_default "VCN name (default oci-fn-vcn): " "oci-fn-vcn" VCN_NAME
+fi
+if [[ -z "$SUBNET_NAME" ]]; then
+  read_with_default "Subnet name (default oci-fn-private-subnet): " "oci-fn-private-subnet" SUBNET_NAME
+fi
+
+if [[ -z "$TOPOLOGY" ]]; then
+  if [[ -t 0 ]]; then
+    human_out "Choose topology:"
+    human_out "  1) private (recommended): private subnet + service gateway"
+    human_out "  2) public: public subnet + internet gateway route 0.0.0.0/0"
+    human_out "  3) mixed: create IGW and SGW but keep function subnet private"
+    read -r -p "Enter 1/2/3 [default 1]: " topo_pick
+    case "$topo_pick" in
+      2) TOPOLOGY="public" ;;
+      3) TOPOLOGY="mixed" ;;
+      *) TOPOLOGY="private" ;;
+    esac
+  else
+    TOPOLOGY="private"
+    log_info "Non-interactive mode: using default topology 'private'."
+  fi
+fi
+
+case "$TOPOLOGY" in
+  private|public|mixed) ;;
+  *)
+    emit_kv network_state error
+    emit_kv network_error_reason runtime_or_cli
+    echo "[ERROR] Unsupported topology: $TOPOLOGY" >&2
+    exit 1
+    ;;
+esac
+
+if [[ -z "$VCN_CIDR" ]]; then
+  read_with_default "VCN CIDR (default 10.0.0.0/16): " "10.0.0.0/16" VCN_CIDR
+fi
+if [[ -z "$SUBNET_CIDR" ]]; then
+  read_with_default "Subnet CIDR (default 10.0.1.0/24): " "10.0.1.0/24" SUBNET_CIDR
+fi
+
+all_vcns_out=""
+vcn_err=""
+if run_oci_display_name_list all_vcns_out vcn_err network vcn list --compartment-id "$COMPARTMENT_ID" --all; then
+  if [[ -n "$(sed '/^$/d' <<<"$all_vcns_out")" ]]; then
+    emit_kv vcns_state found
+  else
+    emit_kv vcns_state empty
+  fi
+else
+  emit_kv vcns_state error
+  emit_kv network_state error
+  emit_kv network_error_reason "$(classify_oci_error_reason "$vcn_err")"
+  echo "[ERROR] Unable to list VCNs." >&2
+  exit 4
+fi
+
+vcn_id=""
+vcn_lookup=""
+if run_oci_display_name_lookup vcn_lookup vcn_err "$VCN_NAME" network vcn list --compartment-id "$COMPARTMENT_ID" --all; then
+  vcn_id="$vcn_lookup"
+else
+  emit_kv network_state error
+  emit_kv network_error_reason "$(classify_oci_error_reason "$vcn_err")"
+  echo "[ERROR] Unable to list VCNs." >&2
+  exit 4
+fi
+
+if [[ -z "$vcn_id" || "$vcn_id" == "null" || "$vcn_id" == "None" ]]; then
+  vcn_cidr_json="$(python3 - <<'PY' "$VCN_CIDR"
+import json
+import sys
+print(json.dumps([sys.argv[1]]))
+PY
+)"
+  run_confirmed "Create VCN '$VCN_NAME'" "oci network vcn create --compartment-id '$COMPARTMENT_ID' --display-name '$VCN_NAME' --cidr-blocks '$vcn_cidr_json' --query 'data.id' --raw-output" oci network vcn create --compartment-id "$COMPARTMENT_ID" --display-name "$VCN_NAME" --cidr-blocks "$vcn_cidr_json" --query 'data.id' --raw-output
+
+  resolve_id_with_retry vcn_id 6 2 "$VCN_NAME" network vcn list --compartment-id "$COMPARTMENT_ID" --all
+fi
+
+if [[ -z "$vcn_id" || "$vcn_id" == "null" || "$vcn_id" == "None" ]]; then
+  echo "[ERROR] VCN '$VCN_NAME' could not be resolved after create/discovery." >&2
+  echo "[HINT] Check OCI permissions and whether duplicate VCN names are causing ambiguous lookup." >&2
+  exit 4
+fi
+
+human_out "Using VCN: $vcn_id"
+
+igw_id=""
+sgw_id=""
+service_id=""
+service_cidr=""
+route_table_id=""
+
+if [[ "$TOPOLOGY" == "public" || "$TOPOLOGY" == "mixed" ]]; then
+  igw_name="${VCN_NAME}-igw"
+  igw_err=""
+  if ! run_oci_display_name_lookup igw_id igw_err "$igw_name" network internet-gateway list --compartment-id "$COMPARTMENT_ID" --all; then
+    echo "[ERROR] Unable to inspect internet gateways: $igw_err" >&2
+    exit 4
+  fi
+  if [[ -z "$igw_id" || "$igw_id" == "null" || "$igw_id" == "None" ]]; then
+    run_confirmed "Create internet gateway for public routing" "oci network internet-gateway create --compartment-id '$COMPARTMENT_ID' --vcn-id '$vcn_id' --display-name '$igw_name' --is-enabled true" oci network internet-gateway create --compartment-id "$COMPARTMENT_ID" --vcn-id "$vcn_id" --display-name "$igw_name" --is-enabled true
+    if ! run_oci_display_name_lookup igw_id igw_err "$igw_name" network internet-gateway list --compartment-id "$COMPARTMENT_ID" --all; then
+      echo "[ERROR] Unable to resolve the created internet gateway." >&2
+      exit 4
+    fi
+  fi
+fi
+
+if [[ "$TOPOLOGY" == "private" || "$TOPOLOGY" == "mixed" ]]; then
+  sgw_name="${VCN_NAME}-sgw"
+  sgw_err=""
+  if ! run_oci_display_name_lookup sgw_id sgw_err "$sgw_name" network service-gateway list --compartment-id "$COMPARTMENT_ID" --all; then
+    echo "[ERROR] Unable to inspect service gateways: $sgw_err" >&2
+    exit 4
+  fi
+
+  service_list_json="$(oci network service list --all 2>/dev/null || true)"
+  if [[ -z "$service_list_json" ]]; then
+    echo "[ERROR] Unable to list OCI network services for service gateway configuration." >&2
+    echo "[HINT] Verify OCI permissions: inspect network services in this region." >&2
+    exit 4
+  fi
+
+  service_meta="$(python3 - <<'PY' "$service_list_json"
+import json
+import sys
+payload = json.loads(sys.argv[1])
+services = payload.get("data", [])
+for svc in services:
+    name = (svc.get("name") or "").lower()
+    cidr = (svc.get("cidr-block") or "").lower()
+    if "oracle services network" in name and cidr.startswith("all-") and cidr.endswith("-services-in-oracle-services-network"):
+        print((svc.get("id") or "") + "\t" + (svc.get("cidr-block") or ""))
+        sys.exit(0)
+print("\t")
+PY
+)"
+
+  service_id="${service_meta%%$'\t'*}"
+  service_cidr="${service_meta#*$'\t'}"
+
+  if [[ -z "$service_id" || -z "$service_cidr" ]]; then
+    echo "[ERROR] Could not resolve 'All <region> Services in Oracle Services Network' service metadata." >&2
+    exit 4
+  fi
+
+  if [[ -z "$sgw_id" || "$sgw_id" == "null" || "$sgw_id" == "None" ]]; then
+    run_confirmed "Create service gateway for private Oracle Services Network access" "oci network service-gateway create --compartment-id '$COMPARTMENT_ID' --vcn-id '$vcn_id' --display-name '$sgw_name' --services '[{\"serviceId\":\"$service_id\"}]'" oci network service-gateway create --compartment-id "$COMPARTMENT_ID" --vcn-id "$vcn_id" --display-name "$sgw_name" --services "[{\"serviceId\":\"$service_id\"}]"
+    if ! run_oci_display_name_lookup sgw_id sgw_err "$sgw_name" network service-gateway list --compartment-id "$COMPARTMENT_ID" --all; then
+      echo "[ERROR] Unable to resolve the created service gateway." >&2
+      exit 4
+    fi
+  fi
+fi
+
+rt_name="${VCN_NAME}-${TOPOLOGY}-rt"
+if [[ "$TOPOLOGY" == "public" ]]; then
+  desired_destination="0.0.0.0/0"
+  desired_destination_type="CIDR_BLOCK"
+  desired_entity_id="$igw_id"
+else
+  desired_destination="$service_cidr"
+  desired_destination_type="SERVICE_CIDR_BLOCK"
+  desired_entity_id="$sgw_id"
+fi
+
+rules="[{\"destination\":\"$desired_destination\",\"destinationType\":\"$desired_destination_type\",\"networkEntityId\":\"$desired_entity_id\"}]"
+
+route_table_err=""
+if ! run_oci_display_name_lookup route_table_id route_table_err "$rt_name" network route-table list --compartment-id "$COMPARTMENT_ID" --vcn-id "$vcn_id" --all; then
+  echo "[ERROR] Unable to inspect route tables: $route_table_err" >&2
+  exit 4
+fi
+if [[ -n "$route_table_id" && "$route_table_id" != "null" && "$route_table_id" != "None" ]]; then
+  rt_json="$(oci network route-table get --rt-id "$route_table_id" --query data 2>/dev/null || true)"
+  rt_compatible="$(python3 - <<'PY' "$rt_json" "$desired_destination" "$desired_destination_type" "$desired_entity_id"
+import json
+import sys
+payload = json.loads(sys.argv[1]) if sys.argv[1] else {}
+destination = sys.argv[2]
+destination_type = sys.argv[3]
+entity = sys.argv[4]
+
+def g(obj, *keys):
+    for k in keys:
+        if k in obj:
+            return obj[k]
+    return None
+
+for rule in payload.get("route-rules", []):
+    if (g(rule, "destination") == destination and
+        g(rule, "destination-type", "destinationType") == destination_type and
+        g(rule, "network-entity-id", "networkEntityId") == entity):
+        print("yes")
+        break
+else:
+    print("no")
+PY
+  )"
+  if [[ "$rt_compatible" != "yes" ]]; then
+    log_warn "Existing route table '$rt_name' is incompatible with selected topology."
+    rt_name="${rt_name}-managed"
+    route_table_id=""
+  else
+    log_ok "Reusing compatible route table: $rt_name"
+  fi
+fi
+
+if [[ -z "$route_table_id" || "$route_table_id" == "null" || "$route_table_id" == "None" ]]; then
+  if ! run_oci_display_name_lookup route_table_id route_table_err "$rt_name" network route-table list --compartment-id "$COMPARTMENT_ID" --vcn-id "$vcn_id" --all; then
+    echo "[ERROR] Unable to inspect route tables." >&2
+    exit 4
+  fi
+  if [[ -z "$route_table_id" || "$route_table_id" == "null" || "$route_table_id" == "None" ]]; then
+    run_confirmed "Create route table '$rt_name'" "oci network route-table create --compartment-id '$COMPARTMENT_ID' --vcn-id '$vcn_id' --display-name '$rt_name' --route-rules '$rules'" oci network route-table create --compartment-id "$COMPARTMENT_ID" --vcn-id "$vcn_id" --display-name "$rt_name" --route-rules "$rules"
+    resolve_id_with_retry route_table_id 6 2 "$rt_name" network route-table list --compartment-id "$COMPARTMENT_ID" --vcn-id "$vcn_id" --all
+  else
+    run_confirmed "Update route table '$rt_name' to match selected topology" "oci network route-table update --rt-id '$route_table_id' --route-rules '$rules' --force" oci network route-table update --rt-id "$route_table_id" --route-rules "$rules" --force
+  fi
+fi
+
+if [[ -z "$route_table_id" || "$route_table_id" == "null" || "$route_table_id" == "None" ]]; then
+  echo "[ERROR] Route table '$rt_name' could not be resolved after create/update." >&2
+  exit 4
+fi
+
+expected_prohibit_public="true"
+if [[ "$TOPOLOGY" == "public" ]]; then
+  expected_prohibit_public="false"
+fi
+
+subnet_err=""
+if ! run_oci_display_name_lookup subnet_id subnet_err "$SUBNET_NAME" network subnet list --compartment-id "$COMPARTMENT_ID" --vcn-id "$vcn_id" --all; then
+  echo "[ERROR] Unable to inspect subnets: $subnet_err" >&2
+  exit 4
+fi
+if [[ -z "$subnet_id" || "$subnet_id" == "null" || "$subnet_id" == "None" ]]; then
+  emit_subnet_sizing_guidance "$SUBNET_CIDR"
+  run_confirmed "Create subnet '$SUBNET_NAME'" "oci network subnet create --compartment-id '$COMPARTMENT_ID' --vcn-id '$vcn_id' --display-name '$SUBNET_NAME' --cidr-block '$SUBNET_CIDR' --route-table-id '$route_table_id' --prohibit-public-ip-on-vnic $expected_prohibit_public" oci network subnet create --compartment-id "$COMPARTMENT_ID" --vcn-id "$vcn_id" --display-name "$SUBNET_NAME" --cidr-block "$SUBNET_CIDR" --route-table-id "$route_table_id" --prohibit-public-ip-on-vnic "$expected_prohibit_public"
+  resolve_id_with_retry subnet_id 6 2 "$SUBNET_NAME" network subnet list --compartment-id "$COMPARTMENT_ID" --vcn-id "$vcn_id" --all
+else
+  subnet_json="$(oci network subnet get --subnet-id "$subnet_id" --query data 2>/dev/null || true)"
+  subnet_route_table="$(python3 - <<'PY' "$subnet_json"
+import json
+import sys
+payload = json.loads(sys.argv[1]) if sys.argv[1] else {}
+print(payload.get("route-table-id", ""))
+PY
+)"
+  subnet_prohibit_public="$(python3 - <<'PY' "$subnet_json"
+import json
+import sys
+payload = json.loads(sys.argv[1]) if sys.argv[1] else {}
+val = payload.get("prohibit-public-ip-on-vnic")
+print("true" if val is True else "false")
+PY
+)"
+
+  if [[ "$subnet_route_table" != "$route_table_id" || "$subnet_prohibit_public" != "$expected_prohibit_public" ]]; then
+    run_confirmed "Update subnet '$SUBNET_NAME' to match selected topology" "oci network subnet update --subnet-id '$subnet_id' --route-table-id '$route_table_id' --prohibit-public-ip-on-vnic $expected_prohibit_public --force" oci network subnet update --subnet-id "$subnet_id" --route-table-id "$route_table_id" --prohibit-public-ip-on-vnic "$expected_prohibit_public" --force
+  else
+    log_ok "Reusing compatible subnet: $SUBNET_NAME"
+  fi
+fi
+
+if [[ -z "$subnet_id" || "$subnet_id" == "null" || "$subnet_id" == "None" ]]; then
+  echo "[ERROR] Subnet '$SUBNET_NAME' could not be resolved after create/update." >&2
+  exit 4
+fi
+
+subnet_json="$(oci network subnet get --subnet-id "$subnet_id" --query data)"
+security_list_ids_csv="$(python3 - <<'PY' "$subnet_json"
+import json
+import sys
+payload = json.loads(sys.argv[1])
+print(",".join(payload.get("security-list-ids") or []))
+PY
+)"
+
+if [[ -z "$security_list_ids_csv" ]]; then
+  echo "[ERROR] Subnet has no security lists attached; cannot validate egress rules." >&2
+  exit 4
+fi
+
+primary_security_list_id="${security_list_ids_csv%%,*}"
+
+if [[ "$TOPOLOGY" == "public" ]]; then
+  egress_destination="0.0.0.0/0"
+  egress_destination_type="CIDR_BLOCK"
+else
+  egress_destination="$service_cidr"
+  egress_destination_type="SERVICE_CIDR_BLOCK"
+fi
+
+egress_rules_json="$(oci network security-list get --security-list-id "$primary_security_list_id" --query 'data."egress-security-rules"' --raw-output)"
+rule_present="$(python3 - <<'PY' "$egress_rules_json" "$egress_destination" "$egress_destination_type"
+import json
+import sys
+rules = json.loads(sys.argv[1]) if sys.argv[1] else []
+destination = sys.argv[2]
+destination_type = sys.argv[3]
+
+def g(obj, *keys):
+    for k in keys:
+        if isinstance(obj, dict) and k in obj:
+            return obj[k]
+    return None
+
+def allows_required_egress(rule):
+    proto = str(g(rule, "protocol") or "").lower()
+    if proto == "all":
+        return True
+    if proto != "6":
+        return False
+
+    opts = g(rule, "tcpOptions", "tcp-options")
+    if not opts:
+        return True
+
+    pr = g(opts, "destinationPortRange", "destination-port-range") or {}
+    min_port = g(pr, "min")
+    max_port = g(pr, "max")
+    if min_port is None or max_port is None:
+        return True
+    return int(min_port) <= 443 <= int(max_port)
+
+for rule in rules:
+    if g(rule, "destination") != destination:
+        continue
+    if g(rule, "destinationType", "destination-type") != destination_type:
+        continue
+    if allows_required_egress(rule):
+        print("yes")
+        break
+else:
+    print("no")
+PY
+)"
+
+if [[ "$rule_present" != "yes" ]]; then
+  updated_rules_json="$(python3 - <<'PY' "$egress_rules_json" "$egress_destination" "$egress_destination_type"
+import json
+import sys
+rules = json.loads(sys.argv[1]) if sys.argv[1] else []
+destination = sys.argv[2]
+destination_type = sys.argv[3]
+rules.append({
+    "destination": destination,
+    "destinationType": destination_type,
+    "isStateless": False,
+    "protocol": "6",
+    "tcpOptions": {
+        "destinationPortRange": {
+            "min": 443,
+            "max": 443,
+        }
+    }
+})
+print(json.dumps(rules, separators=(",", ":")))
+PY
+)"
+  run_confirmed "Add egress TCP/443 rule for registry access on security list" "oci network security-list update --security-list-id '$primary_security_list_id' --egress-security-rules '$updated_rules_json' --force" oci network security-list update --security-list-id "$primary_security_list_id" --egress-security-rules "$updated_rules_json" --force
+else
+  log_ok "Security list already allows required registry/service egress."
+fi
+
+emit_kv network_state found
+emit_kv vcn_id "$vcn_id"
+emit_kv subnet_id "$subnet_id"

--- a/oci/functions/oci-functions-deploy/scripts/install_fn_linux.sh
+++ b/oci/functions/oci-functions-deploy/scripts/install_fn_linux.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/common.sh"
+
+VERSION=""
+ASSET_URL=""
+EXPECTED_DIGEST=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      VERSION="${2:-}"
+      shift 2
+      ;;
+    --asset-url)
+      ASSET_URL="${2:-}"
+      shift 2
+      ;;
+    --sha256)
+      EXPECTED_DIGEST="${2:-}"
+      shift 2
+      ;;
+    *)
+      printf 'Unknown argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$VERSION" && -z "$ASSET_URL" && -z "$EXPECTED_DIGEST" ]]; then
+  resolve_latest_fn_linux_release VERSION ASSET_URL EXPECTED_DIGEST
+elif [[ -z "$VERSION" || -z "$ASSET_URL" || -z "$EXPECTED_DIGEST" ]]; then
+  printf '[ERROR] --version, --asset-url, and --sha256 must be supplied together.\n' >&2
+  exit 1
+fi
+
+if [[ ! "$VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  printf '[ERROR] Invalid Fn CLI release version.\n' >&2
+  exit 1
+fi
+if [[ "$ASSET_URL" != "https://github.com/fnproject/cli/releases/download/$VERSION/fn_linux" ]]; then
+  printf '[ERROR] Refusing a non-canonical Fn CLI asset URL.\n' >&2
+  exit 1
+fi
+if [[ ! "$EXPECTED_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  printf '[ERROR] Invalid Fn CLI SHA-256 digest.\n' >&2
+  exit 1
+fi
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  printf '[ERROR] install_fn_linux.sh only supports Linux.\n' >&2
+  exit 1
+fi
+case "$(uname -m)" in
+  x86_64|amd64) ;;
+  *)
+    printf '[ERROR] The verified fn_linux release asset only supports Linux x86-64.\n' >&2
+    exit 1
+    ;;
+esac
+
+tmp_file="$(mktemp)"
+trap 'rm -f "$tmp_file"' EXIT
+
+curl \
+  --proto '=https' \
+  --proto-redir '=https' \
+  --tlsv1.2 \
+  --fail \
+  --silent \
+  --show-error \
+  --location \
+  --connect-timeout 10 \
+  --max-time 120 \
+  --retry 2 \
+  --output "$tmp_file" \
+  "$ASSET_URL"
+
+actual_hash=""
+if command -v sha256sum >/dev/null 2>&1; then
+  actual_hash="$(sha256sum "$tmp_file" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  actual_hash="$(shasum -a 256 "$tmp_file" | awk '{print $1}')"
+else
+  printf '[ERROR] A SHA-256 verification tool (sha256sum or shasum) is required.\n' >&2
+  exit 1
+fi
+
+if [[ "sha256:$actual_hash" != "$EXPECTED_DIGEST" ]]; then
+  printf '[ERROR] Fn CLI asset SHA-256 verification failed.\n' >&2
+  exit 1
+fi
+
+chmod 0755 "$tmp_file"
+version_output="$("$tmp_file" --version 2>&1)" || {
+  printf '[ERROR] Downloaded Fn CLI asset failed its version check.\n' >&2
+  exit 1
+}
+expected_version="${VERSION#v}"
+escaped_version="${expected_version//./\\.}"
+if ! grep -Eq "(^|[^0-9])${escaped_version}([^0-9]|$)" <<<"$version_output"; then
+  printf '[ERROR] Downloaded Fn CLI version does not match the approved release.\n' >&2
+  exit 1
+fi
+
+install_args=(install -m 0755 "$tmp_file" /usr/local/bin/fn)
+if [[ "$(id -u)" -eq 0 ]]; then
+  "${install_args[@]}"
+elif command -v sudo >/dev/null 2>&1; then
+  sudo "${install_args[@]}"
+else
+  printf '[ERROR] Root privileges or sudo are required to install Fn CLI.\n' >&2
+  exit 1
+fi
+
+printf '[OK] Installed Fn CLI release %s after SHA-256 and version verification.\n' "$VERSION"

--- a/oci/functions/oci-functions-deploy/scripts/install_missing.sh
+++ b/oci/functions/oci-functions-deploy/scripts/install_missing.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIRM="$SCRIPT_DIR/confirm_gate.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/common.sh"
+
+TOOL=""
+OS_NAME=""
+PKG_MGR=""
+MACHINE_READABLE="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tool)
+      TOOL="${2:-}"
+      shift 2
+      ;;
+    --os)
+      OS_NAME="${2:-}"
+      shift 2
+      ;;
+    --machine-readable)
+      # Used by common.sh:is_machine_readable after argument parsing.
+      # shellcheck disable=SC2034
+      MACHINE_READABLE="true"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$TOOL" ]]; then
+  echo "Usage: $0 --tool <fn|oci|docker|java|mvn|python3|node|npm|docker-daemon> [--os <darwin|linux>]" >&2
+  exit 1
+fi
+
+if [[ -z "$OS_NAME" ]]; then
+  case "$(uname -s)" in
+    Darwin) OS_NAME="darwin" ;;
+    Linux) OS_NAME="linux" ;;
+    CYGWIN*|MINGW*|MSYS*) OS_NAME="windows" ;;
+    *)
+      emit_kv install_state error
+      emit_kv install_error_reason unsupported_os
+      echo "Unsupported OS. Provide --os explicitly (darwin|linux)." >&2
+      exit 1
+      ;;
+  esac
+fi
+
+if [[ "$OS_NAME" == "windows" ]]; then
+  emit_kv install_state error
+  emit_kv install_error_reason unsupported_os
+  echo "[ERROR] Windows installation automation is not supported by this skill." >&2
+  echo "[HINT] Install fn, oci-cli, docker, and runtime tools manually before continuing." >&2
+  exit 1
+fi
+
+detect_linux_pkg_mgr() {
+  if command -v apt-get >/dev/null 2>&1; then
+    echo "apt"
+    return
+  fi
+  if command -v dnf >/dev/null 2>&1; then
+    echo "dnf"
+    return
+  fi
+  if command -v yum >/dev/null 2>&1; then
+    echo "yum"
+    return
+  fi
+  if command -v zypper >/dev/null 2>&1; then
+    echo "zypper"
+    return
+  fi
+  echo ""
+}
+
+linux_pkg_install_cmd() {
+  local packages="$1"
+  case "$PKG_MGR" in
+    apt) echo "sudo apt-get update && sudo apt-get install -y $packages" ;;
+    dnf) echo "sudo dnf install -y $packages" ;;
+    yum) echo "sudo yum install -y $packages" ;;
+    zypper) echo "sudo zypper --non-interactive install $packages" ;;
+    *)
+      echo ""
+      ;;
+  esac
+}
+
+run_confirmed() {
+  local description="$1"
+  local display="$2"
+  shift 2
+
+  local nonce
+  local confirm_args=()
+  nonce="$(next_confirm_nonce)"
+  if is_machine_readable; then
+    confirm_args+=(--machine-readable)
+  fi
+  "$CONFIRM" --description "$description" --display "$display" "${confirm_args[@]}" --nonce "$nonce" -- "$@"
+}
+
+if [[ "$OS_NAME" == "linux" ]]; then
+  PKG_MGR="$(detect_linux_pkg_mgr)"
+fi
+
+has_brew="no"
+if [[ "$OS_NAME" == "darwin" ]] && command -v brew >/dev/null 2>&1; then
+  has_brew="yes"
+fi
+
+install_method=""
+display_command=""
+case "$OS_NAME:$TOOL" in
+  darwin:fn) install_method="brew" ;;
+  darwin:oci) install_method="brew" ;;
+  darwin:docker) install_method="brew_cask" ;;
+  darwin:java) install_method="brew" ;;
+  darwin:mvn) install_method="brew" ;;
+  darwin:python3) install_method="brew" ;;
+  darwin:node) install_method="brew" ;;
+  darwin:npm) install_method="brew" ;;
+  darwin:docker-daemon) install_method="app_start" ;;
+
+  linux:fn) install_method="verified_release" ;;
+  linux:oci)
+    if [[ -n "$PKG_MGR" ]]; then
+      install_method="pkg_plus_pip"
+    else
+      install_method="pip"
+    fi
+    ;;
+  linux:docker)
+    case "$PKG_MGR" in
+      apt|dnf|yum|zypper) install_method="pkg" ;;
+      *) install_method="" ;;
+    esac
+    ;;
+  linux:java)
+    case "$PKG_MGR" in
+      apt|dnf|yum|zypper) install_method="pkg" ;;
+      *) install_method="" ;;
+    esac
+    ;;
+  linux:mvn) install_method="pkg" ;;
+  linux:python3) install_method="pkg" ;;
+  linux:node) install_method="pkg" ;;
+  linux:npm) install_method="pkg" ;;
+  linux:docker-daemon) install_method="service_start" ;;
+
+  *)
+    emit_kv install_state error
+    emit_kv install_error_reason unsupported_os
+    echo "No installer mapping for $OS_NAME:$TOOL" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$OS_NAME" == "darwin" && "$install_method" != "app_start" && "$has_brew" != "yes" ]]; then
+  emit_kv install_state error
+  emit_kv install_error_reason missing_package_manager
+  echo "[ERROR] Homebrew is required for automated installation on macOS, but it was not found." >&2
+  echo "[HINT] Install Homebrew or install '$TOOL' manually, then rerun preflight checks." >&2
+  exit 1
+fi
+
+if [[ -z "$install_method" ]]; then
+  emit_kv install_state error
+  emit_kv install_error_reason unsupported_package_manager
+  echo "[ERROR] No installer command for $OS_NAME:$TOOL with package manager '${PKG_MGR:-none}'." >&2
+  echo "[HINT] Install '$TOOL' manually, then rerun preflight checks." >&2
+  exit 1
+fi
+
+case "$OS_NAME:$TOOL:$install_method" in
+  darwin:fn:brew)
+    display_command="brew install fn"
+    run_confirmed "Install/fix '$TOOL' on '$OS_NAME'" "$display_command" brew install fn
+    ;;
+  darwin:oci:brew)
+    display_command="brew install oci-cli"
+    run_confirmed "Install/fix '$TOOL' on '$OS_NAME'" "$display_command" brew install oci-cli
+    ;;
+  darwin:docker:brew_cask)
+    display_command="brew install --cask docker"
+    run_confirmed "Install/fix '$TOOL' on '$OS_NAME'" "$display_command" brew install --cask docker
+    ;;
+  darwin:java:brew)
+    display_command="brew install openjdk@17"
+    run_confirmed "Install/fix '$TOOL' on '$OS_NAME'" "$display_command" brew install openjdk@17
+    ;;
+  darwin:mvn:brew)
+    display_command="brew install maven"
+    run_confirmed "Install/fix '$TOOL' on '$OS_NAME'" "$display_command" brew install maven
+    ;;
+  darwin:python3:brew)
+    display_command="brew install python"
+    run_confirmed "Install/fix '$TOOL' on '$OS_NAME'" "$display_command" brew install python
+    ;;
+  darwin:node:brew|darwin:npm:brew)
+    display_command="brew install node"
+    run_confirmed "Install/fix '$TOOL' on '$OS_NAME'" "$display_command" brew install node
+    ;;
+  darwin:docker-daemon:app_start)
+    display_command="open -a Docker"
+    run_confirmed "Install/fix '$TOOL' on '$OS_NAME'" "$display_command" open -a Docker
+    ;;
+  linux:fn:verified_release)
+    fn_release_version=""
+    fn_release_url=""
+    fn_release_digest=""
+    if ! resolve_latest_fn_linux_release fn_release_version fn_release_url fn_release_digest; then
+      emit_kv install_state error
+      emit_kv install_error_reason release_metadata_validation_failed
+      exit 4
+    fi
+    display_command="scripts/install_fn_linux.sh --version '$fn_release_version' --asset-url '$fn_release_url' --sha256 '$fn_release_digest'"
+    run_confirmed \
+      "Install/fix '$TOOL' on '$OS_NAME' using verified Fn CLI release '$fn_release_version' with digest '$fn_release_digest'" \
+      "$display_command" \
+      "$SCRIPT_DIR/install_fn_linux.sh" \
+      --version "$fn_release_version" \
+      --asset-url "$fn_release_url" \
+      --sha256 "$fn_release_digest"
+    ;;
+  linux:oci:pkg_plus_pip)
+    display_command="$(linux_pkg_install_cmd "python3 python3-pip")"
+    run_confirmed "Install/fix '$TOOL' on '$OS_NAME'" "$display_command" "$SCRIPT_DIR/run_linux_pkg_install.sh" --pkg-manager "$PKG_MGR" --packages "python3 python3-pip"
+    display_command="python3 -m pip install --upgrade oci-cli"
+    run_confirmed "Install/fix '$TOOL' on '$OS_NAME'" "$display_command" python3 -m pip install --upgrade oci-cli
+    ;;
+  linux:oci:pip)
+    display_command="python3 -m pip install --upgrade oci-cli"
+    run_confirmed "Install/fix '$TOOL' on '$OS_NAME'" "$display_command" python3 -m pip install --upgrade oci-cli
+    ;;
+  linux:docker:pkg)
+    case "$PKG_MGR" in
+      apt) display_command="$(linux_pkg_install_cmd "docker.io")" ;;
+      dnf|yum|zypper) display_command="$(linux_pkg_install_cmd "docker")" ;;
+    esac
+    case "$PKG_MGR" in
+      apt) run_confirmed "Install/fix '$TOOL' on '$OS_NAME'" "$display_command" "$SCRIPT_DIR/run_linux_pkg_install.sh" --pkg-manager "$PKG_MGR" --packages "docker.io" ;;
+      dnf|yum|zypper) run_confirmed "Install/fix '$TOOL' on '$OS_NAME'" "$display_command" "$SCRIPT_DIR/run_linux_pkg_install.sh" --pkg-manager "$PKG_MGR" --packages "docker" ;;
+    esac
+    ;;
+  linux:java:pkg)
+    case "$PKG_MGR" in
+      apt) display_command="$(linux_pkg_install_cmd "openjdk-17-jdk")" ;;
+      dnf|yum|zypper) display_command="$(linux_pkg_install_cmd "java-17-openjdk-devel")" ;;
+    esac
+    case "$PKG_MGR" in
+      apt) run_confirmed "Install/fix '$TOOL' on '$OS_NAME'" "$display_command" "$SCRIPT_DIR/run_linux_pkg_install.sh" --pkg-manager "$PKG_MGR" --packages "openjdk-17-jdk" ;;
+      dnf|yum|zypper) run_confirmed "Install/fix '$TOOL' on '$OS_NAME'" "$display_command" "$SCRIPT_DIR/run_linux_pkg_install.sh" --pkg-manager "$PKG_MGR" --packages "java-17-openjdk-devel" ;;
+    esac
+    ;;
+  linux:mvn:pkg)
+    display_command="$(linux_pkg_install_cmd "maven")"
+    run_confirmed "Install/fix '$TOOL' on '$OS_NAME'" "$display_command" "$SCRIPT_DIR/run_linux_pkg_install.sh" --pkg-manager "$PKG_MGR" --packages "maven"
+    ;;
+  linux:python3:pkg)
+    display_command="$(linux_pkg_install_cmd "python3 python3-pip")"
+    run_confirmed "Install/fix '$TOOL' on '$OS_NAME'" "$display_command" "$SCRIPT_DIR/run_linux_pkg_install.sh" --pkg-manager "$PKG_MGR" --packages "python3 python3-pip"
+    ;;
+  linux:node:pkg|linux:npm:pkg)
+    display_command="$(linux_pkg_install_cmd "nodejs npm")"
+    run_confirmed "Install/fix '$TOOL' on '$OS_NAME'" "$display_command" "$SCRIPT_DIR/run_linux_pkg_install.sh" --pkg-manager "$PKG_MGR" --packages "nodejs npm"
+    ;;
+  linux:docker-daemon:service_start)
+    display_command="sudo systemctl start docker"
+    run_confirmed "Install/fix '$TOOL' on '$OS_NAME'" "$display_command" sudo systemctl start docker
+    ;;
+  *)
+    emit_kv install_state error
+    emit_kv install_error_reason unsupported_install_method
+    echo "[ERROR] No executable install path for $OS_NAME:$TOOL." >&2
+    exit 1
+    ;;
+esac
+
+if [[ "$TOOL" == "docker-daemon" ]]; then
+  if docker info >/dev/null 2>&1; then
+    log_ok "Docker daemon is running"
+    emit_kv install_state success
+    emit_kv install_method "$install_method"
+  else
+    emit_kv install_state error
+    emit_kv install_error_reason verification_failed
+    echo "[ERROR] Docker daemon still not running" >&2
+    exit 2
+  fi
+  exit 0
+fi
+
+verify_tool="$TOOL"
+if [[ "$TOOL" == "java" ]]; then
+  verify_tool="java"
+fi
+if [[ "$TOOL" == "python3" ]]; then
+  verify_tool="python3"
+fi
+if [[ "$TOOL" == "npm" ]]; then
+  verify_tool="npm"
+fi
+
+if command -v "$verify_tool" >/dev/null 2>&1; then
+  log_ok "Verified '$verify_tool' is installed"
+  emit_kv install_state success
+  emit_kv install_method "$install_method"
+else
+  emit_kv install_state error
+  emit_kv install_error_reason verification_failed
+  echo "[ERROR] '$verify_tool' is still missing after install" >&2
+  exit 2
+fi

--- a/oci/functions/oci-functions-deploy/scripts/preflight_check.sh
+++ b/oci/functions/oci-functions-deploy/scripts/preflight_check.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/common.sh"
+
+RUNTIME=""
+PROFILE_FALLBACK=""
+STRICT="false"
+MACHINE_READABLE="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --runtime)
+      RUNTIME="${2:-}"
+      shift 2
+      ;;
+    --profile)
+      PROFILE_FALLBACK="${2:-}"
+      shift 2
+      ;;
+    --strict)
+      STRICT="true"
+      shift
+      ;;
+    --machine-readable)
+      # Used by common.sh:is_machine_readable after argument parsing.
+      # shellcheck disable=SC2034
+      MACHINE_READABLE="true"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+missing=()
+warns=()
+
+check_cmd() {
+  local name="$1"
+  local state_key
+  state_key="$(printf '%s' "$name" | tr '[:upper:]-' '[:lower:]_')"
+  if command -v "$name" >/dev/null 2>&1; then
+    local ver
+    ver="$($name --version 2>/dev/null | head -n 1 || true)"
+    log_ok "$name found${ver:+: $ver}"
+    emit_kv "dependency_${state_key}_state" found
+  else
+    log_missing "$name"
+    emit_kv "dependency_${state_key}_state" missing
+    missing+=("$name")
+  fi
+}
+
+parse_fn_context() {
+  FN_CONTEXT_NAME=""
+  FN_CONTEXT_PROVIDER=""
+  FN_CONTEXT_PROFILE=""
+  FN_CONTEXT_COMPARTMENT_ID=""
+  FN_CONTEXT_API_URL=""
+  FN_CONTEXT_REGISTRY=""
+  FN_CONTEXT_IMAGE_COMPARTMENT_ID=""
+
+  local context_out
+  context_out="$(fn inspect context 2>/dev/null || fn list context 2>/dev/null || true)"
+  [[ -n "$context_out" ]] || return 1
+
+  FN_CONTEXT_NAME="$(awk -F': ' '/^Current context:/ {print $2; exit}' <<<"$context_out" || true)"
+  FN_CONTEXT_PROVIDER="$(awk -F': ' '/^provider:/ {print $2; exit}' <<<"$context_out" || true)"
+  FN_CONTEXT_PROFILE="$(awk -F': ' '/^oracle.profile:/ {print $2; exit}' <<<"$context_out" || true)"
+  FN_CONTEXT_COMPARTMENT_ID="$(awk -F': ' '/^oracle.compartment-id:/ {print $2; exit}' <<<"$context_out" || true)"
+  FN_CONTEXT_API_URL="$(awk -F': ' '/^api-url:/ {print $2; exit}' <<<"$context_out" || true)"
+  FN_CONTEXT_REGISTRY="$(awk -F': ' '/^registry:/ {print $2; exit}' <<<"$context_out" || true)"
+  FN_CONTEXT_IMAGE_COMPARTMENT_ID="$(awk -F': ' '/^oracle.image-compartment-id:/ {print $2; exit}' <<<"$context_out" || true)"
+  return 0
+}
+
+
+log_section "Phase 1: Dependency availability"
+check_cmd fn
+check_cmd oci
+check_cmd docker
+
+human_out ""
+log_section "Runtime-specific tools"
+case "$RUNTIME" in
+  java)
+    check_cmd java
+    check_cmd mvn
+    ;;
+  python)
+    check_cmd python3
+    ;;
+  node)
+    check_cmd node
+    check_cmd npm
+    ;;
+  "")
+    log_info "No runtime supplied; skipping runtime-specific checks."
+    ;;
+  *)
+    log_warn "Unsupported runtime '$RUNTIME' (expected java|python|node)."
+    warns+=("runtime:$RUNTIME")
+    ;;
+esac
+
+human_out ""
+log_section "Docker daemon"
+if command -v docker >/dev/null 2>&1; then
+  if docker info >/dev/null 2>&1; then
+    log_ok "Docker daemon is running"
+    emit_kv docker_daemon_state running
+  else
+    log_warn "Docker installed but daemon is not running"
+    emit_kv docker_daemon_state stopped
+    warns+=("docker-daemon")
+  fi
+else
+  emit_kv docker_daemon_state missing
+fi
+
+human_out ""
+log_section "Phase 2: Fn context validation"
+FN_CONTEXT_NAME=""
+FN_CONTEXT_PROVIDER=""
+FN_CONTEXT_PROFILE=""
+FN_CONTEXT_COMPARTMENT_ID=""
+FN_CONTEXT_API_URL=""
+FN_CONTEXT_REGISTRY=""
+FN_CONTEXT_IMAGE_COMPARTMENT_ID=""
+if command -v fn >/dev/null 2>&1 && parse_fn_context; then
+  emit_kv fn_context_name "${FN_CONTEXT_NAME:-}"
+  emit_kv fn_context_provider "${FN_CONTEXT_PROVIDER:-}"
+  emit_kv fn_context_profile "${FN_CONTEXT_PROFILE:-}"
+  emit_kv fn_context_compartment_id "${FN_CONTEXT_COMPARTMENT_ID:-}"
+  emit_kv fn_context_api_url "${FN_CONTEXT_API_URL:-}"
+  emit_kv fn_context_registry "${FN_CONTEXT_REGISTRY:-}"
+  emit_kv fn_context_image_compartment_id "${FN_CONTEXT_IMAGE_COMPARTMENT_ID:-}"
+
+  missing_fn_keys=()
+  [[ -n "$FN_CONTEXT_COMPARTMENT_ID" ]] || missing_fn_keys+=("oracle.compartment-id")
+  [[ -n "$FN_CONTEXT_PROFILE" ]] || missing_fn_keys+=("oracle.profile")
+  [[ -n "$FN_CONTEXT_API_URL" ]] || missing_fn_keys+=("api-url")
+  [[ -n "$FN_CONTEXT_REGISTRY" ]] || missing_fn_keys+=("registry")
+
+  if [[ -z "$FN_CONTEXT_PROVIDER" || "$FN_CONTEXT_PROVIDER" != "oracle" ]]; then
+    log_warn "Active Fn context is missing or not using provider 'oracle'"
+    warns+=("fn-context:provider")
+  fi
+
+  if [[ ${#missing_fn_keys[@]} -eq 0 && -n "$FN_CONTEXT_NAME" ]]; then
+    log_ok "Fn context is defined and contains the required values"
+    emit_kv fn_context_state found
+  elif [[ -n "$FN_CONTEXT_NAME" || -n "$FN_CONTEXT_PROVIDER" || -n "$FN_CONTEXT_API_URL" || -n "$FN_CONTEXT_REGISTRY" || -n "$FN_CONTEXT_PROFILE" || -n "$FN_CONTEXT_COMPARTMENT_ID" ]]; then
+    log_warn "Fn context exists but is incomplete"
+    emit_kv fn_context_state incomplete
+    emit_kv fn_context_missing_keys "${missing_fn_keys[*]:-provider}"
+    warns+=("fn-context:incomplete")
+  else
+    log_warn "No active Fn context was discovered"
+    emit_kv fn_context_state missing
+    warns+=("fn-context:missing")
+  fi
+else
+  log_warn "No active Fn context was discovered"
+  emit_kv fn_context_state missing
+  warns+=("fn-context:missing")
+fi
+
+human_out ""
+log_section "OCI CLI session validation"
+resolved_profile=""
+if [[ -n "$PROFILE_FALLBACK" ]]; then
+  resolved_profile="$PROFILE_FALLBACK"
+  emit_kv oci_profile_source explicit_flag
+elif [[ -n "$FN_CONTEXT_PROFILE" ]]; then
+  resolved_profile="$FN_CONTEXT_PROFILE"
+  emit_kv oci_profile_source fn_context
+else
+  emit_kv oci_profile_source missing
+fi
+emit_kv oci_profile "${resolved_profile:-}"
+
+if command -v oci >/dev/null 2>&1; then
+  if [[ -f "$HOME/.oci/config" ]]; then
+    log_ok "OCI config exists at $HOME/.oci/config"
+  else
+    log_warn "OCI config not found at $HOME/.oci/config"
+    warns+=("oci-config")
+  fi
+
+  if [[ -n "$resolved_profile" ]]; then
+    oci_err=""
+    if run_oci_capture _oci_out oci_err iam region list --profile "$resolved_profile" --all; then
+      log_ok "OCI profile '$resolved_profile' validated successfully"
+      emit_kv oci_auth_state valid
+      emit_kv oci_auth_mode default
+    else
+      retry_succeeded="no"
+      if grep -Eiq 'security[_ -]?token|session token|token-based profile|must use.*security_token|use.*security_token|OCI_CLI_AUTH=security_token' <<<"$oci_err"; then
+        emit_kv oci_auth_retry_state available
+        if is_interactive; then
+          read -r -p "OCI profile '$resolved_profile' may require security_token auth. Retry validation with security_token? [y/N]: " retry_reply
+          case "$(normalize_reply "$retry_reply")" in
+            y|yes)
+              if OCI_CLI_AUTH=security_token run_oci_capture _retry_out _retry_err iam region list --profile "$resolved_profile" --all; then
+                log_ok "OCI profile '$resolved_profile' validated with security_token auth"
+                emit_kv oci_auth_state valid
+                emit_kv oci_auth_mode security_token
+                retry_succeeded="yes"
+              else
+                log_warn "OCI profile '$resolved_profile' still failed with security_token auth"
+                emit_kv oci_auth_retry_state failed
+                warns+=("oci-profile:$resolved_profile")
+              fi
+              ;;
+            *)
+              emit_kv oci_auth_retry_state declined
+              warns+=("oci-profile:$resolved_profile")
+              ;;
+          esac
+        else
+          emit_kv oci_auth_retry_state approval_required
+          warns+=("oci-profile:$resolved_profile")
+        fi
+      fi
+
+      if [[ "$retry_succeeded" != "yes" ]]; then
+        log_warn "OCI profile '$resolved_profile' could not be validated"
+        emit_kv oci_auth_state error
+        emit_kv oci_auth_error_reason "$(classify_oci_error_reason "$oci_err")"
+        emit_kv oci_auth_error "$(tr '\n' ' ' <<<"$oci_err" | sed 's/[[:space:]]\+/ /g')"
+        warns+=("oci-profile:$resolved_profile")
+      fi
+    fi
+  else
+    log_warn "No OCI profile could be resolved from Fn context"
+    emit_kv oci_auth_state missing
+    warns+=("oci-profile:missing")
+  fi
+fi
+
+human_out ""
+log_section "Docker registry validation"
+registry_host=""
+if [[ -n "$FN_CONTEXT_REGISTRY" ]]; then
+  registry_host="${FN_CONTEXT_REGISTRY%%/*}"
+  emit_kv docker_registry_host "$registry_host"
+  registry_auth_state="$(docker_registry_auth_probe "$registry_host")"
+  case "$registry_auth_state" in
+    valid)
+      log_ok "Docker registry auth for '$registry_host' was validated live"
+      emit_kv docker_registry_auth_state valid
+      emit_kv docker_registry_auth_probe_state valid
+      ;;
+    cached)
+      log_warn "Docker has cached auth for '$registry_host', but live validation did not confirm it"
+      emit_kv docker_registry_auth_state cached
+      emit_kv docker_registry_auth_probe_state cached
+      warns+=("docker-auth:$registry_host")
+      ;;
+    error)
+      emit_kv docker_registry_auth_state error
+      emit_kv docker_registry_auth_probe_state error
+      emit_kv docker_registry_auth_error_reason runtime_or_cli
+      warns+=("docker-auth:$registry_host")
+      ;;
+    *)
+      log_warn "Docker is not logged in to '$registry_host'"
+      emit_kv docker_registry_auth_state missing
+      emit_kv docker_registry_auth_probe_state missing
+      warns+=("docker-auth:$registry_host")
+      ;;
+  esac
+else
+  log_warn "Fn context does not define a registry yet"
+  emit_kv docker_registry_auth_state missing
+  emit_kv docker_registry_auth_probe_state missing
+  warns+=("docker-auth:registry-missing")
+fi
+
+human_out ""
+log_section "Summary"
+if [[ ${#missing[@]} -eq 0 ]]; then
+  human_out "Missing tools: none"
+else
+  human_out "Missing tools: ${missing[*]}"
+fi
+if [[ ${#warns[@]} -eq 0 ]]; then
+  human_out "Warnings: none"
+else
+  human_out "Warnings: ${warns[*]}"
+fi
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  exit 2
+fi
+
+if [[ "$STRICT" == "true" && ${#warns[@]} -gt 0 ]]; then
+  exit 3
+fi

--- a/oci/functions/oci-functions-deploy/scripts/run_linux_pkg_install.sh
+++ b/oci/functions/oci-functions-deploy/scripts/run_linux_pkg_install.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PKG_MGR=""
+PACKAGES=""
+RUN_UPDATE="auto"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pkg-manager)
+      PKG_MGR="${2:-}"
+      shift 2
+      ;;
+    --packages)
+      PACKAGES="${2:-}"
+      shift 2
+      ;;
+    --run-update)
+      RUN_UPDATE="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$PKG_MGR" || -z "$PACKAGES" ]]; then
+  echo "Usage: $0 --pkg-manager <apt|dnf|yum|zypper> --packages \"pkg1 pkg2\" [--run-update <auto|yes|no>]" >&2
+  exit 1
+fi
+
+read -r -a package_argv <<<"$PACKAGES"
+
+case "$PKG_MGR" in
+  apt)
+    if [[ "$RUN_UPDATE" != "no" ]]; then
+      sudo apt-get update
+    fi
+    sudo apt-get install -y "${package_argv[@]}"
+    ;;
+  dnf)
+    sudo dnf install -y "${package_argv[@]}"
+    ;;
+  yum)
+    sudo yum install -y "${package_argv[@]}"
+    ;;
+  zypper)
+    sudo zypper --non-interactive install "${package_argv[@]}"
+    ;;
+  *)
+    echo "Unsupported package manager: $PKG_MGR" >&2
+    exit 1
+    ;;
+esac

--- a/oci/functions/oci-functions-deploy/tests/test_skill_contract.sh
+++ b/oci/functions/oci-functions-deploy/tests/test_skill_contract.sh
@@ -1,0 +1,985 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$TEST_DIR/.." && pwd)"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+run_capture() {
+  local __stdout_var="$1"
+  local __stderr_var="$2"
+  local __status_var="$3"
+  shift 3
+
+  local stdout_file
+  local stderr_file
+  local capture_status
+
+  stdout_file="$(mktemp)"
+  stderr_file="$(mktemp)"
+  if "$@" >"$stdout_file" 2>"$stderr_file"; then
+    capture_status=0
+  else
+    capture_status=$?
+  fi
+
+  printf -v "$__stdout_var" "%s" "$(cat "$stdout_file")"
+  printf -v "$__stderr_var" "%s" "$(cat "$stderr_file")"
+  printf -v "$__status_var" "%s" "$capture_status"
+  rm -f "$stdout_file" "$stderr_file"
+}
+
+fail_test() {
+  local name="$1"
+  local message="$2"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  printf 'not ok - %s: %s\n' "$name" "$message"
+}
+
+pass_test() {
+  local name="$1"
+  PASS_COUNT=$((PASS_COUNT + 1))
+  printf 'ok - %s\n' "$name"
+}
+
+assert_contains() {
+  local haystack="$1"
+  local needle="$2"
+  grep -Fq -- "$needle" <<<"$haystack"
+}
+
+assert_kv_only() {
+  local text="$1"
+  local line=""
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    [[ "$line" =~ ^[a-z0-9_]+=.*$ ]] || return 1
+  done <<<"$text"
+}
+
+make_stub_env() {
+  local root="$1"
+  mkdir -p "$root/bin" "$root/home/.docker"
+
+  cat >"$root/bin/fn" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  inspect)
+    if [[ "${2:-}" == "context" ]]; then
+      cat <<'CTX'
+Current context: ctx
+provider: oracle
+oracle.profile: ctxprofile
+oracle.compartment-id: ocid1.compartment.oc1..ctx
+api-url: https://functions.us-phoenix-1.oci.oraclecloud.com
+registry: phx.ocir.io/namespace/repo
+oracle.image-compartment-id: ocid1.compartment.oc1..images
+CTX
+      exit 0
+    fi
+    ;;
+  list)
+    if [[ "${2:-}" == "context" ]]; then
+      cat <<'CTX'
+Current context: ctx
+provider: oracle
+oracle.profile: ctxprofile
+oracle.compartment-id: ocid1.compartment.oc1..ctx
+api-url: https://functions.us-phoenix-1.oci.oraclecloud.com
+registry: phx.ocir.io/namespace/repo
+oracle.image-compartment-id: ocid1.compartment.oc1..images
+CTX
+      exit 0
+    fi
+    ;;
+  create)
+    exit 0
+    ;;
+  use)
+    exit 0
+    ;;
+  update)
+    exit 0
+    ;;
+  init)
+    : > func.yaml
+    printf 'initialized\n'
+    exit 0
+    ;;
+  -v)
+    if [[ "${2:-}" == "deploy" ]]; then
+      printf 'deployed\n'
+      exit 0
+    fi
+    ;;
+esac
+
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'fn version 0.6.32\n'
+  exit 0
+fi
+
+printf 'unsupported fn invocation: %s\n' "$*" >&2
+exit 1
+EOF
+
+  cat >"$root/bin/oci" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "iam" && "${2:-}" == "region" && "${3:-}" == "list" ]]; then
+  printf '[]\n'
+  exit 0
+fi
+
+if [[ "${1:-}" == "fn" && "${2:-}" == "application" && "${3:-}" == "list" ]]; then
+  printf '{"data":[{"display-name":"existing-app","id":"ocid1.fnapp.oc1..existing"}]}\n'
+  exit 0
+fi
+
+printf 'unsupported oci invocation: %s\n' "$*" >&2
+exit 1
+EOF
+
+  cat >"$root/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  --version)
+    printf 'Docker version 25.0.0\n'
+    ;;
+  info)
+    printf 'docker-info\n'
+    ;;
+  login)
+    printf 'login-ok\n'
+    ;;
+  *)
+    printf 'unsupported docker invocation: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+EOF
+
+  chmod +x "$root/bin/fn" "$root/bin/oci" "$root/bin/docker"
+
+  cat >"$root/home/.docker/config.json" <<'EOF'
+{
+  "auths": {
+    "phx.ocir.io": {
+      "auth": "dXNlcjp0b2tlbg=="
+    }
+  }
+}
+EOF
+}
+
+test_confirm_gate_contract() {
+  local name="confirm gate uppercase env + replay"
+  local temp_dir
+  local stdout=""
+  local stderr=""
+  local status=""
+  local action_id=""
+
+  temp_dir="$(mktemp -d)"
+  run_capture stdout stderr status \
+    env TMPDIR="$temp_dir" PATH="$PATH" \
+    "$SKILL_DIR/scripts/confirm_gate.sh" \
+    --description "test approval" \
+    --nonce "nonce-1" \
+    -- /usr/bin/true
+
+  [[ "$status" -eq 3 ]] || {
+    fail_test "$name" "expected initial unapproved status 3, got $status"
+    rm -rf "$temp_dir"
+    return
+  }
+
+  action_id="$(awk -F= '/^confirm_action_id=/{print $2}' <<<"$stdout")"
+  [[ -n "$action_id" ]] || {
+    fail_test "$name" "missing action id from initial probe"
+    rm -rf "$temp_dir"
+    return
+  }
+
+  run_capture stdout stderr status \
+    env TMPDIR="$temp_dir" PATH="$PATH" \
+    confirm_response=yes \
+    confirm_action_id="$action_id" \
+    confirm_nonce="nonce-1" \
+    "$SKILL_DIR/scripts/confirm_gate.sh" \
+    --description "test approval" \
+    --nonce "nonce-1" \
+    -- /usr/bin/true
+
+  if [[ "$status" -ne 3 ]] || ! assert_contains "$stdout" "confirm_state=skipped"; then
+    fail_test "$name" "lowercase env vars should be ignored"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  run_capture stdout stderr status \
+    env TMPDIR="$temp_dir" PATH="$PATH" \
+    CONFIRM_RESPONSE=yes \
+    CONFIRM_ACTION_ID="$action_id" \
+    CONFIRM_NONCE="nonce-1" \
+    "$SKILL_DIR/scripts/confirm_gate.sh" \
+    --description "test approval" \
+    --nonce "nonce-1" \
+    -- /usr/bin/true
+
+  if [[ "$status" -ne 0 ]] || ! assert_contains "$stdout" "confirm_state=approved"; then
+    fail_test "$name" "uppercase env vars should approve the command"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  run_capture stdout stderr status \
+    env TMPDIR="$temp_dir" PATH="$PATH" \
+    CONFIRM_RESPONSE=yes \
+    CONFIRM_ACTION_ID="$action_id" \
+    CONFIRM_NONCE="nonce-1" \
+    "$SKILL_DIR/scripts/confirm_gate.sh" \
+    --description "test approval" \
+    --nonce "nonce-1" \
+    -- /usr/bin/true
+
+  if [[ "$status" -ne 4 ]] || ! assert_contains "$stdout" "confirm_error_reason=already_consumed"; then
+    fail_test "$name" "replay should be rejected after a successful mutation"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  run_capture stdout stderr status \
+    env TMPDIR="$temp_dir" PATH="$PATH" \
+    "$SKILL_DIR/scripts/confirm_gate.sh" \
+    --description "test approval" \
+    --nonce "../unsafe" \
+    -- /usr/bin/true
+
+  if [[ "$status" -ne 2 ]] || ! assert_contains "$stdout" "confirm_error_reason=invalid_nonce"; then
+    fail_test "$name" "unsafe nonce path was not rejected"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  pass_test "$name"
+  rm -rf "$temp_dir"
+}
+
+test_confirm_gate_interactive_fresh_nonce() {
+  local name="confirm gate interactive fresh nonce"
+
+  if python3 - <<'PY' "$SKILL_DIR/scripts/confirm_gate.sh"; then
+import os
+import pty
+import select
+import subprocess
+import sys
+import time
+
+script = sys.argv[1]
+cmd = [script, "--description", "interactive replay test", "--", "/usr/bin/true"]
+
+def run_once():
+    master, slave = pty.openpty()
+    proc = subprocess.Popen(
+        cmd,
+        stdin=slave,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        close_fds=True,
+    )
+    os.close(slave)
+    err_chunks = []
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline:
+        ready, _, _ = select.select([proc.stderr], [], [], 0.1)
+        if not ready:
+            if proc.poll() is not None:
+                break
+            continue
+        chunk = os.read(proc.stderr.fileno(), 1024)
+        if not chunk:
+            break
+        err_chunks.append(chunk)
+        if b"Proceed? [y/N]: " in b"".join(err_chunks):
+            break
+    else:
+        proc.kill()
+        raise RuntimeError("confirmation prompt timed out")
+
+    if b"Proceed? [y/N]: " not in b"".join(err_chunks):
+        proc.kill()
+        raise RuntimeError("confirmation prompt was not emitted")
+
+    os.write(master, b"y\n")
+    os.close(master)
+    out, remaining_err = proc.communicate(timeout=15)
+    err = b"".join(err_chunks) + remaining_err
+    return proc.returncode, out.decode(), err.decode()
+
+results = [run_once() for _ in range(10)]
+for index, result in enumerate(results):
+    if result[0] != 0 or "confirm_state=approved" not in result[1]:
+        raise SystemExit(index + 1)
+PY
+    pass_test "$name"
+  else
+    fail_test "$name" "interactive re-approval should succeed on a second identical command"
+  fi
+}
+
+test_common_security_contracts() {
+  local name="common helpers reject injected output and mint unique nonces"
+  local stdout=""
+  local stderr=""
+  local status=""
+
+  # shellcheck disable=SC2016
+  run_capture stdout stderr status bash -c '
+    set -euo pipefail
+    source "$1"
+    declare -A seen=()
+    for _ in $(seq 1 128); do
+      nonce="$(next_confirm_nonce)"
+      [[ "$nonce" =~ ^[0-9a-f]{32}$ ]]
+      [[ -z "${seen[$nonce]:-}" ]]
+      seen[$nonce]=1
+    done
+    emit_kv safe_key safe-value
+    if emit_kv unsafe_key $'"'"'first\nforged_key=value'"'"'; then
+      exit 11
+    fi
+    read_confirm_nonce_bytes() { return 1; }
+    if next_confirm_nonce >/dev/null; then
+      exit 12
+    fi
+  ' _ "$SKILL_DIR/scripts/common.sh"
+
+  if [[ "$status" -ne 0 ]]; then
+    fail_test "$name" "security helper contract failed with $status: $stderr"
+    return
+  fi
+  if [[ "$stdout" != "safe_key=safe-value" ]] || assert_contains "$stdout" "forged_key=value"; then
+    fail_test "$name" "unsafe machine-readable value was emitted"
+    return
+  fi
+
+  pass_test "$name"
+}
+
+test_json_display_name_lookup_contract() {
+  local name="JSON display-name lookup is exact and rejects ambiguity"
+  local stdout=""
+  local stderr=""
+  local status=""
+  local payload='{"data":[{"display-name":"safe-app","id":"ocid.safe"},{"display-name":"x'"'"'] | [0]","id":"ocid.inject"}]}'
+
+  # shellcheck disable=SC2016
+  run_capture stdout stderr status bash -c '
+    set -euo pipefail
+    source "$1"
+    find_unique_resource_id_by_display_name "$2" "$3"
+  ' _ "$SKILL_DIR/scripts/common.sh" "$payload" "x'] | [0]"
+
+  if [[ "$status" -ne 0 || "$stdout" != "ocid.inject" ]]; then
+    fail_test "$name" "exact lookup failed: status=$status stdout=$stdout stderr=$stderr"
+    return
+  fi
+
+  payload='{"data":[{"display-name":"duplicate","id":"ocid.one"},{"display-name":"duplicate","id":"ocid.two"}]}'
+  # shellcheck disable=SC2016
+  run_capture stdout stderr status bash -c '
+    set -euo pipefail
+    source "$1"
+    find_unique_resource_id_by_display_name "$2" duplicate
+  ' _ "$SKILL_DIR/scripts/common.sh" "$payload"
+
+  if [[ "$status" -eq 0 ]] || ! assert_contains "$stderr" "ambiguous"; then
+    fail_test "$name" "duplicate lookup was not rejected"
+    return
+  fi
+
+  pass_test "$name"
+}
+
+test_confirm_gate_escapes_display_controls() {
+  local name="confirm gate escapes control characters in review text"
+  local stdout=""
+  local stderr=""
+  local status=""
+  local description=$'Deploy app\n[COMMAND] forged'
+  local display=$'oci fn deploy\033[2Jforged'
+
+  run_capture stdout stderr status \
+    env TMPDIR="$(mktemp -d)" PATH="$PATH" \
+    "$SKILL_DIR/scripts/confirm_gate.sh" \
+    --description "$description" \
+    --display "$display" \
+    --nonce "control-test" \
+    -- /usr/bin/true
+
+  if [[ "$status" -ne 3 ]]; then
+    fail_test "$name" "expected unapproved status 3, got $status"
+    return
+  fi
+  if [[ "$(grep -c '^\[COMMAND\]' <<<"$stdout")" -ne 1 ]] || grep -Fq $'\033' <<<"$stdout"; then
+    fail_test "$name" "raw control characters altered the confirmation output"
+    return
+  fi
+
+  pass_test "$name"
+}
+
+test_latest_fn_release_metadata_contract() {
+  local name="latest Fn release metadata is strictly validated"
+  local temp_dir
+  local stdout=""
+  local stderr=""
+  local status=""
+
+  temp_dir="$(mktemp -d)"
+  mkdir -p "$temp_dir/bin"
+  cat >"$temp_dir/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${FN_TEST_CURL_FAIL:-no}" == "yes" ]]; then
+  exit 22
+fi
+printf '%s' "${FN_TEST_RELEASE_JSON:?}"
+EOF
+  cat >"$temp_dir/bin/od" <<'EOF'
+#!/usr/bin/env bash
+printf ' 00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff\n'
+EOF
+  chmod +x "$temp_dir/bin/curl" "$temp_dir/bin/od"
+
+  good_json='{"draft":false,"prerelease":false,"tag_name":"0.6.61","assets":[{"name":"fn_linux","state":"uploaded","size":20490071,"browser_download_url":"https://github.com/fnproject/cli/releases/download/0.6.61/fn_linux","digest":"sha256:dba87f9e3406d3bb3f6a796693e6bd83a0af189a4a8ef875a3f5f55cb4711683"}]}'
+  # shellcheck disable=SC2016
+  run_capture stdout stderr status env PATH="$temp_dir/bin:$PATH" FN_TEST_RELEASE_JSON="$good_json" bash -c '
+    set -euo pipefail
+    source "$1"
+    resolve_latest_fn_linux_release version url digest
+    printf "%s\n%s\n%s\n" "$version" "$url" "$digest"
+  ' _ "$SKILL_DIR/scripts/common.sh"
+
+  if [[ "$status" -ne 0 ]] || ! assert_contains "$stdout" "0.6.61" || ! assert_contains "$stdout" "sha256:dba87f9e"; then
+    fail_test "$name" "valid release metadata was rejected: $stderr"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  bad_json='{"draft":false,"prerelease":false,"tag_name":"0.6.61","assets":[{"name":"fn_linux","state":"uploaded","size":10,"browser_download_url":"https://attacker.invalid/fn_linux","digest":null}]}'
+  # shellcheck disable=SC2016
+  run_capture stdout stderr status env PATH="$temp_dir/bin:$PATH" FN_TEST_RELEASE_JSON="$bad_json" bash -c '
+    set -euo pipefail
+    source "$1"
+    resolve_latest_fn_linux_release version url digest
+  ' _ "$SKILL_DIR/scripts/common.sh"
+
+  if [[ "$status" -eq 0 ]]; then
+    fail_test "$name" "unsafe release metadata was accepted"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  missing_digest_json='{"draft":false,"prerelease":false,"tag_name":"0.6.61","assets":[{"name":"fn_linux","state":"uploaded","size":10,"browser_download_url":"https://github.com/fnproject/cli/releases/download/0.6.61/fn_linux","digest":null}]}'
+  # shellcheck disable=SC2016
+  run_capture stdout stderr status env PATH="$temp_dir/bin:$PATH" FN_TEST_RELEASE_JSON="$missing_digest_json" bash -c '
+    set -euo pipefail
+    source "$1"
+    resolve_latest_fn_linux_release version url digest
+  ' _ "$SKILL_DIR/scripts/common.sh"
+  if [[ "$status" -eq 0 ]]; then
+    fail_test "$name" "release metadata without a digest was accepted"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  malformed_json='{not-json'
+  # shellcheck disable=SC2016
+  run_capture stdout stderr status env PATH="$temp_dir/bin:$PATH" FN_TEST_RELEASE_JSON="$malformed_json" bash -c '
+    set -euo pipefail
+    source "$1"
+    resolve_latest_fn_linux_release version url digest
+  ' _ "$SKILL_DIR/scripts/common.sh"
+  if [[ "$status" -eq 0 ]]; then
+    fail_test "$name" "malformed release metadata was accepted"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  # shellcheck disable=SC2016
+  run_capture stdout stderr status env PATH="$temp_dir/bin:$PATH" FN_TEST_RELEASE_JSON="$good_json" FN_TEST_CURL_FAIL=yes bash -c '
+    set -euo pipefail
+    source "$1"
+    resolve_latest_fn_linux_release version url digest
+  ' _ "$SKILL_DIR/scripts/common.sh"
+  if [[ "$status" -eq 0 ]]; then
+    fail_test "$name" "release metadata transport failure was accepted"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  pass_test "$name"
+  rm -rf "$temp_dir"
+}
+
+test_fn_installer_verification_contract() {
+  local name="Fn installer verifies digest and version before privileged install"
+  local temp_dir
+  local stdout=""
+  local stderr=""
+  local status=""
+  local digest=""
+  local wrong_version_digest=""
+
+  temp_dir="$(mktemp -d)"
+  mkdir -p "$temp_dir/bin"
+  cat >"$temp_dir/fn_linux" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'fn version 0.6.61\n'
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$temp_dir/fn_linux"
+  digest="sha256:$(shasum -a 256 "$temp_dir/fn_linux" | awk '{print $1}')"
+
+  cat >"$temp_dir/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output) output="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [[ "${FN_TEST_CURL_FAIL:-no}" == "yes" ]]; then
+  exit 22
+fi
+cp "${FN_TEST_ASSET:?}" "$output"
+EOF
+  cat >"$temp_dir/bin/uname" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  -s) printf 'Linux\n' ;;
+  -m) printf '%s\n' "${FN_TEST_ARCH:-x86_64}" ;;
+  *) exit 1 ;;
+esac
+EOF
+  cat >"$temp_dir/bin/id" <<'EOF'
+#!/usr/bin/env bash
+printf '1000\n'
+EOF
+  cat >"$temp_dir/bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >"${FN_TEST_INSTALL_LOG:?}"
+EOF
+  chmod +x "$temp_dir/bin/curl" "$temp_dir/bin/uname" "$temp_dir/bin/id" "$temp_dir/bin/sudo"
+
+  run_capture stdout stderr status env \
+    PATH="$temp_dir/bin:$PATH" \
+    FN_TEST_ASSET="$temp_dir/fn_linux" \
+    FN_TEST_INSTALL_LOG="$temp_dir/install.log" \
+    "$SKILL_DIR/scripts/install_fn_linux.sh" \
+    --version 0.6.61 \
+    --asset-url https://github.com/fnproject/cli/releases/download/0.6.61/fn_linux \
+    --sha256 "$digest"
+
+  if [[ "$status" -ne 0 ]] || [[ ! -f "$temp_dir/install.log" ]] || ! assert_contains "$(cat "$temp_dir/install.log")" "/usr/local/bin/fn"; then
+    fail_test "$name" "verified installer did not reach the install step: $stderr"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  rm -f "$temp_dir/install.log"
+  run_capture stdout stderr status env \
+    PATH="$temp_dir/bin:$PATH" \
+    FN_TEST_ASSET="$temp_dir/fn_linux" \
+    FN_TEST_INSTALL_LOG="$temp_dir/install.log" \
+    "$SKILL_DIR/scripts/install_fn_linux.sh" \
+    --version 0.6.61 \
+    --asset-url https://github.com/fnproject/cli/releases/download/0.6.61/fn_linux \
+    --sha256 sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+  if [[ "$status" -eq 0 ]] || [[ -f "$temp_dir/install.log" ]]; then
+    fail_test "$name" "checksum mismatch reached the install step"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  cat >"$temp_dir/fn_wrong_version" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'fn version 0.6.60\n'
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$temp_dir/fn_wrong_version"
+  wrong_version_digest="sha256:$(shasum -a 256 "$temp_dir/fn_wrong_version" | awk '{print $1}')"
+  run_capture stdout stderr status env \
+    PATH="$temp_dir/bin:$PATH" \
+    FN_TEST_ASSET="$temp_dir/fn_wrong_version" \
+    FN_TEST_INSTALL_LOG="$temp_dir/install.log" \
+    "$SKILL_DIR/scripts/install_fn_linux.sh" \
+    --version 0.6.61 \
+    --asset-url https://github.com/fnproject/cli/releases/download/0.6.61/fn_linux \
+    --sha256 "$wrong_version_digest"
+  if [[ "$status" -eq 0 || -f "$temp_dir/install.log" ]]; then
+    fail_test "$name" "version mismatch reached the install step"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  run_capture stdout stderr status env \
+    PATH="$temp_dir/bin:$PATH" \
+    FN_TEST_ASSET="$temp_dir/fn_linux" \
+    FN_TEST_INSTALL_LOG="$temp_dir/install.log" \
+    FN_TEST_ARCH=arm64 \
+    "$SKILL_DIR/scripts/install_fn_linux.sh" \
+    --version 0.6.61 \
+    --asset-url https://github.com/fnproject/cli/releases/download/0.6.61/fn_linux \
+    --sha256 "$digest"
+  if [[ "$status" -eq 0 || -f "$temp_dir/install.log" ]]; then
+    fail_test "$name" "unsupported architecture reached the install step"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  run_capture stdout stderr status env \
+    PATH="$temp_dir/bin:$PATH" \
+    FN_TEST_ASSET="$temp_dir/fn_linux" \
+    FN_TEST_INSTALL_LOG="$temp_dir/install.log" \
+    FN_TEST_CURL_FAIL=yes \
+    "$SKILL_DIR/scripts/install_fn_linux.sh" \
+    --version 0.6.61 \
+    --asset-url https://github.com/fnproject/cli/releases/download/0.6.61/fn_linux \
+    --sha256 "$digest"
+  if [[ "$status" -eq 0 || -f "$temp_dir/install.log" ]]; then
+    fail_test "$name" "download failure reached the install step"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  pass_test "$name"
+  rm -rf "$temp_dir"
+}
+
+test_fn_install_confirmation_binds_release() {
+  local name="Fn install confirmation binds the resolved release digest"
+  local temp_dir
+  local stdout_one=""
+  local stderr_one=""
+  local status_one=""
+  local stdout_two=""
+  local stderr_two=""
+  local status_two=""
+  local action_one=""
+  local action_two=""
+
+  temp_dir="$(mktemp -d)"
+  mkdir -p "$temp_dir/bin"
+  cat >"$temp_dir/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s' "${FN_TEST_RELEASE_JSON:?}"
+EOF
+  cat >"$temp_dir/bin/od" <<'EOF'
+#!/usr/bin/env bash
+printf ' 00 11 22 33 44 55 66 77 88 99 aa bb cc dd ee ff\n'
+EOF
+  chmod +x "$temp_dir/bin/curl" "$temp_dir/bin/od"
+
+  json_one='{"draft":false,"prerelease":false,"tag_name":"0.6.61","assets":[{"name":"fn_linux","state":"uploaded","size":10,"browser_download_url":"https://github.com/fnproject/cli/releases/download/0.6.61/fn_linux","digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]}'
+  json_two="${json_one//sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb}"
+
+  run_capture stdout_one stderr_one status_one env PATH="$temp_dir/bin:$PATH" FN_TEST_RELEASE_JSON="$json_one" TMPDIR="$temp_dir/one" \
+    "$SKILL_DIR/scripts/install_missing.sh" --tool fn --os linux --machine-readable
+  run_capture stdout_two stderr_two status_two env PATH="$temp_dir/bin:$PATH" FN_TEST_RELEASE_JSON="$json_two" TMPDIR="$temp_dir/two" \
+    "$SKILL_DIR/scripts/install_missing.sh" --tool fn --os linux --machine-readable
+
+  action_one="$(awk -F= '/^confirm_action_id=/{print $2}' <<<"$stdout_one")"
+  action_two="$(awk -F= '/^confirm_action_id=/{print $2}' <<<"$stdout_two")"
+  if [[ "$status_one" -ne 3 || "$status_two" -ne 3 || -z "$action_one" || -z "$action_two" || "$action_one" == "$action_two" ]]; then
+    fail_test "$name" "confirmation action did not change with the release digest: $stderr_one $stderr_two"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  pass_test "$name"
+  rm -rf "$temp_dir"
+}
+
+test_preflight_precedence_and_machine_readable() {
+  local name="preflight explicit precedence + machine-readable stdout"
+  local temp_dir
+  local stdout=""
+  local stderr=""
+  local status=""
+
+  temp_dir="$(mktemp -d)"
+  make_stub_env "$temp_dir"
+
+  run_capture stdout stderr status \
+    env PATH="$temp_dir/bin:$PATH" HOME="$temp_dir/home" \
+    "$SKILL_DIR/scripts/preflight_check.sh" \
+    --runtime python \
+    --profile explicit-profile \
+    --machine-readable
+
+  if [[ "$status" -ne 0 ]]; then
+    fail_test "$name" "preflight exited with $status"
+    rm -rf "$temp_dir"
+    return
+  fi
+  if ! assert_kv_only "$stdout"; then
+    fail_test "$name" "stdout included non key=value content"
+    rm -rf "$temp_dir"
+    return
+  fi
+  if ! assert_contains "$stdout" "oci_profile=explicit-profile"; then
+    fail_test "$name" "missing explicit oci_profile"
+    rm -rf "$temp_dir"
+    return
+  fi
+  if ! assert_contains "$stdout" "oci_profile_source=explicit_flag"; then
+    fail_test "$name" "expected explicit flag to win over Fn context"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  pass_test "$name"
+  rm -rf "$temp_dir"
+}
+
+test_discover_state_precedence_and_contract() {
+  local name="discover_state explicit precedence + machine-readable stdout"
+  local temp_dir
+  local stdout=""
+  local stderr=""
+  local status=""
+
+  temp_dir="$(mktemp -d)"
+  make_stub_env "$temp_dir"
+
+  run_capture stdout stderr status \
+    env PATH="$temp_dir/bin:$PATH" HOME="$temp_dir/home" \
+    "$SKILL_DIR/scripts/discover_state.sh" \
+    --region us-ashburn-1 \
+    --compartment-id ocid1.compartment.oc1..explicit \
+    --profile explicit-profile \
+    --app-name existing-app \
+    --machine-readable
+
+  if [[ "$status" -ne 0 ]]; then
+    fail_test "$name" "discover_state exited with $status"
+    rm -rf "$temp_dir"
+    return
+  fi
+  if ! assert_kv_only "$stdout"; then
+    fail_test "$name" "stdout included non key=value content"
+    rm -rf "$temp_dir"
+    return
+  fi
+  if ! assert_contains "$stdout" "region=us-ashburn-1"; then
+    fail_test "$name" "missing explicit region"
+    rm -rf "$temp_dir"
+    return
+  fi
+  if ! assert_contains "$stdout" "compartment_id=ocid1.compartment.oc1..explicit"; then
+    fail_test "$name" "missing explicit compartment id"
+    rm -rf "$temp_dir"
+    return
+  fi
+  if ! assert_contains "$stdout" "profile=explicit-profile"; then
+    fail_test "$name" "missing explicit profile"
+    rm -rf "$temp_dir"
+    return
+  fi
+  if ! assert_contains "$stdout" "oci_cli_state=found"; then
+    fail_test "$name" "missing explicit oci_cli_state"
+    rm -rf "$temp_dir"
+    return
+  fi
+  if ! assert_contains "$stdout" "compartment_state=found"; then
+    fail_test "$name" "missing explicit compartment_state"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  pass_test "$name"
+  rm -rf "$temp_dir"
+}
+
+test_discover_state_rejects_name_injection() {
+  local name="discover_state uses JSON matching and rejects injected output"
+  local temp_dir
+  local stdout=""
+  local stderr=""
+  local status=""
+  local malicious_name="x'] | [0]"
+
+  temp_dir="$(mktemp -d)"
+  make_stub_env "$temp_dir"
+  cat >"$temp_dir/bin/oci" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" >>"${OCI_TEST_ARG_LOG:?}"
+if [[ "${1:-}" == "fn" && "${2:-}" == "application" && "${3:-}" == "list" ]]; then
+  printf '%s\n' "${OCI_TEST_JSON:?}"
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$temp_dir/bin/oci"
+
+  safe_json='{"data":[{"display-name":"x'"'"'] | [0]","id":"ocid1.fnapp.oc1..exact"}]}'
+  run_capture stdout stderr status env \
+    PATH="$temp_dir/bin:$PATH" \
+    HOME="$temp_dir/home" \
+    OCI_TEST_ARG_LOG="$temp_dir/oci.args" \
+    OCI_TEST_JSON="$safe_json" \
+    "$SKILL_DIR/scripts/discover_state.sh" \
+    --region us-ashburn-1 \
+    --compartment-id ocid1.compartment.oc1..explicit \
+    --profile explicit-profile \
+    --app-name "$malicious_name" \
+    --machine-readable
+
+  if [[ "$status" -ne 0 ]] || ! assert_contains "$stdout" "app_id=ocid1.fnapp.oc1..exact" || grep -Fq 'data[?' "$temp_dir/oci.args"; then
+    fail_test "$name" "malicious display name altered the OCI request: $stderr"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  : >"$temp_dir/oci.args"
+  newline_json='{"data":[{"display-name":"safe\nforged_key=value","id":"ocid1.fnapp.oc1..unsafe"}]}'
+  run_capture stdout stderr status env \
+    PATH="$temp_dir/bin:$PATH" \
+    HOME="$temp_dir/home" \
+    OCI_TEST_ARG_LOG="$temp_dir/oci.args" \
+    OCI_TEST_JSON="$newline_json" \
+    "$SKILL_DIR/scripts/discover_state.sh" \
+    --region us-ashburn-1 \
+    --compartment-id ocid1.compartment.oc1..explicit \
+    --profile explicit-profile \
+    --machine-readable
+
+  if [[ "$status" -eq 0 ]] || assert_contains "$stdout" "forged_key=value"; then
+    fail_test "$name" "control-character display name entered machine-readable output"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  pass_test "$name"
+  rm -rf "$temp_dir"
+}
+
+test_ensure_app_reuse_rejects_create_only_flags() {
+  local name="ensure_app rejects create-only flags on reuse"
+  local temp_dir
+  local stdout=""
+  local stderr=""
+  local status=""
+
+  temp_dir="$(mktemp -d)"
+  make_stub_env "$temp_dir"
+
+  run_capture stdout stderr status \
+    env PATH="$temp_dir/bin:$PATH" HOME="$temp_dir/home" \
+    "$SKILL_DIR/scripts/ensure_app.sh" \
+    --region us-phoenix-1 \
+    --compartment-id ocid1.compartment.oc1..explicit \
+    --profile explicit-profile \
+    --app-name existing-app \
+    --app-choice reuse \
+    --shape GENERIC_ARM \
+    --machine-readable
+
+  if [[ "$status" -ne 2 ]]; then
+    fail_test "$name" "expected exit 2, got $status"
+    rm -rf "$temp_dir"
+    return
+  fi
+  if ! assert_kv_only "$stdout"; then
+    fail_test "$name" "stdout included non key=value content"
+    rm -rf "$temp_dir"
+    return
+  fi
+  if ! assert_contains "$stdout" "app_state=error"; then
+    fail_test "$name" "expected app_state=error"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  pass_test "$name"
+  rm -rf "$temp_dir"
+}
+
+test_build_and_deploy_directory_guard() {
+  local name="build_and_deploy stops on non-empty non-function directory"
+  local temp_dir
+  local stdout=""
+  local stderr=""
+  local status=""
+
+  temp_dir="$(mktemp -d)"
+  mkdir -p "$temp_dir/existing-dir"
+  printf 'hello\n' >"$temp_dir/existing-dir/README.txt"
+
+  run_capture stdout stderr status \
+    env PATH="$PATH" HOME="$temp_dir/home" \
+    "$SKILL_DIR/scripts/build_and_deploy.sh" \
+    --runtime python \
+    --app demo-app \
+    --function-dir "$temp_dir/existing-dir" \
+    --function-name demo-fn \
+    --function-name-source explicit \
+    --machine-readable
+
+  if [[ "$status" -ne 2 ]]; then
+    fail_test "$name" "expected exit 2, got $status"
+    rm -rf "$temp_dir"
+    return
+  fi
+  if ! assert_contains "$stdout" "function_name_state=explicit"; then
+    fail_test "$name" "expected function_name_state=explicit before guard failure"
+    rm -rf "$temp_dir"
+    return
+  fi
+
+  pass_test "$name"
+  rm -rf "$temp_dir"
+}
+
+main() {
+  test_confirm_gate_contract
+  test_confirm_gate_interactive_fresh_nonce
+  test_common_security_contracts
+  test_json_display_name_lookup_contract
+  test_confirm_gate_escapes_display_controls
+  test_latest_fn_release_metadata_contract
+  test_fn_installer_verification_contract
+  test_fn_install_confirmation_binds_release
+  test_preflight_precedence_and_machine_readable
+  test_discover_state_precedence_and_contract
+  test_discover_state_rejects_name_injection
+  test_ensure_app_reuse_rejects_create_only_flags
+  test_build_and_deploy_directory_guard
+
+  printf '\nPassed: %s\nFailed: %s\n' "$PASS_COUNT" "$FAIL_COUNT"
+  [[ "$FAIL_COUNT" -eq 0 ]]
+}
+
+main "$@"

--- a/oci/functions/oci-functions-troubleshoot/SKILL.md
+++ b/oci/functions/oci-functions-troubleshoot/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: oci-functions-troubleshoot
+description: Diagnose OCI Functions setup, control-plane, deployment, invocation, and observability issues using a deterministic triage workflow. Use when asked to classify Fn CLI errors, deploy or invoke failures, OCIR auth and registry issues, app-limit symptoms, logs, tracing, metrics, or limits. Diagnose first, prefer read-only checks, and do not execute fixes unless the user explicitly asks.
+---
+
+# OCI Function Troubleshoot
+
+Use this skill to isolate the most likely cause of an OCI Functions problem from error text, command output, or observability signals.
+
+This skill is diagnosis-first and non-mutating by default:
+- prefer read-only checks
+- do not edit Fn context, log into Docker, create or update apps, redeploy, or change infrastructure unless the user explicitly asks to execute a fix
+- if the user wants the fix executed, finish the diagnosis first and hand off mutating remediation to `$oci-functions-deploy`
+
+## Output Contract
+
+Always answer in this exact shape:
+- `stage`: one of `setup_or_control_plane`, `create`, `deploy`, `invoke`, `observability_first`
+- `evidence`: 1-3 concrete facts from the user's error text, command, config, logs, metrics, or limits
+- `most_likely_cause`: one primary cause, or a ranked top-2 shortlist when confidence is low
+- `confidence`: `low`, `medium`, or `high`
+- `next_confirming_check`: the single best read-only check to narrow or confirm the cause
+- `smallest_safe_remediation`: the least invasive next action; if evidence is weak, this can be "collect more evidence with ..."
+- `validation`: the follow-up step that proves the remediation worked
+
+## Triage
+
+1. If the user provides an exact error string, start with `references/error-patterns.md`.
+2. Classify the issue from the failed action:
+- `setup_or_control_plane`: local Fn/OCI/OCIR/tooling/auth/context/policy problems before normal app or function operations succeed
+- `create`: application creation failures
+- `deploy`: `fn deploy`, image build or push, `func.yaml`, app config, subnet annotation, or registry-target failures
+- `invoke`: runtime invocation, HTTP, image pull, timeout, memory, networking, detached delivery, or response-limit failures after a function has been deployed
+- `observability_first`: the user starts from logs, traces, metrics, limits, or "why is this function unhealthy?"
+3. If the stage is ambiguous:
+- ask exactly one disambiguating question when a single missing fact would change the stage
+- otherwise present the top 2 plausible stages in ranked order and continue with the best read-only confirming check
+
+## Minimum Facts
+
+Capture the minimum facts before diagnosing:
+- exact error text and HTTP status if present
+- command or action that failed
+- region, compartment/profile, app name, and function name if known
+- whether the problem is local, deploy-time, invoke-time, or telemetry-first
+- whether Fn CLI, OCI CLI, Docker, Logging, Monitoring, and Tracing access are available
+
+## Preferred Read-Only Checks
+
+Prefer non-mutating checks when tooling is available:
+- `fn inspect context`
+- `fn list apps`
+- `fn inspect app <app-name>`
+- `fn inspect function <app-name> <function-name>`
+- read local `func.yaml`
+- inspect environment values that can override expected behavior, especially `FN_REGISTRY`
+- read logs, traces, metrics, and limits before recommending edits
+- use `DEBUG=1` or `OCI_GO_SDK_DEBUG=v` only for additional diagnostic signal, not as a first fix
+
+If tools or access are missing, stay docs-first:
+- classify the failure from the error text
+- use the phase reference file for likely causes
+- use `references/error-patterns.md` when the text is the strongest clue
+
+## Workflow
+
+### Setup Or Control Plane
+
+Use `references/setup-and-runtime.md` for:
+- Fn CLI `401` and `404`
+- OCI key, passphrase, and private key format problems
+- wrong region, compartment, endpoint, or app/function target
+- IAM, policy, dynamic-group, or network-resource authorization failures
+- Docker registry unauthorized failures
+- stale or outdated CLI behavior
+
+Start with read-only checks:
+- inspect active Fn context values
+- verify the intended OCI profile, compartment, and region match the failing target
+- confirm the registry host derived from the context
+- for `404`, separate endpoint or name mismatches from IAM/policy or compartment-targeting issues before suggesting reconfiguration
+
+### Application Creation
+
+Use `references/create.md` for create-time failures.
+
+Focus on:
+- documented service-limit style failures such as maximum application count
+- whether the request is going to the intended compartment and region
+- whether IAM or compartment targeting is wrong when the error is not clearly limit-shaped
+- whether the smallest safe path is reuse, cleanup, or a limit increase request
+
+### Deployment
+
+Use `references/deploy.md` for:
+- `fn deploy` failures
+- image build, push, or registry auth problems
+- `func.yaml` schema issues
+- wrong application context or missing subnet annotations
+- architecture mismatch symptoms
+- identity-domain or federated OCIR username issues
+
+Check in this order:
+- active Fn context and target app
+- local `func.yaml`
+- effective registry target, including `FN_REGISTRY`
+- app annotations and subnet/network assumptions
+- whether the failure is local build, image push, or service-side deploy
+- `fn version` when architecture or stale-client symptoms are plausible
+
+### Invocation
+
+Use `references/invoke.md` for:
+- request or response size limits
+- throttling, detached delivery, or event-triggered retries
+- client disconnect, image pull, DNS, timeout, memory, syslog, security-attribute, or dynamic-group failures
+- subnet, DHCP, resolver, or service-availability failures
+
+Check in this order:
+- exact HTTP code and service error text
+- whether the error happens before code starts, during init, during execution, or after execution but before delivery completes
+- logs first for code/runtime clues when available
+- traces next when enabled and downstream timing or dependency timing is unclear
+- metrics next for error rate, latency, concurrency, and invoke-type trends
+- limits last when the symptom suggests capacity pressure or service ceilings
+
+### Observability First
+
+Use `references/observability.md` when the user starts from symptoms instead of a single failing command.
+
+Default observability sequence:
+1. Logs: determine whether the function ran and whether application logging is enabled
+2. Tracing: use traces when enabled and the missing clue is dependency timing, latency, or call path
+3. Metrics: distinguish execution failure, throttling, detached delivery, latency, and capacity pressure
+4. Limits: confirm whether create or invoke failures align with service limits
+5. Debug flags: use `DEBUG=1` or `OCI_GO_SDK_DEBUG=v` only when reproducing locally or when request/SDK details are still missing
+
+## Reference Map
+
+- setup/control-plane issues: `references/setup-and-runtime.md`
+- app creation issues: `references/create.md`
+- deployment issues: `references/deploy.md`
+- invocation issues: `references/invoke.md`
+- logs, traces, metrics, limits, debug flags: `references/observability.md`
+- exact strings to likely causes: `references/error-patterns.md`
+- reusable prompt patterns: `references/example-prompts.md`
+
+## Guardrails
+
+- Diagnose and isolate first. Do not mutate local context, Docker auth, app config, deployed state, or infrastructure unless the user explicitly asks to execute a fix.
+- If the user asks to execute the fix, complete the diagnosis summary first and hand off mutating repair work to `$oci-functions-deploy`.
+- Do not start with mutating fixes when a read-only check can narrow the cause.
+- Do not assume a `404` is only an endpoint or name problem; treat IAM, policy, compartment targeting, dynamic groups, and network-resource authorization as first-class alternatives.
+- Do not assume a deploy issue is code-related until registry, app, client version, and network context are checked.
+- Do not assume an invoke issue is platform-related until logs, traces, and metrics are checked.
+- Treat `FN_REGISTRY`, active Fn context, app annotations, tracing availability, and service limits as common hidden causes.
+- If the user gives only a partial symptom, ask for the exact error text or failing command before escalating to broad remediation.
+- When evidence is partial, prefer a ranked shortlist of plausible causes over a single overconfident root cause.
+
+## Sources
+
+- [Troubleshooting OCI Functions](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionstroubleshooting.htm)
+- [Issues deploying applications and functions](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionstroubleshooting_topic-Issues-deploying-applications-and-functions.htm)
+- [Issues invoking functions](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionstroubleshooting_topic-Issues-invoking-functions.htm)
+- [Storing and Viewing Function Logs](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionsexportingfunctionlogfiles.htm)
+- [Function Metrics](https://docs.oracle.com/en-us/iaas/Content/Functions/Reference/functionsmetrics.htm)
+- [Functions QuickStart on Local Host](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionsquickstartlocalhost.htm)

--- a/oci/functions/oci-functions-troubleshoot/agents/openai.yaml
+++ b/oci/functions/oci-functions-troubleshoot/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "OCI Functions Troubleshoot"
+  short_description: "Diagnose OCI Functions issues with read-only checks before any fix is attempted"
+  default_prompt: "Use $oci-functions-troubleshoot to classify an OCI Functions problem, stay diagnosis-only unless I explicitly ask you to execute a fix, and answer with stage, evidence, most_likely_cause, confidence, next_confirming_check, smallest_safe_remediation, and validation."

--- a/oci/functions/oci-functions-troubleshoot/references/create.md
+++ b/oci/functions/oci-functions-troubleshoot/references/create.md
@@ -1,0 +1,33 @@
+# Application Creation
+
+Use this reference when creating an OCI Functions application fails.
+
+## Common Documented Failure
+
+- A failed application create with a service-limit style message often means the tenancy or compartment already reached the OCI Functions application count limit.
+
+## Read-Only Checks
+
+- List existing applications in the target compartment.
+- Check current Functions limits and availability for the target region.
+- Confirm the create request is going to the intended compartment and region.
+- Capture the exact service message. If it does not read like a limit or capacity message, keep IAM or compartment mis-targeting in play.
+
+## Diagnosis Rules
+
+- If the error mentions maximum applications, limit exceeded, or no remaining capacity for application creation, treat limits as the primary cause.
+- If the create request is valid but the wrong compartment is targeted, fix the compartment selection before discussing service limits.
+- If the error is generic auth or not-found text, or the compartment and region are mismatched, treat IAM or targeting as a co-equal branch rather than forcing a limit diagnosis.
+- If the user needs only one more application and many old apps exist, cleanup may be smaller than requesting a limit increase.
+
+## Safe Remediation Ideas
+
+- Reuse an existing application when appropriate.
+- Delete unused applications only after the user confirms they are not needed.
+- Request a service limit increase when the application count is legitimately too low for the workload.
+- If evidence points to IAM or targeting, correct compartment selection or permissions before discussing cleanup or limit increases.
+
+## Sources
+
+- [Creating Applications](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionscreatingapps.htm)
+- [Troubleshooting OCI Functions](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionstroubleshooting.htm)

--- a/oci/functions/oci-functions-troubleshoot/references/deploy.md
+++ b/oci/functions/oci-functions-troubleshoot/references/deploy.md
@@ -1,0 +1,44 @@
+# Deployment
+
+Use this reference for `fn deploy`, image build and push, and application-config-related failures.
+
+## High-Value Patterns
+
+- Docker or OCIR auth failures during deploy are often registry credential issues, not function code issues.
+- `FN_REGISTRY` overrides the registry destination that `fn deploy` would otherwise use from context, so inspect it before trusting the target.
+- `triggers:` in `func.yaml` is not supported in current OCI Functions deploy flow and can cause deployment-time failure.
+- Missing or incorrect subnet annotations usually come from deploying against the wrong application or from app-level network configuration not matching the function's expected environment.
+- Identity-domain or federated OCIR usernames often need the tenancy namespace prefix, for example `tenancy-namespace/oracleidentitycloudservice/<username>`, so a short local username can fail even when the auth token is valid.
+- Architecture mismatch symptoms can appear when the built image platform does not align with the Functions application expectation. Record `fn version` first; older clients deserve extra suspicion, and Oracle documents improved architecture handling in Fn CLI `0.6.25+`.
+
+## Read-Only Checks
+
+- Run `fn inspect context` and confirm the active app target.
+- Run `fn inspect app <app-name>` and inspect annotations when a subnet or network issue is suspected.
+- Read local `func.yaml` and confirm no unsupported deployment fields are present.
+- Inspect the effective registry destination, including whether `FN_REGISTRY` is set in the shell.
+- Record `fn version` when architecture or stale-client symptoms are plausible.
+- Separate local build failure from image push failure from service-side deploy failure.
+
+## Likely Cause Mapping
+
+- push unauthorized or denied: OCIR credentials or username format
+- unexpected registry host: `FN_REGISTRY` override or wrong context
+- subnet annotation missing: wrong app or incomplete app networking setup
+- schema or unsupported key error: invalid `func.yaml`
+- image or architecture mismatch text on an older CLI: client-version or local build-target problem
+- image or architecture mismatch text on a current CLI: local build target or application expectation mismatch
+
+## Safe Remediation Ideas
+
+- Remove or correct `FN_REGISTRY` when it conflicts with the intended OCI registry.
+- Fix the target application or its annotations before rebuilding the function.
+- Simplify `func.yaml` to supported keys only.
+- Correct the OCIR username shape before regenerating tokens or re-running login.
+- Rebuild with the intended platform after confirming the target architecture and client version.
+
+## Sources
+
+- [Troubleshooting OCI Functions](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionstroubleshooting.htm)
+- [Issues deploying applications and functions](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionstroubleshooting_topic-Issues-deploying-applications-and-functions.htm)
+- [Pushing Images Using the Docker CLI](https://docs.oracle.com/en-us/iaas/Content/Registry/Tasks/registrypushingimagesusingthedockercli.htm)

--- a/oci/functions/oci-functions-troubleshoot/references/error-patterns.md
+++ b/oci/functions/oci-functions-troubleshoot/references/error-patterns.md
@@ -1,0 +1,75 @@
+# Error Patterns
+
+Use this file when the user leads with a raw error string.
+
+## Fast Mapping
+
+- `401 Unauthorized`
+  - likely area: Fn context auth, OCI profile, security token, or OCIR auth
+  - first checks: `fn inspect context`, OCI profile, registry auth state
+
+- `404 Not Found` or `Resource is not authorized or not found`
+  - likely area: wrong Functions endpoint, region, compartment, app/function name, or IAM/policy/dynamic-group/network-resource authorization
+  - first checks: context `api-url`, active region, target resource names, compartment, recent policy changes
+
+- `x509`, `passphrase`, `private key`
+  - likely area: OCI CLI key material or config shape
+  - first checks: profile paths, key format, passphrase alignment
+
+- `unauthorized: authentication required`
+  - likely area: OCIR login or wrong registry target
+  - first checks: registry host, OCIR username format, `FN_REGISTRY`
+
+- `Maximum applications exceeded` or similar
+  - likely area: Functions service limits
+  - first checks: application count and remaining regional limit
+
+- `TooManyRequests` or `429`
+  - likely area: throttling, concurrency pressure, or service-side rate control
+  - first checks: response metrics, concurrency metrics, recent traffic increase
+
+- `FunctionInvokeExecutionFailed`
+  - likely area: user code or downstream dependency after execution started
+  - first checks: logs, traces, response metrics
+
+- `FunctionInvokeImageNotAvailable` or `image pull`
+  - likely area: image pull, registry access, image availability, or VCN gateway/routing
+  - first checks: deployed image reference, OCIR reachability, app networking, recent image push status
+
+- `FunctionInvokeSyslogUnavailable`
+  - likely area: external logging endpoint reachability or syslog config
+  - first checks: syslog target config, network reachability, recent logging changes
+
+- `FunctionInvokeResponseBodyTooLarge`, `FunctionInvokeResponseHeaderTooLarge`, `response body too large`, or `response headers too large`
+  - likely area: function response exceeds platform limits
+  - first checks: response size, header count/size, whether large data should be returned indirectly
+
+- `FunctionInvokeContainerInitFail`
+  - likely area: startup, dependency, DNS, or memory problem
+  - first checks: early logs, image contents, startup path, memory setting
+
+- `FunctionInvokeTimeout`
+  - likely area: long startup, slow downstream dependency, or too-short function timeout
+  - first checks: execution duration trends, logs, downstream call latency
+
+- `FunctionInvokeTooManyMatchingDGs`, `FunctionInvokeSecurityAttributeNotAvailable`, `dynamic groups`, or `security attributes`
+  - likely area: IAM or org configuration
+  - first checks: exact OCI error text, recent identity-policy changes, compartment and identity setup
+
+- `FunctionInvokeSubnetConfigError`, `Customer subnet DNS resolver error`, `custom resolver`, or `DNS resolver`
+  - likely area: subnet, DHCP, resolver, or DNS configuration
+  - first checks: subnet config, DHCP options, resolver assumptions, downstream name-resolution failures
+
+- `ServiceUnavailable` or `503`
+  - likely area: transient capacity ramp-up, cold ramp, or unreachable dependency
+  - first checks: retry pattern, invoke type, metrics spike timing, dependency health
+
+## Usage Rule
+
+Treat this file as the triage shortcut, then switch to the phase-specific reference once the likely stage is clear.
+
+## Sources
+
+- [Troubleshooting OCI Functions](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionstroubleshooting.htm)
+- [Issues deploying applications and functions](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionstroubleshooting_topic-Issues-deploying-applications-and-functions.htm)
+- [Issues invoking functions](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionstroubleshooting_topic-Issues-invoking-functions.htm)

--- a/oci/functions/oci-functions-troubleshoot/references/example-prompts.md
+++ b/oci/functions/oci-functions-troubleshoot/references/example-prompts.md
@@ -1,0 +1,18 @@
+# Example Prompts
+
+- Use $oci-functions-troubleshoot to troubleshoot this `fn deploy` error: `<paste exact error>`. Stay diagnosis-only and answer with `stage`, `evidence`, `most_likely_cause`, `confidence`, `next_confirming_check`, `smallest_safe_remediation`, and `validation`.
+
+- Use $oci-functions-troubleshoot to classify this OCI Functions invocation failure: HTTP `429` with error `<paste error>`. Stay diagnosis-only, answer with `stage`, `evidence`, `most_likely_cause`, `confidence`, `next_confirming_check`, `smallest_safe_remediation`, and `validation`, and make `next_confirming_check` the first signal to inspect.
+
+- Use $oci-functions-troubleshoot to analyze this deploy transcript and identify whether the problem is local build, OCIR auth, Fn context, app config, or client version: `<paste transcript>`. Stay diagnosis-only and answer with `stage`, `evidence`, `most_likely_cause`, `confidence`, `next_confirming_check`, `smallest_safe_remediation`, and `validation`.
+
+- Use $oci-functions-troubleshoot to distinguish code failure from platform, IAM, or network failure using logs, traces, metrics, and limits for this function: `<paste telemetry summary>`. Stay diagnosis-only and answer with `stage`, `evidence`, `most_likely_cause`, `confidence`, `next_confirming_check`, `smallest_safe_remediation`, and `validation`.
+
+- Use $oci-functions-troubleshoot to inspect this Fn context and OCI region configuration and identify whether the likely problem is endpoint mismatch, compartment targeting, or IAM/policy setup: `<paste fn inspect context output>`. Stay diagnosis-only and answer with `stage`, `evidence`, `most_likely_cause`, `confidence`, `next_confirming_check`, `smallest_safe_remediation`, and `validation`.
+
+- Use $oci-functions-troubleshoot to debug this OCI Functions error string: `<paste exact error>`. Stay diagnosis-only, answer with `stage`, `evidence`, `most_likely_cause`, `confidence`, `next_confirming_check`, `smallest_safe_remediation`, and `validation`, and if evidence is partial put the top 2 likely causes in rank order inside `most_likely_cause`.
+
+## Sources
+
+- [OCI Functions documentation](https://docs.oracle.com/en-us/iaas/Content/Functions/home.htm)
+- [Troubleshooting OCI Functions](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionstroubleshooting.htm)

--- a/oci/functions/oci-functions-troubleshoot/references/invoke.md
+++ b/oci/functions/oci-functions-troubleshoot/references/invoke.md
@@ -1,0 +1,70 @@
+# Invocation
+
+Use this reference for runtime and HTTP failures after a function has been deployed.
+
+## High-Value Patterns
+
+- `413` usually means the request payload is too large for the invocation path.
+- response body or response headers too large usually means the function returned more data than the invocation path allows.
+- `429 TooManyRequests` usually means throttling or concurrency pressure.
+- `444` usually means the client disconnected before the response completed.
+- `FunctionInvokeExecutionFailed` usually points to user code or a downstream dependency after execution started.
+- `FunctionInvokeSyslogUnavailable` points to external logging reachability or syslog configuration rather than core function logic.
+- image-not-available, image-pull, or combined image-size failures happen before normal execution and usually indicate registry/image accessibility, VCN gateway/routing, or image-size problems.
+- subnet, DHCP, custom resolver, and DNS issues commonly surface as outbound access or name resolution failures during init or execution.
+- security-attribute or too-many-dynamic-groups failures point to IAM or org configuration rather than code.
+- `503 Service Unavailable` can be transient capacity ramp-up; for detached or event-driven invocations, automatic retries may already be in play.
+- container init failures and some `504` cases often correlate with startup, dependency, DNS, or memory pressure.
+- timeout failures usually require comparing function timeout settings, cold-start cost, and downstream latency.
+
+## Read-Only Checks
+
+- Capture the exact HTTP status and OCI Functions error text.
+- Capture the invoke type: synchronous, detached, or event-driven.
+- Decide whether the failure occurred:
+  - before code ran
+  - during container init
+  - during function execution
+  - after execution but before response or delivery completed
+- Read function logs first when available.
+- Use traces next when enabled and downstream timing or call path is unclear.
+- Review Functions metrics next, especially:
+  - `FunctionInvocationCount`
+  - `FunctionExecutionDuration`
+  - `FunctionResponseCount`
+  - `FunctionDetachedDeliveries`
+  - `AllocatedTotalConcurrency`
+  - `AllocatedProvisionedConcurrency`
+- Check limits if the symptom suggests throttling or capacity exhaustion.
+- Inspect app subnet, DHCP, resolver, or routing assumptions when network clues appear.
+
+## Likely Cause Mapping
+
+- `413`: request payload-size problem
+- response body or header size text: function returned too much data or too many/too-large headers
+- `429`: concurrency or throttling pressure
+- `444`: client-side disconnect or caller timeout
+- image unavailable or pull timeout with no user logs: registry, image availability, or VCN gateway/routing problem before code ran
+- combined image size or persistent image-pull delays: oversized image or slow registry access
+- container init fail plus little or no app logging: startup, dependency, DNS, or memory problem
+- timeout with normal starts: downstream dependency latency or timeout configuration
+- execution failed plus stack trace: function code or dependency issue first
+- syslog unavailable: external logging endpoint reachability or config
+- security attributes or too many dynamic groups text: IAM or org configuration issue
+- `503` that recovers with retries, especially for detached or event-driven invokes: transient platform capacity or cold ramp
+- `503` isolated to one dependency path: unreachable downstream service or network issue
+
+## Safe Remediation Ideas
+
+- Reduce request or response size, or move large payloads through Object Storage or another indirection path.
+- Use logs, traces, and concurrency metrics before changing timeout or memory.
+- Retry with backoff before blaming code for transient `503`, especially on event-driven workloads.
+- Trim image size and confirm registry accessibility, service-gateway or internet-gateway routing, and image availability before retrying image-pull failures.
+- Check DNS, DHCP options, custom resolver config, subnet routes, and service access when runtime code cannot reach external dependencies.
+- Correct IAM, dynamic-group, or security-attribute configuration with the smallest scope change before rebuilding.
+
+## Sources
+
+- [Troubleshooting OCI Functions](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionstroubleshooting.htm)
+- [Issues invoking functions](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionstroubleshooting_topic-Issues-invoking-functions.htm)
+- [Function Metrics](https://docs.oracle.com/en-us/iaas/Content/Functions/Reference/functionsmetrics.htm)

--- a/oci/functions/oci-functions-troubleshoot/references/observability.md
+++ b/oci/functions/oci-functions-troubleshoot/references/observability.md
@@ -1,0 +1,106 @@
+# Observability
+
+Use this reference when the user wants to diagnose OCI Functions behavior from signals instead of a single failing command.
+
+## Signal Selection
+
+- Logs are best for proving whether the function started and whether it reached user code.
+- Traces are best for dependency timing, call path, and downstream latency when tracing is enabled.
+- Metrics are best for aggregate failure classification, concurrency pressure, and detached-delivery trends.
+- Limits are best when create or invoke symptoms hint at service ceilings.
+- Debug flags are best for local reproduction when request details are still missing.
+
+## Logs First When Available
+
+- OCI Logging is the default and recommended place to inspect OCI Functions logs.
+- Invocation logs exist only when Logging is enabled for the application.
+- Custom application logs require the function code to emit output with normal print or logging calls.
+
+Questions to answer with logs:
+- Did the function start?
+- Did it reach user code?
+- Is the failure during init, execution, or downstream access?
+- Is there a stack trace, dependency error, or timeout clue?
+
+Common blockers:
+- Logging is disabled for the application.
+- The failure happens before user code emits logs.
+- The issue is in external log forwarding rather than normal invocation logging.
+
+## Tracing When Timing Or Call Path Is Missing
+
+- Use tracing when the missing clue is dependency timing, latency, or call path rather than raw application output.
+- Tracing is useful when logs show a symptom but not which downstream call or hop introduced it.
+
+Common blockers:
+- Tracing is not enabled.
+- The failing invocation did not emit a trace.
+- The problem is local CLI or control-plane behavior, where traces add little.
+
+## Metrics For Aggregate Patterns
+
+Use the `oci_faas` metrics namespace to separate platform symptoms from code symptoms.
+
+Most useful metrics:
+- `FunctionInvocationCount`
+- `FunctionExecutionDuration`
+- `FunctionResponseCount`
+- `AllocatedTotalConcurrency`
+- `AllocatedProvisionedConcurrency`
+- `FunctionDetachedDeliveries` when detached or event-driven delivery is suspected
+
+Most useful dimensions and groupings:
+- `responseType`
+- `ErrorCode`
+- `ErrorMessage`
+- `InvokeType` where available
+- app and function identity dimensions
+
+What to look for:
+- rising invocation count with normal response mix: traffic increase, not necessarily failure
+- error-heavy response counts by `responseType` or `ErrorCode`: failure classification
+- detached delivery failures with `InvokeType` where available, or with `FunctionDetachedDeliveries`: async delivery problem, not necessarily synchronous execution failure
+- growing execution duration before timeouts: slow startup or slow downstream dependency
+- concurrency near `AllocatedTotalConcurrency` or provisioned concurrency saturation: likely throttling or capacity issue
+- no logs but invocation metrics present: failure before user logging or logging disabled
+- traces show a slow downstream call while platform metrics remain healthy: dependency issue first
+
+## Limits When Symptoms Suggest A Ceiling
+
+Check limits when create or invoke symptoms hint at service ceilings.
+
+Focus on:
+- `application-count`
+- `function-count`
+- `total-concurrency-mb`
+- `provisioned-concurrency-mb`
+
+Diagnosis rules:
+- create-time failures often map to `application-count`
+- scale or throttling symptoms often map to concurrency limits
+- broad deployment growth problems can involve `function-count`
+- provisioned concurrency symptoms need `provisioned-concurrency-mb`, not just total concurrency
+
+## Debug Flags For Local Reproduction
+
+- Use `DEBUG=1` when reproducing Fn CLI behavior and you need more request/response detail.
+- Use `OCI_GO_SDK_DEBUG=v` when OCI Go SDK request logging would clarify control-plane or auth behavior.
+- Treat these as signal amplifiers, not as fixes.
+
+Common blockers:
+- The user cannot safely reproduce the command.
+- The command output would be too noisy or sensitive to share verbatim.
+
+## Practical Sequence
+
+1. Logs if they are available.
+2. Traces if enabled and the missing clue is timing or call path.
+3. Metrics to classify response behavior, invoke type, and resource pressure.
+4. Limits to confirm whether service policy explains the pattern.
+5. Debug flags when reproducing locally or when CLI/API request details remain unclear.
+
+## Sources
+
+- [Storing and Viewing Function Logs](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionsexportingfunctionlogfiles.htm)
+- [Function Metrics](https://docs.oracle.com/en-us/iaas/Content/Functions/Reference/functionsmetrics.htm)
+- [Troubleshooting OCI Functions](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionstroubleshooting.htm)

--- a/oci/functions/oci-functions-troubleshoot/references/setup-and-runtime.md
+++ b/oci/functions/oci-functions-troubleshoot/references/setup-and-runtime.md
@@ -1,0 +1,45 @@
+# Setup And Control Plane
+
+Use this reference when the user is blocked before normal OCI Functions operations work.
+
+## High-Value Patterns
+
+- `401 Unauthorized` from Fn CLI usually means the OCI profile, auth material, token, or registry auth does not match the target tenancy or region.
+- `404 Not Found` or "Resource is not authorized or not found" can mean the context points at the wrong Functions endpoint, compartment, region, or app/resource name, or that IAM/policy/dynamic-group/network-resource authorization is missing.
+- X509, passphrase, and private key parsing failures usually point to a bad key path, wrong passphrase, unsupported key format, or a damaged config entry.
+- Docker unauthorized failures usually indicate OCIR auth is missing, stale, or using the wrong username format for the tenancy model.
+- Some symptoms that look like platform breakage are caused by an outdated Fn CLI, so client age matters when the behavior conflicts with current documentation.
+
+## Read-Only Checks
+
+- Run `fn inspect context` and verify:
+  - `api-url`
+  - `oracle.compartment-id`
+  - `oracle.profile`
+  - `registry`
+- Confirm the OCI CLI profile exists and points at the expected region and auth material.
+- Compare the failing command's target app or function against the active context.
+- If the symptom is `404`, verify the expected app/function names, target compartment, active region, and whether recent IAM, dynamic-group, or network-policy changes align with the failure.
+- Check whether Docker is already authenticated to the registry host from the Fn context.
+
+## Likely Cause Mapping
+
+- `401` plus valid resource names: auth or token problem first.
+- `404` after a region, context, or app change: wrong endpoint, compartment, or resource name first.
+- `404` with the correct region and names, or after policy/network changes: `iam_or_policy` first.
+- key or X509 parsing text: local OCI config and key material first.
+- Docker push or pull unauthorized text: registry credentials and tenancy username format first.
+
+## Safe Remediation Ideas
+
+- Correct the active Fn context instead of changing the function first.
+- Verify or update IAM, dynamic-group, policy, or compartment targeting before changing the endpoint blindly.
+- Re-derive the registry host from the working region and tenancy.
+- Refresh or replace OCI auth material if the profile is stale.
+- Update Fn CLI if the symptom matches a known outdated-client issue.
+
+## Sources
+
+- [Functions QuickStart on Local Host](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionsquickstartlocalhost.htm)
+- [Troubleshooting OCI Functions](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionstroubleshooting.htm)
+- [Pushing Images Using the Docker CLI](https://docs.oracle.com/en-us/iaas/Content/Registry/Tasks/registrypushingimagesusingthedockercli.htm)


### PR DESCRIPTION
Closes #58

## Summary

Adds OCI Functions skills under `oci/functions/` for local deployment and troubleshooting workflows.

This PR includes:

- `oci-functions-deploy`: dependency-first local OCI Functions setup, Fn context validation, OCIR auth checks, application selection/creation, function scaffolding, deployment, and explicit mutating-action gates.
- `oci-functions-troubleshoot`: diagnosis-first workflow for setup/control-plane, application creation, deployment, invocation, observability, limits, and common error patterns.
- OCI domain TOC updates in `oci/SKILL.md`.
- Root README navigation updates for the OCI domain.
- Public Oracle `## Sources` sections on OCI Functions skill and reference markdown files.

## What Changed

This PR adds OCI Functions skills under `oci/functions/`:

- `oci/functions/oci-functions-deploy/`
  - Guides local macOS/Linux OCI Functions deployment workflows.
  - Validates Fn CLI, OCI CLI, Docker, Fn context, OCI auth, and OCIR registry auth.
  - Supports Java, Python, and Node function scaffolding and deployment.
  - Requires explicit confirmation for mutating actions such as installs, Docker login, Fn context changes, app creation, network creation, `fn init`, and `fn deploy`.
  - Includes helper scripts and contract tests for command gating and machine-readable output.

- `oci/functions/oci-functions-troubleshoot/`
  - Provides a read-only, diagnosis-first triage workflow.
  - Covers setup/control-plane, app creation, deploy, invoke, observability, metrics, limits, and common error patterns.
  - Hands off mutating remediation to `$oci-functions-deploy` only after diagnosis.

This PR also updates:

- `oci/SKILL.md` as the OCI domain table of contents.
- `README.md` to include the current OCI domain layout.
- All OCI Functions markdown files with `## Sources` sections backed by public Oracle documentation.

## Safety and Public-Readiness

- Customer-facing language only.
- No internal Confluence, Slack, Jira, tenancy-specific, roadmap-only, or unpublished behavior included.
- Mutating actions are explicitly classified and confirmation-gated.
- Public Oracle sources are listed in each skill/reference markdown file.
- OCI CLI, Fn CLI, Docker, and OCIR command forms were checked against installed CLI help and public Oracle documentation.

## Platform Scope

The helper scripts in `oci-functions-deploy` are intended for local macOS/Linux environments. Windows automation is out of scope for this initial contribution. Windows users can still use the skill guidance manually, but the bundled shell scripts are not expected to run natively on Windows without a POSIX-compatible environment.

## Note on Fn Project CLI Installer

`install_fn_linux.sh` uses the Fn Project CLI installer from the public `fnproject/cli` GitHub repository because Oracle’s public OCI Functions QuickStart documents that URL as the Fn CLI install path. The helper is confirmation-gated and identified as a high-risk remote installer path before execution.

Source:
- Oracle OCI Functions QuickStart on Local Host: https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionsquickstartlocalhost.htm

## Validation Performed

- Ran ShellCheck:
  - `shellcheck oci/functions/oci-functions-deploy/scripts/*.sh oci/functions/oci-functions-deploy/tests/test_skill_contract.sh`
- Ran Bash syntax checks:
  - `bash -n` across deploy scripts and tests
- Ran contract tests:
  - `bash oci/functions/oci-functions-deploy/tests/test_skill_contract.sh`
  - Result: 6 passed, 0 failed
- Verified every markdown file under `oci/functions` has a `## Sources` section.
- Verified stale `$oci-function-deploy` handoff references were corrected to `$oci-functions-deploy`.
- Updated deprecated VCN create command usage from `--cidr-block` to `--cidr-blocks`.