### PR TITLE
Add OCI IoT Platform skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -41,9 +41,9 @@
     {
       "name": "oci",
       "source": "./oci",
-      "description": "Oracle Cloud Infrastructure domain. Placeholder for future OCI skills.",
+      "description": "Oracle Cloud Infrastructure guidance for OKE, OCI IoT Platform digital twins and publish flows, Enterprise AI models, agents, RAG, governance, and Oracle platform integrations.",
       "category": "oracle",
-      "keywords": ["oracle", "oci", "cloud-infrastructure"]
+      "keywords": ["oracle", "oci", "cloud-infrastructure", "oke", "iot", "digital-twins", "generative-ai"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Browse and toggle installed plugins anytime with `/plugin`. Enabled plugins are 
 ## Domains
 
 - `db/` is the active Oracle Database domain and includes database, ORDS, SQLcl, framework, container, and agent workflow skills.
-- `oci/` contains Oracle Cloud Infrastructure skills, including OCI Kubernetes Engine cluster design and troubleshooting plus Enterprise AI guidance for OCI Generative AI, agents, RAG, governance, model endpoints, Autonomous Database, APEX, and integrations.
+- `oci/` contains Oracle Cloud Infrastructure skills, including OCI Kubernetes Engine cluster design and troubleshooting, OCI IoT Platform digital twin workflows, plus Enterprise AI guidance for OCI Generative AI, agents, RAG, governance, model endpoints, Autonomous Database, APEX, and integrations.
 - `fusion/` is the root for future Oracle Fusion skills.
 - `apex/` is the root for future Oracle APEX skills.
 - `graal/` contains GraalVM skills, starting with Native Image.
@@ -103,6 +103,13 @@ Browse and toggle installed plugins anytime with `/plugin`. Enabled plugins are 
     │   ├── data/
     │   ├── cost/
     │   └── integrations/
+    ├── iot-platform/
+    │   ├── SKILL.md
+    │   ├── agents/
+    │   ├── references/
+    │   ├── scripts/
+    │   ├── templates/
+    │   └── tests/
     └── oke/
         ├── cluster-design.md
         ├── troubleshooting.md
@@ -137,4 +144,6 @@ For stub domains, keep `SKILL.md` minimal and point users back to this `README.m
 ## Sources
 
 - https://docs.oracle.com/en-us/iaas/Content/ContEng/home.htm
+- https://docs.oracle.com/en-us/iaas/Content/internet-of-things/home.htm
+- https://github.com/oracle-samples/oci-iot-samples
 - https://www.graalvm.org/latest/reference-manual/native-image/

--- a/oci/SKILL.md
+++ b/oci/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: oci
-description: Oracle Cloud Infrastructure guidance for designing, operating, and troubleshooting OCI services, including OCI Kubernetes Engine (OKE) and Enterprise AI workflows for OCI Generative AI models, Responses API agents, RAG, cost estimation, governance, private endpoints, hosted agentic applications, and Oracle platform integrations. Use when the user asks about OKE cluster design, Terraform or Resource Manager planning, OKE incident troubleshooting, Generic VNIC Attachment, Multus, pod networking, node pools, add-ons, ingress, load balancers, OCIR image pulls, Workload Identity, Kubernetes workloads on OCI, OCI Generative AI, Enterprise AI Models, Enterprise AI Agents, governed GenAI applications, agentic workflows, RAG on Oracle Cloud, or OCI Generative AI pricing.
+description: Oracle Cloud Infrastructure guidance for designing, operating, and troubleshooting OCI services, including OCI Kubernetes Engine (OKE), OCI Internet of Things Platform, and Enterprise AI workflows for OCI Generative AI models, Responses API agents, RAG, cost estimation, governance, private endpoints, hosted agentic applications, and Oracle platform integrations. Use when the user asks about OKE cluster design, Terraform or Resource Manager planning, OKE incident troubleshooting, Generic VNIC Attachment, Multus, pod networking, node pools, add-ons, ingress, load balancers, OCIR image pulls, Workload Identity, Kubernetes workloads on OCI, OCI IoT domains or digital twins, device publish flows, OCI Generative AI, Enterprise AI Models, Enterprise AI Agents, governed GenAI applications, agentic workflows, RAG on Oracle Cloud, or OCI Generative AI pricing.
 ---
 
 # Oracle Cloud Infrastructure Skills
 
-Use this domain for practical Oracle Cloud Infrastructure guidance. Current content covers OCI Kubernetes Engine (OKE): cluster design, operational troubleshooting, Generic VNIC Attachment (GVA), and Multus multi-interface pod validation. It also covers Enterprise AI because that work is built around OCI Generative AI, OCI networking, IAM, cost estimation, hosted applications, and OCI platform integrations.
+Use this domain for practical Oracle Cloud Infrastructure guidance. Current content covers OCI Kubernetes Engine (OKE): cluster design, operational troubleshooting, Generic VNIC Attachment (GVA), and Multus multi-interface pod validation. It covers OCI Internet of Things Platform resource discovery, digital twin lifecycle workflows, device publish flows, and optional MCP-assisted operation. It also covers Enterprise AI because that work is built around OCI Generative AI, OCI networking, IAM, cost estimation, hosted applications, and OCI platform integrations.
 
 ## How to Use This Domain
 
@@ -28,6 +28,13 @@ oci/
 │   ├── data/
 │   ├── cost/
 │   └── integrations/
+├── iot-platform/
+│   ├── SKILL.md
+│   ├── agents/
+│   ├── references/
+│   ├── scripts/
+│   ├── templates/
+│   └── tests/
 └── oke/
     ├── cluster-design.md
     ├── troubleshooting.md
@@ -49,6 +56,7 @@ oci/
 | Troubleshoot OKE workloads, pods, services, DNS, add-ons, ingress, load balancers, image pulls, storage, Workload Identity, or cluster access | Start with `oci/oke/troubleshooting.md`, then load `oci/oke/skills/oke-troubleshooter/SKILL.md` |
 | Configure OKE managed node pools with Generic VNIC Attachment secondary VNIC profiles and Application Resources | Start with `oci/oke/gva-node-pools.md`, then load `oci/oke/skills/oke-gva-deployer/SKILL.md` |
 | Deploy or validate Multus NetworkAttachmentDefinitions and multi-interface pods on OKE | Start with `oci/oke/multus-multihome.md`, then load `oci/oke/skills/oke-multihome-deployer/SKILL.md` |
+| OCI IoT domains, domain groups, digital twin models, adapters, instances, relationships, raw commands, Data API access, or HTTPS publish flows | `oci/iot-platform/SKILL.md` |
 | OCI Generative AI models, custom/imported models, endpoints, or private endpoints | `oci/enterprise-ai/SKILL.md` |
 | OCI Responses API agents, tools, memory, File Search, Code Interpreter, MCP, or SQL Search | `oci/enterprise-ai/SKILL.md` |
 | OCI Generative AI and OCI Generative AI Agents cost estimation | `oci/enterprise-ai/cost/cost-estimation.md` |
@@ -60,6 +68,9 @@ oci/
 - `oci/oke/troubleshooting.md`
 - `oci/oke/gva-node-pools.md`
 - `oci/oke/multus-multihome.md`
+- `oci/iot-platform/SKILL.md`
+- `oci/iot-platform/references/cli-workflows.md`
+- `oci/iot-platform/references/mcp-optional-use.md`
 - `oci/enterprise-ai/SKILL.md`
 - `oci/enterprise-ai/models/enterprise-ai-models.md`
 - `oci/enterprise-ai/agent-workflows/responses-api-agents.md`
@@ -85,11 +96,14 @@ The OKE operational skills include deterministic helper tools under `oci/oke/scr
 | Build a node pool with workload-specific secondary VNIC profiles | `oke/gva-node-pools.md` -> `oke/multus-multihome.md` if pods need multiple interfaces |
 | Validate Multus pod networking on GVA-enabled nodes | `oke/multus-multihome.md` -> `oke/troubleshooting.md` if symptoms remain |
 | Investigate OKE workload access to OCI APIs | `oke/troubleshooting.md` |
+| Explore or update OCI IoT digital twin resources | `iot-platform/SKILL.md` -> `iot-platform/references/cli-workflows.md` -> `iot-platform/references/resilience-guidance.md` |
+| Publish test telemetry to an OCI IoT twin | `iot-platform/SKILL.md` -> `iot-platform/references/cli-workflows.md` -> `iot-platform/templates/publish-curl.template.sh` |
 | Build a governed enterprise assistant | `enterprise-ai/SKILL.md` -> `enterprise-ai/agent-workflows/agent-tools.md` -> `enterprise-ai/data/rag-and-search.md` -> `enterprise-ai/governance/private-endpoints-and-governance.md` |
 
 ## Scope Boundaries
 
 - Keep OCI service, networking, IAM, agent hosting, and cost-estimation guidance in this domain.
+- Route OCI IoT domain, digital twin, adapter, device publish, raw command, and Data API workflows to `oci/iot-platform/`.
 - Route Oracle Database-owned implementation details to `db/features/`.
 - Route APEX artifact generation to `apex/apexlang/`.
 - Prefer official Oracle documentation for OCI service limits, IAM verbs, endpoint formats, regions, and pricing inputs because these change frequently.
@@ -100,5 +114,7 @@ The OKE operational skills include deterministic helper tools under `oci/oke/scr
 - https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengAttaching_Multiple_VNICs.htm
 - https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contenggrantingworkloadaccesstoresources.htm
 - https://github.com/oracle-terraform-modules/terraform-oci-oke
+- https://docs.oracle.com/en-us/iaas/Content/internet-of-things/home.htm
+- https://github.com/oracle-samples/oci-iot-samples
 - https://docs.oracle.com/en-us/iaas/Content/generative-ai/overview.htm
 - https://docs.oracle.com/en-us/iaas/Content/generative-ai/home.htm

--- a/oci/iot-platform/SKILL.md
+++ b/oci/iot-platform/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: oci-iot-platform
+description: Explore, create, and troubleshoot Oracle Cloud Infrastructure Internet of Things Platform resources, including domains, digital twin models, adapters, instances, relationships, and device publish flows. Use when requests involve OCI IoT bootstrap, digital twin inspection, safe lifecycle operations, or translating OCI IoT docs and samples into concrete commands.
+---
+
+# OCI IoT Platform
+
+## Quick Start
+
+1. Confirm the user is working with Oracle Cloud Infrastructure Internet of Things Platform.
+2. Ask for the minimum context needed before giving commands:
+   - `IOT_DOMAIN_ID` when available
+   - `OCI_CLI_PROFILE`
+   - `OCI_CLI_AUTH` when the selected profile needs it, such as `security_token`
+   - `OCI_REGION` if it cannot be derived from the domain
+   - intended operation: inspect, create, update, delete, or publish test telemetry
+3. Prefer this execution order:
+   - discover the domain and current state
+   - inspect the relevant model, adapter, or twin
+   - check local CLI capability with `oci ... --help` when using newer filters or gateway/raw-command options
+   - make the smallest required change
+   - verify the result with a fresh read
+
+## Default Workflow
+
+1. Start with read-only OCI CLI discovery.
+2. Use `scripts/derive_domain_context.sh` when the user only has `IOT_DOMAIN_ID`.
+3. Use [references/platform-surface.md](references/platform-surface.md) when the task needs orientation on OCI IoT resource families, data flow, connectivity types, or which surface to use.
+4. Use [references/cli-workflows.md](references/cli-workflows.md) for control-plane actions:
+   - domains and domain groups
+   - digital twin models
+   - adapters
+   - instances
+   - relationships
+   - work requests
+   - HTTPS publish examples
+5. Use [references/mcp-optional-use.md](references/mcp-optional-use.md) only when an OCI IoT MCP server is already available in the user's environment. Keep CLI as the fallback and never require MCP for public workflows.
+6. Use [references/resilience-guidance.md](references/resilience-guidance.md) for:
+   - large or ambiguous list operations
+   - SDK or CLI command-shape drift
+   - gateway-aware topology
+   - relationship source/target diagnosis
+   - work-request failures
+   - publish rejection triage
+   - raw-command final-state validation
+   - cleanup or rollback planning
+7. Use [references/modeling-guidance.md](references/modeling-guidance.md) when the request involves DTDL authoring or adapter payload design.
+8. Use [references/data-access.md](references/data-access.md) only when the user explicitly needs Data API, ORDS, direct database access, or APEX-oriented workflows.
+9. Use [references/release-validation.md](references/release-validation.md) before calling the skill package ready to share publicly.
+
+## Bundled Resources
+
+- Run [scripts/derive_domain_context.sh](scripts/derive_domain_context.sh) to derive:
+  - region
+  - device host
+  - data host
+  - domain group OCID
+  - short IDs used in later commands
+- Run [scripts/twin_tools.py](scripts/twin_tools.py) for:
+  - `last-known`
+  - `offline`
+  - `telemetry-template`
+- Reuse [templates/model.temperature-sensor.template.json](templates/model.temperature-sensor.template.json), [templates/adapter.default.template.json](templates/adapter.default.template.json), [templates/instance.template.json](templates/instance.template.json), and [templates/publish-curl.template.sh](templates/publish-curl.template.sh) as neutral starting points.
+- Use [references/platform-surface.md](references/platform-surface.md) to explain how domains, domain groups, models, adapters, twins, relationships, work requests, raw commands, and data access fit together.
+- Use [references/resilience-guidance.md](references/resilience-guidance.md) to keep operator responses bounded, active-resource focused, and explicit about final-state evidence.
+- Use [references/mcp-optional-use.md](references/mcp-optional-use.md) to recognize optional OCI IoT MCP tool families, gateway-aware helper behavior, Data API wrappers, and safety rules.
+
+## Guardrails
+
+- Do not assume internal tenancy names, profiles, network access patterns, or private tooling.
+- Treat Oracle product docs and official samples as the source of truth for platform behavior.
+- Prefer read-only commands first and verify current state before recommending mutations.
+- When suggesting create, update, or delete operations, include a verification command immediately after the mutation.
+- Bound large reads with filters and `--limit` before using `--all`.
+- Treat asynchronous acceptance, including raw-command `202`, as incomplete until final state is verified.
+- For digital twin instance creation, never use `INDIRECT` as a shortcut to avoid auth setup. Use `INDIRECT` only when the user explicitly asks for a gateway/downstream topology or provides a gateway routing requirement. Otherwise clarify connectivity or proceed with `DIRECT` when a publishing device is implied.
+- Keep MCP guidance optional. Do not make MCP installation or private MCP bootstrap part of the public workflow.
+- When MCP is already available, treat it as an accelerator for joined context, selector resolution, bounded pagination, gateway topology, Data API summaries, and polling; always be ready to fall back to CLI or SDK commands.
+- Treat device publishing auth modes separately:
+  - vault-secret-backed basic auth
+  - certificate-based mTLS
+- Do not imply OCI IoT is a general-purpose MQTT broker.
+- Keep examples redacted and tenant-neutral.
+
+## Authoritative References
+
+- Oracle IoT service docs:
+  - `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/home.htm`
+- OCI CLI IoT command reference:
+  - `https://docs.oracle.com/en-us/iaas/tools/oci-cli/latest/oci_cli_docs/cmdref/iot.html`
+- Oracle sample repository:
+  - `https://github.com/oracle-samples/oci-iot-samples`
+
+## Output Style
+
+For each task, return:
+
+1. The exact command sequence with placeholders filled or called out.
+2. The key IDs, state, or timestamps that matter.
+3. The next verification step.

--- a/oci/iot-platform/agents/openai.yaml
+++ b/oci/iot-platform/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "OCI IoT Platform"
+  short_description: "Operate OCI IoT digital twins and publish workflows."
+  default_prompt: "Use $oci-iot-platform to inspect domains, manage digital twins, and build safe OCI IoT CLI workflows."

--- a/oci/iot-platform/references/cli-workflows.md
+++ b/oci/iot-platform/references/cli-workflows.md
@@ -1,0 +1,350 @@
+# OCI IoT CLI Workflows
+
+Use this file for the public, CLI-first operator path. For large fleets, gateway topology, publish failures, raw commands, or cleanup, pair these commands with [resilience-guidance.md](resilience-guidance.md).
+
+## Inputs To Gather
+
+- `IOT_DOMAIN_ID`
+- `OCI_CLI_PROFILE`
+- `OCI_CLI_AUTH` when the profile requires a non-default auth mode, such as `security_token`
+- `OCI_REGION` when not derivable from the domain
+- resource identifiers already known by the user:
+  - digital twin model ID
+  - digital twin adapter ID
+  - digital twin instance ID
+  - digital twin relationship ID
+  - work request ID
+
+If only `IOT_DOMAIN_ID` is known, derive the rest first:
+
+```bash
+bash scripts/derive_domain_context.sh \
+  --profile <oci_profile> \
+  --auth <oci_cli_auth> \
+  --iot-domain-id <iot_domain_ocid>
+```
+
+Omit `--auth` only when the selected profile uses the CLI default auth mode. For security-token profiles, use `--auth security_token` and add the same global option to later OCI CLI commands.
+
+## Command Capability Check
+
+Check local CLI help before relying on newer filters or topology options:
+
+```bash
+oci iot digital-twin-instance list --help
+oci iot digital-twin-instance create --help
+oci iot digital-twin-relationship list --help
+oci iot digital-twin-instance invoke-raw-json-command --help
+```
+
+If a documented CLI flag is missing locally, use the Python SDK or a narrower CLI fallback and call out the drift.
+
+## Read-First Discovery
+
+List the domain:
+
+```bash
+oci iot --profile <oci_profile> domain get \
+  --iot-domain-id <iot_domain_ocid> \
+  --output json
+```
+
+List domain groups only when the user needs tenancy discovery:
+
+```bash
+oci iot --profile <oci_profile> domain-group list --all
+```
+
+List active digital twin instances with a bounded first page:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-instance list \
+  --iot-domain-id <iot_domain_ocid> \
+  --lifecycle-state ACTIVE \
+  --limit 100 \
+  --output json
+```
+
+List active models:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-model list \
+  --iot-domain-id <iot_domain_ocid> \
+  --lifecycle-state ACTIVE \
+  --limit 100 \
+  --output json
+```
+
+List active adapters:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-adapter list \
+  --iot-domain-id <iot_domain_ocid> \
+  --lifecycle-state ACTIVE \
+  --limit 100 \
+  --output json
+```
+
+Use `--all` only after confirming the domain is small enough or the operator needs complete inventory.
+
+## Full CLI Surface Awareness
+
+For complete command-family coverage, see [platform-surface.md](platform-surface.md). The public CLI includes domain and domain-group lifecycle operations, data-retention changes, data-access configuration, work requests, all digital twin resource CRUD, digital twin content reads, and raw binary/json/text command invocation.
+
+Use help before high-risk or less common operations:
+
+```bash
+oci iot domain change-data-retention-period --help
+oci iot domain configure-apex-data-access --help
+oci iot domain configure-direct-data-access --help
+oci iot domain configure-ords-data-access --help
+oci iot domain-group configure-data-access --help
+oci iot digital-twin-instance invoke-raw-json-command --help
+```
+
+Do not provide an executable mutation for delete, compartment move, data-access configuration, retention changes, raw commands, or publish validation until the user approves that specific operation.
+
+## Inspect Twin Content
+
+Get instance metadata:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-instance get \
+  --digital-twin-instance-id <digital_twin_instance_ocid> \
+  --output json
+```
+
+Get latest content with metadata:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-instance get-content \
+  --digital-twin-instance-id <digital_twin_instance_ocid> \
+  --should-include-metadata true \
+  --output json
+```
+
+Normalize exported JSON locally when helpful:
+
+```bash
+python3 scripts/twin_tools.py last-known \
+  --input twin-content.json \
+  --timestamp-key _metadata.timeLastHeard
+```
+
+If the content response has metadata but no current values, treat that as incomplete evidence and check publish/rejected-data paths before claiming the twin is healthy.
+
+## Create A Model
+
+Start from the neutral template:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-model create \
+  --iot-domain-id <iot_domain_ocid> \
+  --display-name "Temperature Sensor v1" \
+  --spec file://templates/model.temperature-sensor.template.json \
+  --wait-for-state ACTIVE
+```
+
+Verify both metadata and stored spec:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-model get \
+  --digital-twin-model-id <digital_twin_model_ocid> \
+  --output json
+```
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-model get-spec \
+  --digital-twin-model-id <digital_twin_model_ocid> \
+  --output json
+```
+
+## Create An Adapter
+
+Use the neutral adapter template and update endpoint, timestamp mapping, and payload fields first.
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-adapter create \
+  --iot-domain-id <iot_domain_ocid> \
+  --digital-twin-model-id <digital_twin_model_ocid> \
+  --display-name "Temperature Adapter" \
+  --from-json file://templates/adapter.default.template.json \
+  --wait-for-state ACTIVE
+```
+
+Verify:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-adapter get \
+  --digital-twin-adapter-id <digital_twin_adapter_ocid> \
+  --output json
+```
+
+## Create A Publishing Twin Instance
+
+Update the instance template with the model, adapter, external key, and auth identifier first. For `DIRECT` twins, use an auth identifier owned by the test or deployment being validated; do not borrow an existing certificate or secret for release validation.
+
+Do not default to `INDIRECT` connectivity to avoid supplying `authId`. If the user simply asks for a device or publishing twin and does not mention gateway routing, treat `DIRECT` as the likely default and explain that direct twins require an auth resource such as a Vault secret or certificate. Only create an `INDIRECT` twin when the user explicitly asks for an indirectly connected, downstream, or gateway-routed device, or when they provide a gateway twin and state that the new twin should use it.
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-instance create \
+  --iot-domain-id <iot_domain_ocid> \
+  --connectivity-type DIRECT \
+  --from-json file://templates/instance.template.json \
+  --wait-for-state ACTIVE
+```
+
+Verify:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-instance get \
+  --digital-twin-instance-id <digital_twin_instance_ocid> \
+  --output json
+```
+
+## Gateway-Aware Instances
+
+Gateway routing is an explicit topology choice, not a substitute for publishing-device auth setup. Before creating an indirect twin, confirm the user intends a downstream device and identify the gateway twin.
+
+List active gateway twins:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-instance list \
+  --iot-domain-id <iot_domain_ocid> \
+  --connectivity-type GATEWAY \
+  --lifecycle-state ACTIVE \
+  --limit 100 \
+  --output json
+```
+
+Create an indirect twin only after the gateway twin is active:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-instance create \
+  --iot-domain-id <iot_domain_ocid> \
+  --connectivity-type INDIRECT \
+  --gateways '["<gateway_twin_ocid>"]' \
+  --digital-twin-model-id <digital_twin_model_ocid> \
+  --digital-twin-adapter-id <digital_twin_adapter_ocid> \
+  --display-name "<display_name>" \
+  --external-key "<external_key>" \
+  --wait-for-state ACTIVE
+```
+
+Verify the created instance and confirm `connectivityType` and `gateways`.
+
+## Create A Relationship
+
+Only create a relationship after confirming the source model defines the content path and both twins are active.
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-relationship create \
+  --iot-domain-id <iot_domain_ocid> \
+  --source-digital-twin-instance-id <source_twin_ocid> \
+  --target-digital-twin-instance-id <target_twin_ocid> \
+  --content-path <relationship_name>
+```
+
+Verify with source, target, and content-path filters:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-relationship list \
+  --iot-domain-id <iot_domain_ocid> \
+  --source-digital-twin-instance-id <source_twin_ocid> \
+  --target-digital-twin-instance-id <target_twin_ocid> \
+  --content-path <relationship_name> \
+  --lifecycle-state ACTIVE \
+  --limit 100 \
+  --output json
+```
+
+If no relationship appears, check the reverse direction before creating another relationship.
+
+## Work Request Inspection
+
+Use work requests for asynchronous failures or long-running operations:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> work-request get \
+  --work-request-id <work_request_ocid> \
+  --output json
+```
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> work-request list-errors \
+  --work-request-id <work_request_ocid> \
+  --limit 100 \
+  --output json
+```
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> work-request list-logs \
+  --work-request-id <work_request_ocid> \
+  --limit 100 \
+  --output json
+```
+
+After inspecting the work request, read the target resource again. A queued or accepted operation is not final-state proof.
+
+## Device Connectivity And Publish Testing
+
+The bundled template covers HTTPS publish testing. Oracle also documents MQTTs device-connect paths for structured publish and command response workflows. When MQTTs is in scope, use the official device-connect documentation and samples for topic/auth details; do not adapt the HTTPS template by guessing MQTT behavior.
+
+## Publish Test Telemetry Over HTTPS
+
+Choose the auth mode first.
+
+The HTTPS publish URL path must match the adapter `inboundEnvelope.referenceEndpoint`. For the bundled adapter template, `referenceEndpoint` is `/sampletopic`, so the publish URL is:
+
+```text
+https://<domain-short-id>.device.iot.<region>.oci.oraclecloud.com/sampletopic
+```
+
+Posting to the bare device host returns `404 Not Found`; that usually means the path is missing or does not match the adapter endpoint.
+
+For vault-secret-backed basic auth, start from:
+
+```bash
+bash templates/publish-curl.template.sh
+```
+
+For certificate-based publishing, switch to an mTLS client flow instead of `curl -u`.
+
+After publishing, verify the twin content again. For basic validation, `digital-twin-instance get-content` with metadata is enough to prove the publish updated the twin:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-instance get-content \
+  --digital-twin-instance-id <digital_twin_instance_ocid> \
+  --should-include-metadata true \
+  --output json
+```
+
+If content did not update, check adapter endpoint path, payload content type, timestamp mapping, and auth mode. Rejected-data, snapshot, historized, or ORDS/Data API checks are optional advanced evidence paths and require separate Data API or `OCI_IOT_ORDS_*` credentials.
+
+## Invoke A Raw JSON Command
+
+Raw-command acceptance is not the same as device completion. Include response fields when a response is expected:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-instance invoke-raw-json-command \
+  --digital-twin-instance-id <digital_twin_instance_ocid> \
+  --request-endpoint <request_endpoint> \
+  --request-duration PT30S \
+  --response-endpoint <response_endpoint> \
+  --response-duration PT30S \
+  --request-data-content-type application/json \
+  --request-data file://command-request.json
+```
+
+Verify final state through command response records, device-side evidence, or a fresh twin read.
+
+## Cleanup Ordering
+
+For teardown, read dependencies first, then delete in this order:
+
+1. relationships
+2. digital twin instances
+3. adapters with no active dependent instances
+4. models with no active dependent adapters or instances
+
+Ask for explicit approval before destructive operations, and verify each resource reaches `DELETED` or disappears from active listings.

--- a/oci/iot-platform/references/data-access.md
+++ b/oci/iot-platform/references/data-access.md
@@ -1,0 +1,110 @@
+# OCI IoT Data Access
+
+Use this file only when the user explicitly needs data-plane access beyond the default OCI CLI workflows.
+
+## Scope
+
+This reference covers advanced and optional paths:
+
+- IoT Data API
+- ORDS-backed queries
+- direct database access
+- APEX-oriented workspace access
+
+These paths usually require separate authentication, networking, or tenancy setup beyond normal CLI usage.
+
+## When To Use This Path
+
+Use advanced data access when the user asks for one of these:
+
+- historized values
+- raw ingestion records
+- rejected telemetry details
+- command round-trip data
+- APEX workspace changes
+
+Do not default to this path for ordinary digital twin inspection.
+
+## Prerequisite Checklist
+
+Confirm which of these already exist:
+
+- an IoT domain group and domain
+- IAM policy allowing the requested access
+- OAuth client details for the Data API path
+- network path for database access, when direct DB access is required
+- any required private network connectivity
+
+If these prerequisites are missing, say so clearly before giving commands.
+
+## Data API / ORDS Notes
+
+- Treat the Data API and ORDS flows as separate from the control plane.
+- Keep tokens, client secrets, and user passwords out of logs and shared transcripts.
+- Prefer narrow, task-specific queries rather than broad dumps.
+- Verify the user actually needs raw, rejected, or historized records before steering them here.
+- Use the domain-group short ID and domain short ID to form the ORDS/Data API base path.
+- Treat snapshot, raw, historized, rejected, and raw-command data as separate collections with different verification value.
+- Keep list windows bounded by time, twin filter, limit, or another narrow query parameter.
+- Fetch a record by ID when a list response omits payload details needed for diagnosis.
+
+Typical Data API base URL shape:
+
+```text
+https://<domain_group_short_id>.data.iot.<region>.oci.oraclecloud.com/ords/<domain_short_id>
+```
+
+Common collection paths:
+
+- `/snapshotData` for latest normalized twin snapshots
+- `/rawData` for accepted raw ingestion records
+- `/historizedData` for historized records when retention is enabled
+- `/rejectedData` for rejected ingest details
+- `/rawCommandData` for raw-command request and response records
+
+Optional MCP servers may provide wrappers for these collections, token minting, and latest-state summaries. Use them only when already available and still treat returned bearer tokens as secrets.
+
+## Direct Database Access Notes
+
+Direct database access is powerful but operationally heavier than the CLI path.
+
+Typical prerequisites include:
+
+- a reachable network path
+- tenancy permissions
+- token-based database access
+- the correct schema context for the requested task
+
+If the user only needs current twin state, prefer `digital-twin-instance get-content` instead.
+
+## Data Access Configuration
+
+Treat data-access configuration as a mutation on the IoT domain or domain group. The public CLI includes separate domain commands for APEX, DIRECT, and ORDS access, plus domain-group data access configuration. These are not default troubleshooting steps.
+
+Before suggesting them:
+
+- identify whether the user needs APEX, ORDS/Data API, direct database, or VCN-scoped access
+- read the existing domain or domain-group configuration
+- inspect the relevant `oci iot domain ... --help` or `oci iot domain-group ... --help` output
+- confirm the IAM, identity-domain, VCN, or workspace prerequisites
+- ask for explicit approval before making the change
+
+## APEX Notes
+
+APEX-related work should be treated as separate from core digital twin operations.
+
+Before suggesting workspace changes:
+
+- confirm that the user actually needs APEX access
+- separate workspace actions from IoT control-plane actions
+- avoid implying APEX is part of the default public skill path
+
+## Guidance For Responses
+
+When using this reference:
+
+1. State that the workflow is advanced or optional.
+2. List the prerequisites that are assumed.
+3. Give the smallest command set needed for the task.
+4. Include a verification step.
+5. Say whether a CLI/API fallback exists if an optional MCP helper was used.

--- a/oci/iot-platform/references/mcp-optional-use.md
+++ b/oci/iot-platform/references/mcp-optional-use.md
@@ -1,0 +1,95 @@
+# Optional OCI IoT MCP Use
+
+Use this reference only when the user's environment already exposes an OCI IoT MCP server. The public skill must stay useful without MCP; do not make MCP installation, private server bootstrap, or private credentials part of the default workflow.
+
+## When MCP Helps
+
+Prefer the OCI CLI for public, repeatable command sequences. Use MCP as an optional accelerator when the task needs joined context or operator-friendly wrappers, such as:
+
+- resolving an IoT domain or twin from friendly selectors
+- inspecting how a twin maps to its domain, domain group, model, adapter, and gateway topology
+- checking latest snapshot, historized, raw-command, and rejected-data records together
+- passively validating whether a twin is reporting data
+- waiting for a raw-command result or a snapshot update
+- avoiding unbounded relationship traversal by using page-aware or bounded helpers
+- checking gateway-aware fields before diagnosing indirect device telemetry
+
+## Tool Families To Recognize
+
+An OCI IoT MCP server may expose these categories. Names vary by implementation, so inspect the tool list in the active client instead of assuming every tool exists.
+
+Control plane:
+
+- IoT domain and domain group get/list/create/update/delete
+- compartment moves
+- data retention changes
+- data access configuration
+- work request get/list/log/error inspection
+- digital twin model, adapter, instance, and relationship CRUD
+- digital twin instance content reads
+- raw-command invocation
+
+Data plane:
+
+- token or domain-context helpers for the IoT Data API
+- raw data list/get
+- snapshot data list
+- historized data list/get
+- rejected data list/get
+- raw command data list/get
+
+Agent-oriented wrappers:
+
+- domain context derivation
+- latest twin state
+- platform context for a twin
+- passive twin readiness validation
+- recent raw command and rejected-data lookups for a twin
+- raw command invocation plus wait
+- wait for twin snapshot update
+
+## Auth Mode Pinning
+
+For customer environments that should use an API-key OCI profile, pin the MCP server auth environment instead of relying on auto-detection:
+
+```bash
+OCI_CONFIG_PROFILE=<customer_api_key_profile>
+OCI_IOT_AUTH_TYPE=api_key
+OCI_REGION=<oci_region>
+```
+
+If MCP calls fail with `401 NotAuthenticated`, first verify the selected profile, region, and auth type. In workstations with multiple OCI auth styles configured, automatic auth selection may choose a different or stale local auth path. Pinning `OCI_IOT_AUTH_TYPE=api_key` avoids that ambiguity for API-key profile tests. Use `OCI_IOT_AUTH_TYPE=security_token` only when the intended profile is a fresh security-token profile.
+
+## Gateway-Aware Patterns
+
+Gateway-aware MCP surfaces should preserve these instance fields:
+
+- `connectivity_type`: `DIRECT`, `INDIRECT`, `GATEWAY`, or `NONE`
+- `gateways`: gateway digital twin instance OCIDs for indirect twins
+- `auth_id`, `external_key`, model IDs, adapter IDs, lifecycle state, and tags when available
+
+Use these fields to reason about topology:
+
+1. For an `INDIRECT` twin, resolve each gateway ID before diagnosing telemetry.
+2. For a `GATEWAY` twin, use a bounded indirect-child lookup; do not assume one page contains every child.
+3. For missing data, verify adapter endpoint paths, external keys, payload mapping, rejected-data records, and gateway topology before blaming the platform.
+4. For relationship checks, filter by source, target, content path, and lifecycle state before broad listing.
+
+## Safety Rules
+
+- MCP tool calls run with the authority of the configured OCI profile or bearer token.
+- Treat returned Data API bearer tokens as secrets.
+- Prefer read-only MCP calls first.
+- Ask for explicit approval before create, update, delete, data-access configuration, compartment moves, raw-command invocation, or publish-like actions.
+- Treat asynchronous acceptance and raw-command `202` responses as incomplete until final state is verified.
+- For basic publish validation, a digital twin instance content read with metadata is sufficient when it shows the updated state. MCP Data API or ORDS helpers are optional and may require separate `OCI_IOT_ORDS_*` credentials.
+- If MCP output conflicts with CLI or SDK behavior, verify with a direct read and state the discrepancy.
+
+## Response Pattern
+
+When using MCP, tell the user:
+
+1. Which MCP tool family was used.
+2. Why MCP was useful compared with direct CLI.
+3. What final-state evidence was verified.
+4. Which direct CLI or SDK command would be the fallback if MCP is unavailable.

--- a/oci/iot-platform/references/modeling-guidance.md
+++ b/oci/iot-platform/references/modeling-guidance.md
@@ -1,0 +1,56 @@
+# OCI IoT Modeling Guidance
+
+Use this file when the request involves digital twin model authoring, version changes, adapter payload mapping, or DTDL review.
+
+## Principles
+
+1. Start with the smallest model that supports the use case.
+2. Keep payload shape and adapter mapping aligned.
+3. Version the model when semantics change.
+4. Prefer explicit names and units.
+5. Treat local modeling preferences as examples, not platform rules.
+
+## DTDL Basics
+
+- Use DTDL v3 for model definitions.
+- Give every interface a stable DTMI.
+- Use descriptive `displayName` values, but avoid depending on them for logic.
+- Keep schema choices simple unless the use case demands complexity.
+
+## Versioning
+
+Increment the DTMI version when behavior or meaning changes, such as:
+
+- adding or removing telemetry fields
+- changing units
+- changing validation constraints
+- changing relationship semantics
+
+## Telemetry Design
+
+- Use consistent timestamp handling between the device payload and the adapter envelope.
+- Add units for quantitative values when the model supports them.
+- Keep field names stable once devices start publishing.
+- Prefer one clear example model over a broad, overloaded sample.
+
+## Adapter Design
+
+- Keep the inbound envelope small and representative.
+- Make the reference payload realistic enough to test mapping.
+- Map only the fields the model actually exposes.
+- Review publish auth and endpoint choices separately from payload mapping.
+
+## Relationship Design
+
+- Use relationships when they model real graph structure.
+- Confirm the relationship content path exists in the source model before creating instances.
+- Avoid encoding business meaning twice in both strings and relationships unless there is a specific reason.
+
+## Safe Public Examples
+
+For public templates:
+
+- use neutral names
+- use placeholder identifiers
+- avoid tenant-specific topic paths unless clearly labeled as examples
+- avoid environment-specific assumptions about auth mode

--- a/oci/iot-platform/references/platform-surface.md
+++ b/oci/iot-platform/references/platform-surface.md
@@ -1,0 +1,90 @@
+# OCI IoT Platform Surface
+
+Use this reference to orient before choosing CLI, SDK, or optional MCP tools. It summarizes the public OCI IoT resource model and function families without assuming a specific tenancy.
+
+## Resource Model
+
+OCI IoT Platform work usually flows through these resources:
+
+```text
+Compartment
+  -> IoT domain group
+      -> IoT domain
+          -> digital twin model
+          -> digital twin adapter
+          -> digital twin instance
+          -> digital twin relationship
+          -> work requests
+          -> data retention and data access configuration
+```
+
+The data path is separate from control-plane management:
+
+```text
+device, gateway, or external application publish
+  -> domain device host
+  -> adapter endpoint and envelope mapping
+  -> digital twin snapshot / historized data / rejected data
+  -> optional Data API, ORDS, direct database, or APEX-facing views
+```
+
+Raw commands are a control-plane request that must be verified through a data-plane or device-side final-state signal.
+
+Device connectivity is broader than the HTTPS template bundled with this skill. Oracle documents sending unstructured data over HTTPS, structured data over HTTPS, structured data over MQTTs, custom-format structured data over HTTPS, and receiving unstructured commands with MQTTs responses. Do not describe OCI IoT as a general-purpose MQTT broker; treat MQTTs as a documented device-connect path with its own auth, topic, and response semantics.
+
+## Function Families
+
+| Family | What It Controls | Typical Use | Verification |
+| --- | --- | --- | --- |
+| Domain groups | Shared grouping, data host, group-level data access | Bootstrap tenancy context and data-host short ID | Read domain group and derived data host |
+| Domains | Device host, domain metadata, data retention, domain-level data access | Locate target IoT environment | Read domain, lifecycle state, device host, group ID |
+| Models | DTDL model specs | Define twin shape, telemetry, properties, relationships | Read model and stored spec |
+| Adapters | Inbound routes and payload envelope mapping | Map published payloads into twin content | Read adapter, route, model link, envelope |
+| Instances | Digital twins for devices, gateways, logical assets, or indirect devices | Create or inspect a twin and its connectivity | Read instance, content, connectivity type, gateways |
+| Relationships | Directed graph edges between twins | Model topology or containment | Filter by source, target, content path, lifecycle |
+| Work requests | Async operation status, errors, logs | Diagnose create/update/delete failures | Read status, errors, logs, target resource state |
+| Raw commands | Request/response dispatch through a twin | Send a command to a device integration | Verify response record, device evidence, or state change |
+| Data API | Snapshot, raw, historized, rejected, and raw-command records | Troubleshoot current and historical ingest | Bounded query plus record-by-ID when needed |
+| Data access config | ORDS, direct DB, APEX, VCN/identity access | Enable advanced data workflows | Read config and test narrow access path |
+
+## CLI Command Families
+
+The public OCI CLI exposes these IoT command groups:
+
+- `digital-twin-adapter`: create, delete, get, list, update
+- `digital-twin-instance`: create, delete, get, get-content, invoke raw binary/json/text command, list, update
+- `digital-twin-model`: create, delete, get, get-spec, list, update
+- `digital-twin-relationship`: create, delete, get, list, update
+- `domain`: create, delete, get, list, update, change compartment, change data retention period, configure APEX/DIRECT/ORDS data access
+- `domain-group`: create, delete, get, list, update, change compartment, configure data access
+- `work-request`: get, list, list errors, list logs
+
+For high-risk operations such as data-access configuration, compartment moves, deletes, raw commands, or retention changes, inspect command help first and ask for explicit approval before giving an executable mutation sequence.
+
+## Connectivity Types
+
+Digital twin instances may use:
+
+- `DIRECT`: a directly connected device twin; usually needs an auth resource for publishing.
+- `GATEWAY`: a gateway twin that can represent downstream device connectivity.
+- `INDIRECT`: a downstream twin connected through one or more gateway twin OCIDs in `gateways`.
+- `NONE`: a logical or non-connected twin.
+
+Before diagnosing telemetry, inspect `connectivity_type`, `gateways`, adapter endpoint path, external key, and latest content metadata.
+
+## Operation Posture
+
+For every function family:
+
+1. Read the current resource first.
+2. Prefer lifecycle-state filters and `--limit` before complete inventory.
+3. Check local CLI help or SDK docs when using newer fields.
+4. Ask for explicit approval before create, update, delete, data-access config, compartment moves, raw commands, or publish validation.
+5. Verify final state after the operation.
+
+## Surface Selection
+
+- Use OCI CLI for public, reproducible command sequences.
+- Use Python SDK for programmatic pagination, typed fields, or structured reports.
+- Use optional MCP only when it is already available and helps join context, resolve selectors, poll state, or summarize Data API evidence.
+- Use direct Data API, ORDS, database, or APEX paths only when the user explicitly needs advanced data access.

--- a/oci/iot-platform/references/release-validation.md
+++ b/oci/iot-platform/references/release-validation.md
@@ -1,0 +1,74 @@
+# Public Skill Release Validation
+
+Use this checklist before calling the `oci-iot-platform` skill ready to share.
+
+## Automated Checks
+
+Run:
+
+```bash
+bash oci-iot-platform/tests/smoke.sh
+```
+
+```bash
+bash oci-iot-platform/tests/redaction_scan.sh
+```
+
+## Content Review
+
+Check for:
+
+- no internal tenancy names
+- no private network-access or MCP bootstrap instructions
+- no team-specific account setup
+- no secrets or real OCIDs in examples
+- no environment-specific behavior stated as a platform rule
+
+## Manual Validation Scenarios
+
+Validate at least one clean or minimally configured operator environment with public OCI CLI authentication. A separate tenancy is useful but not required when one is not available; the validation must prove the workflow can run without internal profiles, private setup, or MCP dependencies. Prefer a `security_token` auth profile or another documented public OCI CLI auth mode for this pass.
+
+1. `IOT_DOMAIN_ID` bootstrap, including `--auth security_token` when using a security-token profile
+2. read-only discovery of domains and twins
+3. model creation and readback
+4. adapter creation and readback
+5. twin instance creation and readback
+6. test publish flow and content verification using a test-owned auth resource; do not reuse an existing certificate or secret
+7. confirm the HTTPS publish URL includes the adapter `inboundEnvelope.referenceEndpoint`; posting to the bare device host is not a valid publish test
+8. confirm normal publishing-device twins are `DIRECT` unless the validation intentionally covers a gateway/downstream topology
+
+If Data API or direct DB guidance ships in the release, validate at least one example there too.
+
+Also verify operator-resilience guidance remains public-safe and covers:
+
+- bounded list pagination and lifecycle-state filtering, with no unbounded fleet scans
+- SDK and CLI capability drift checks, including documented fallbacks when one surface lacks a feature
+- gateway-aware twin validation, including child or downstream device context where relevant
+- direct-vs-indirect instance creation guidance that does not use `INDIRECT` to avoid auth setup
+- relationship direction and source/target filtering, not only broad relationship listing
+- work-request status, log, and error inspection for asynchronous operations
+- publish rejection triage for topic, auth, schema, domain, and lifecycle-state failures
+- publish endpoint triage for missing or mismatched adapter reference endpoint paths
+- raw-command final-state validation after command submission, not only accepted requests
+- cleanup ordering that removes relationships, twins, adapters, and models safely
+- optional MCP guidance that recognizes tool families and fallback rules without requiring MCP install or private bootstrap
+- Data API collection guidance for snapshot, raw, historized, rejected, and raw-command records
+
+## Release Blockers
+
+Do not release if any of these are true:
+
+- the skill requires internal-only tooling
+- MCP is treated as required instead of optional
+- MCP guidance omits direct CLI or SDK fallback behavior
+- the smoke checks fail
+- redaction scanning finds likely secrets
+- the examples depend on undocumented tenant assumptions
+- the default workflow cannot be followed with public docs plus OCI CLI
+- default list guidance uses unbounded fleet scans before filters or `--limit`
+- newer CLI flags are documented without a `oci ... --help` drift check or SDK fallback
+- raw-command acceptance is treated as final completion evidence
+- publish examples skip final twin-content or rejected-data verification
+- publish examples omit the adapter reference endpoint path or imply that the bare device host is enough
+- instance creation examples use `INDIRECT` to avoid supplying a direct-auth resource
+- cleanup guidance omits dependency ordering or destructive-operation approval

--- a/oci/iot-platform/references/resilience-guidance.md
+++ b/oci/iot-platform/references/resilience-guidance.md
@@ -1,0 +1,207 @@
+# OCI IoT Operator Resilience Guidance
+
+Use this reference when an OCI IoT task involves troubleshooting, large fleets, gateway topology, raw commands, publish failures, cleanup, or uncertainty about CLI, SDK, or MCP behavior.
+
+## Default Operator Posture
+
+- Read before changing. Capture current resource state before create, update, delete, publish, or command operations.
+- Prefer `ACTIVE` resources unless the user is explicitly auditing deleted or historical resources.
+- Bound list operations. Use `--limit`, targeted filters, and follow-up pages before using `--all` in a large domain.
+- Verify every mutation with a fresh read. For asynchronous operations, also inspect the work request.
+- Keep public examples tenant-neutral. Do not introduce internal profiles, private network access patterns, schemas, or private tooling.
+
+## CLI, SDK, And MCP Routing
+
+Use the OCI CLI as the default public path because it is broadly available and maps cleanly to Oracle documentation.
+
+Before using recently added flags or when CLI docs, SDK docs, and local behavior differ, verify the local command shape:
+
+```bash
+oci iot digital-twin-instance list --help
+oci iot digital-twin-instance create --help
+oci iot digital-twin-relationship list --help
+oci iot digital-twin-instance invoke-raw-json-command --help
+```
+
+Use the Python SDK when the task needs repeatable structured pagination, programmatic reporting, or fields that are exposed in the SDK before examples appear in CLI docs.
+
+MCP is optional. Use an OCI IoT MCP server only when it is already available in the user's environment. Treat MCP output as an operator convenience, not as a release requirement. Useful MCP-style patterns to preserve in responses are structured errors, retry hints, bounded pagination, selector ambiguity checks, friendly domain/twin resolution, gateway-topology summaries, Data API current-state summaries, and explicit final-state validation. See [mcp-optional-use.md](mcp-optional-use.md) for the optional tool families and fallback rules.
+
+## Bounded Pagination
+
+For first-pass discovery, avoid unbounded domain-wide reads:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-instance list \
+  --iot-domain-id <iot_domain_ocid> \
+  --lifecycle-state ACTIVE \
+  --limit 100 \
+  --output json
+```
+
+If a response includes a next page token, continue only while the next token is new and the page is useful. Stop and report the condition if a page is empty but returns another token, or if the same next token repeats.
+
+For operator summaries, use targeted filters first:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-instance list \
+  --iot-domain-id <iot_domain_ocid> \
+  --digital-twin-model-id <digital_twin_model_ocid> \
+  --connectivity-type DIRECT \
+  --lifecycle-state ACTIVE \
+  --limit 100 \
+  --output json
+```
+
+Use `--all` only after confirming the domain is small enough or the user explicitly needs complete inventory.
+
+## Latest Twin Content
+
+Always request metadata when checking current state:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-instance get-content \
+  --digital-twin-instance-id <digital_twin_instance_ocid> \
+  --should-include-metadata true \
+  --output json
+```
+
+Treat `timeLastHeard`, adapter timestamps, and content timestamps as evidence, not assumptions. In exported JSON, metadata may appear at `data._metadata` or under the returned content object. If the response is effectively etag-only or lacks content, say that there is no current-state evidence yet and verify publish, adapter mapping, and rejected data instead of claiming the twin is healthy.
+
+## Gateway-Aware Twins
+
+Digital twin instances can be direct devices, gateways, indirect devices, or non-connected logical twins. Check the topology before diagnosing telemetry:
+
+When creating a digital twin instance, do not assume `INDIRECT` connectivity. If the request is for a normal publishing device and no gateway routing is mentioned, use or recommend `DIRECT` and explain the required auth resource. Use `INDIRECT` only when the user explicitly asks for a downstream/gateway-routed device or provides a gateway routing requirement.
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-instance list \
+  --iot-domain-id <iot_domain_ocid> \
+  --connectivity-type GATEWAY \
+  --lifecycle-state ACTIVE \
+  --limit 100 \
+  --output json
+```
+
+For indirect devices, inspect the instance and confirm the `gateways` field:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-instance get \
+  --digital-twin-instance-id <indirect_twin_ocid> \
+  --output json
+```
+
+When creating an indirect twin, pass a gateway list only after confirming the gateway twin is `ACTIVE` and has `connectivityType` of `GATEWAY`:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-instance create \
+  --iot-domain-id <iot_domain_ocid> \
+  --connectivity-type INDIRECT \
+  --gateways '["<gateway_twin_ocid>"]' \
+  --digital-twin-model-id <digital_twin_model_ocid> \
+  --digital-twin-adapter-id <digital_twin_adapter_ocid> \
+  --display-name "<display_name>" \
+  --external-key "<external_key>" \
+  --wait-for-state ACTIVE
+```
+
+If a gateway publishes on behalf of downstream devices, verify adapter endpoint paths, external keys, and timestamp mapping before assuming a platform issue.
+
+When an optional MCP server is available, prefer gateway-aware context helpers for topology diagnosis because they can combine the twin, domain, domain group, adapter, model, gateway references, and bounded indirect-child discovery in one structured payload. Still verify critical results with direct reads before mutation.
+
+## Relationship Direction
+
+Relationship direction matters. Before creating or troubleshooting a relationship:
+
+- confirm the source model defines the `contentPath` or relationship property being used
+- confirm both source and target twins are `ACTIVE`
+- filter by source, target, and content path instead of reading all relationships
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-relationship list \
+  --iot-domain-id <iot_domain_ocid> \
+  --source-digital-twin-instance-id <source_twin_ocid> \
+  --target-digital-twin-instance-id <target_twin_ocid> \
+  --content-path <relationship_name> \
+  --lifecycle-state ACTIVE \
+  --limit 100 \
+  --output json
+```
+
+If a relationship appears missing, check the reverse direction before creating a duplicate.
+
+## Work Requests
+
+After create, update, or delete operations, capture the work request ID when the CLI returns one. For failures or slow state transitions, inspect status, errors, and logs:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> work-request get \
+  --work-request-id <work_request_ocid> \
+  --output json
+```
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> work-request list-errors \
+  --work-request-id <work_request_ocid> \
+  --limit 100 \
+  --output json
+```
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> work-request list-logs \
+  --work-request-id <work_request_ocid> \
+  --limit 100 \
+  --output json
+```
+
+Do not treat a queued or accepted work request as a completed operation. Verify the target resource state afterward.
+
+## Publish Failure Triage
+
+After a publish attempt, verify the latest content first. If content did not update:
+
+- confirm the HTTPS endpoint path matches the adapter `inboundEnvelope.referenceEndpoint`
+- confirm the payload content type matches the adapter expectation
+- confirm the timestamp format and property names match the adapter mapping
+- keep basic-auth and mTLS troubleshooting separate
+- check rejected data through the advanced Data API or ORDS path when available
+- check historized data only when the domain is configured to store it
+
+A `404 Not Found` from the bare device host usually means the publish URL is missing the adapter endpoint path or the path does not match `inboundEnvelope.referenceEndpoint`. Add the reference endpoint path before changing auth or payload assumptions.
+
+For basic validation, a fresh `digital-twin-instance get-content --should-include-metadata true` read is enough when it shows the published state. Data API or ORDS checks for rejected, snapshot, historized, or raw records are optional advanced evidence paths and may require separate credentials. For failures with only partial evidence, state exactly what was verified and what remains unknown. A successful HTTP response from a publishing client is not enough by itself; the twin content or rejected-data reason is the stronger verification point.
+
+If MCP Data API helpers are available, use them to fetch recent rejected-data, snapshot, historized, and raw-command records for the target twin. Keep the query bounded and avoid logging bearer tokens.
+
+## Raw Command Completion
+
+For raw commands, a `202` response means the command was accepted for processing. It does not prove the device received the command or returned a response.
+
+When a response is expected, include response endpoint and duration fields:
+
+```bash
+oci iot --profile <oci_profile> --region <oci_region> digital-twin-instance invoke-raw-json-command \
+  --digital-twin-instance-id <digital_twin_instance_ocid> \
+  --request-endpoint <request_endpoint> \
+  --request-duration PT30S \
+  --response-endpoint <response_endpoint> \
+  --response-duration PT30S \
+  --request-data-content-type application/json \
+  --request-data file://command-request.json
+```
+
+Verify the final state through the Data API, ORDS command records, device logs, or a fresh twin content read. If the command has no response path, say that the command can only be verified by downstream state or device-side evidence.
+
+If an optional MCP server exposes a raw-command-and-wait helper, use it only after explicit approval to send the command. It should poll for terminal data-plane evidence; a `202` accepted response alone is not completion.
+
+## Cleanup Ordering
+
+For teardown or rollback:
+
+1. List and delete active relationships for the target twins.
+2. Delete digital twin instances.
+3. Delete adapters only after no active instances use them.
+4. Delete models only after no active adapters or instances depend on them.
+5. Verify each resource reaches `DELETED` or no longer appears in active listings.
+
+Never recommend broad deletion from a name match alone. Read the resource by OCID, confirm dependencies, and ask for explicit approval before destructive operations.

--- a/oci/iot-platform/scripts/derive_domain_context.sh
+++ b/oci/iot-platform/scripts/derive_domain_context.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROFILE=""
+AUTH_MODE=""
+IOT_DOMAIN_ID=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)
+      PROFILE="$2"
+      shift 2
+      ;;
+    --auth)
+      AUTH_MODE="$2"
+      shift 2
+      ;;
+    --iot-domain-id)
+      IOT_DOMAIN_ID="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$IOT_DOMAIN_ID" ]]; then
+  echo "Missing required --iot-domain-id" >&2
+  exit 2
+fi
+
+OCI_BASE=(oci iot)
+if [[ -n "$PROFILE" ]]; then
+  OCI_BASE+=(--profile "$PROFILE")
+fi
+if [[ -n "$AUTH_MODE" ]]; then
+  OCI_BASE+=(--auth "$AUTH_MODE")
+fi
+
+DOMAIN_JSON="$("${OCI_BASE[@]}" domain get --iot-domain-id "$IOT_DOMAIN_ID" --output json)"
+DEVICE_HOST="$(jq -r '.data."device-host"' <<<"$DOMAIN_JSON")"
+DOMAIN_GROUP_OCID="$(jq -r '.data."iot-domain-group-id"' <<<"$DOMAIN_JSON")"
+
+REGION="$(printf '%s' "$DEVICE_HOST" | awk -F. '{print $(NF-3)}')"
+DOMAIN_SHORT_ID="$(printf '%s' "$DEVICE_HOST" | cut -d. -f1)"
+
+DOMAIN_GROUP_JSON="$("${OCI_BASE[@]}" domain-group get --iot-domain-group-id "$DOMAIN_GROUP_OCID" --output json)"
+DATA_HOST="$(jq -r '.data."data-host"' <<<"$DOMAIN_GROUP_JSON")"
+DOMAIN_GROUP_SHORT_ID="$(printf '%s' "$DATA_HOST" | cut -d. -f1)"
+
+cat <<EOF
+IOT_DOMAIN_ID=$IOT_DOMAIN_ID
+REGION=$REGION
+DEVICE_HOST=$DEVICE_HOST
+DATA_HOST=$DATA_HOST
+DOMAIN_SHORT_ID=$DOMAIN_SHORT_ID
+DOMAIN_GROUP_SHORT_ID=$DOMAIN_GROUP_SHORT_ID
+DOMAIN_GROUP_OCID=$DOMAIN_GROUP_OCID
+EOF

--- a/oci/iot-platform/scripts/twin_tools.py
+++ b/oci/iot-platform/scripts/twin_tools.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Utility helpers for OCI IoT digital twin JSON workflows."""
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="OCI IoT twin JSON utilities")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    p_last = subparsers.add_parser("last-known", help="Find latest observation")
+    p_last.add_argument("--input", required=True, help="Input JSON file path")
+    p_last.add_argument("--device-key", default=None, help="Key with device ID")
+    p_last.add_argument("--device-id", default=None, help="Filter by device ID")
+    p_last.add_argument(
+        "--timestamp-key",
+        default="timestamp",
+        help="Timestamp key path (supports dot notation)",
+    )
+    p_last.add_argument(
+        "--value-key",
+        default=None,
+        help="Value key path to highlight (supports dot notation)",
+    )
+
+    p_offline = subparsers.add_parser("offline", help="List offline devices")
+    p_offline.add_argument("--input", required=True, help="Input JSON file path")
+    p_offline.add_argument(
+        "--device-key",
+        default="deviceId",
+        help="Key containing device identifier",
+    )
+    p_offline.add_argument(
+        "--timestamp-key",
+        default="lastSeen",
+        help="Timestamp key path (supports dot notation)",
+    )
+    p_offline.add_argument(
+        "--threshold-minutes",
+        type=float,
+        required=True,
+        help="Offline threshold in minutes",
+    )
+    p_offline.add_argument(
+        "--now",
+        default=None,
+        help="Reference UTC time (ISO8601). Defaults to current UTC.",
+    )
+
+    p_template = subparsers.add_parser(
+        "telemetry-template", help="Generate telemetry payload JSON"
+    )
+    p_template.add_argument("--device-id", required=True, help="Device identifier")
+    p_template.add_argument("--twin-id", required=True, help="Twin identifier")
+    p_template.add_argument(
+        "--metric",
+        action="append",
+        default=[],
+        help="Metric key=value pair; can be repeated",
+    )
+    p_template.add_argument(
+        "--output", default=None, help="Optional output file path for JSON"
+    )
+
+    return parser.parse_args()
+
+
+def load_json(path: str) -> Any:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def iter_records(payload: Any) -> Iterable[Dict[str, Any]]:
+    if isinstance(payload, list):
+        for item in payload:
+            if isinstance(item, dict):
+                yield item
+        return
+    if isinstance(payload, dict):
+        yield payload
+        for key in ("data", "items", "records"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                for item in value:
+                    if isinstance(item, dict):
+                        yield item
+
+
+def get_key_path(data: Dict[str, Any], path: Optional[str]) -> Any:
+    if not path:
+        return None
+    current: Any = data
+    for part in path.split("."):
+        if not isinstance(current, dict):
+            return None
+        if part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def parse_time(value: Any) -> Optional[datetime]:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    normalized = value.strip().replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def cmd_last_known(args: argparse.Namespace) -> int:
+    payload = load_json(args.input)
+    latest: Optional[Dict[str, Any]] = None
+    latest_dt: Optional[datetime] = None
+    for record in iter_records(payload):
+        if args.device_key and args.device_id:
+            if str(get_key_path(record, args.device_key)) != args.device_id:
+                continue
+        dt = parse_time(get_key_path(record, args.timestamp_key))
+        if dt is None:
+            continue
+        if latest_dt is None or dt > latest_dt:
+            latest_dt = dt
+            latest = record
+
+    if latest is None:
+        print(
+            json.dumps(
+                {"error": "No record matched filter or timestamp was unparsable"},
+                indent=2,
+            )
+        )
+        return 1
+
+    result: Dict[str, Any] = {
+        "latest_timestamp": latest_dt.isoformat() if latest_dt else None,
+        "record": latest,
+    }
+    if args.value_key:
+        result["selected_value"] = get_key_path(latest, args.value_key)
+
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+def cmd_offline(args: argparse.Namespace) -> int:
+    payload = load_json(args.input)
+    now = parse_time(args.now) if args.now else datetime.now(timezone.utc)
+    if now is None:
+        raise SystemExit("--now must be ISO8601")
+    threshold_seconds = args.threshold_minutes * 60.0
+    latest_by_device: Dict[str, datetime] = {}
+
+    for record in iter_records(payload):
+        device_id = get_key_path(record, args.device_key)
+        last_seen_raw = get_key_path(record, args.timestamp_key)
+        last_seen = parse_time(last_seen_raw)
+        if device_id is None or last_seen is None:
+            continue
+        device_key = str(device_id)
+        existing = latest_by_device.get(device_key)
+        if existing is None or last_seen > existing:
+            latest_by_device[device_key] = last_seen
+
+    offline_devices: List[Dict[str, Any]] = []
+    for device_key, last_seen in latest_by_device.items():
+        age_seconds = (now - last_seen).total_seconds()
+        if age_seconds >= threshold_seconds:
+            offline_devices.append(
+                {
+                    "device_id": device_key,
+                    "last_seen": last_seen.isoformat(),
+                    "minutes_since_seen": round(age_seconds / 60.0, 2),
+                }
+            )
+
+    result = {
+        "evaluated_at": now.isoformat(),
+        "threshold_minutes": args.threshold_minutes,
+        "offline_count": len(offline_devices),
+        "offline_devices": offline_devices,
+    }
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+def parse_metric(items: List[str]) -> Dict[str, Any]:
+    metrics: Dict[str, Any] = {}
+    for item in items:
+        if "=" not in item:
+            raise SystemExit(f"Invalid metric '{item}'. Expected key=value.")
+        key, raw = item.split("=", 1)
+        key = key.strip()
+        raw = raw.strip()
+        if not key:
+            raise SystemExit("Metric key cannot be empty.")
+        try:
+            if "." in raw:
+                value: Any = float(raw)
+            else:
+                value = int(raw)
+        except ValueError:
+            value = raw
+        metrics[key] = value
+    return metrics
+
+
+def cmd_telemetry_template(args: argparse.Namespace) -> int:
+    payload = {
+        "deviceId": args.device_id,
+        "digitalTwinId": args.twin_id,
+        "observedAt": datetime.now(timezone.utc).isoformat(),
+        "metrics": parse_metric(args.metric),
+    }
+    rendered = json.dumps(payload, indent=2)
+    if args.output:
+        out_path = Path(args.output)
+        out_path.write_text(rendered + "\n", encoding="utf-8")
+        print(f"Wrote {out_path}")
+    else:
+        print(rendered)
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    if args.command == "last-known":
+        return cmd_last_known(args)
+    if args.command == "offline":
+        return cmd_offline(args)
+    if args.command == "telemetry-template":
+        return cmd_telemetry_template(args)
+    raise SystemExit(f"Unknown command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oci/iot-platform/templates/adapter.default.template.json
+++ b/oci/iot-platform/templates/adapter.default.template.json
@@ -1,0 +1,33 @@
+{
+  "displayName": "Replace Adapter Name",
+  "description": "Public sample adapter for a temperature sensor model.",
+  "inboundEnvelope": {
+    "referenceEndpoint": "/sampletopic",
+    "envelopeMapping": {
+      "timeObserved": "$.time"
+    },
+    "referencePayload": {
+      "dataFormat": "JSON",
+      "data": {
+        "time": "2026-04-22T12:00:00.123456Z",
+        "temperature": 23.5
+      }
+    }
+  },
+  "inboundRoutes": [
+    {
+      "description": "Default route",
+      "condition": "*",
+      "payloadMapping": {
+        "$.temperature": "$.temperature"
+      },
+      "referencePayload": {
+        "dataFormat": "JSON",
+        "data": {
+          "time": "2026-04-22T12:00:00.123456Z",
+          "temperature": 23.5
+        }
+      }
+    }
+  ]
+}

--- a/oci/iot-platform/templates/instance.template.json
+++ b/oci/iot-platform/templates/instance.template.json
@@ -1,0 +1,8 @@
+{
+  "displayName": "Replace Twin Name",
+  "description": "Publishing twin instance for a physical sensor device.",
+  "externalKey": "<device-identity>",
+  "authId": "<vault-secret-or-certificate-auth-id>",
+  "digitalTwinModelId": "<digital-twin-model-id>",
+  "digitalTwinAdapterId": "<digital-twin-adapter-id>"
+}

--- a/oci/iot-platform/templates/model.temperature-sensor.template.json
+++ b/oci/iot-platform/templates/model.temperature-sensor.template.json
@@ -1,0 +1,15 @@
+{
+  "@context": "dtmi:dtdl:context;3",
+  "@id": "dtmi:com:example:iot:temperature_sensor;1",
+  "@type": "Interface",
+  "displayName": "Temperature Sensor",
+  "description": "Simple public sample model for a publishing temperature sensor.",
+  "contents": [
+    {
+      "@type": "Telemetry",
+      "name": "temperature",
+      "schema": "double",
+      "displayName": "Temperature"
+    }
+  ]
+}

--- a/oci/iot-platform/templates/publish-curl.template.sh
+++ b/oci/iot-platform/templates/publish-curl.template.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Required env:
+#   DEVICE_USER
+#   DEVICE_SECRET
+#   DOMAIN_SHORT_ID
+#   OCI_REGION
+# Optional env:
+#   REFERENCE_ENDPOINT (default: /sampletopic)
+
+: "${DEVICE_USER:?set DEVICE_USER}"
+: "${DEVICE_SECRET:?set DEVICE_SECRET}"
+: "${DOMAIN_SHORT_ID:?set DOMAIN_SHORT_ID}"
+: "${OCI_REGION:?set OCI_REGION}"
+
+REFERENCE_ENDPOINT="${REFERENCE_ENDPOINT:-/sampletopic}"
+REFERENCE_ENDPOINT="/${REFERENCE_ENDPOINT#/}"
+URL="https://${DOMAIN_SHORT_ID}.device.iot.${OCI_REGION}.oci.oraclecloud.com${REFERENCE_ENDPOINT}"
+TS="$(date -u +"%Y-%m-%dT%H:%M:%S").000000Z"
+
+PAYLOAD="$(cat <<JSON
+{
+  "time": "${TS}",
+  "temperature": 23.5
+}
+JSON
+)"
+
+curl -sS -u "${DEVICE_USER}:${DEVICE_SECRET}" \
+  -H "Content-Type: application/json" \
+  -d "${PAYLOAD}" \
+  "${URL}"
+
+echo

--- a/oci/iot-platform/tests/redaction_scan.sh
+++ b/oci/iot-platform/tests/redaction_scan.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "Scanning for obvious secret and internal-provenance patterns..."
+
+MATCHES="$(rg -n --hidden \
+  --glob '!.git' \
+  '(/Users/[^[:space:]]+|/home/[^[:space:]]+|dashboard\.localhost|Local pre-PR|pre-PR|IAM_PASSWORD=|IAM_APP_CLIENT_SECRET=|BEGIN (RSA |EC |OPENSSH |)PRIVATE KEY|PRIVATE KEY-----|ocid1\.(vaultsecret|certificate|user|tenancy)\.oc1\.|idcscs-|refresh_token|client_secret)' "$ROOT_DIR" \
+  | rg -v 'tests/redaction_scan.sh' || true)"
+
+if [[ -n "$MATCHES" ]]; then
+  printf '%s\n' "$MATCHES"
+  echo "Potential secret material found. Review before sharing."
+  exit 1
+fi
+
+echo "No obvious secret or internal-provenance patterns found."

--- a/oci/iot-platform/tests/smoke.sh
+++ b/oci/iot-platform/tests/smoke.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+export PYTHONPYCACHEPREFIX="${PYTHONPYCACHEPREFIX:-${TMPDIR:-/tmp}/oci-iot-platform-pycache}"
+
+required_files=(
+  "$ROOT_DIR/SKILL.md"
+  "$ROOT_DIR/agents/openai.yaml"
+  "$ROOT_DIR/scripts/derive_domain_context.sh"
+  "$ROOT_DIR/scripts/twin_tools.py"
+  "$ROOT_DIR/templates/adapter.default.template.json"
+  "$ROOT_DIR/templates/instance.template.json"
+  "$ROOT_DIR/templates/model.temperature-sensor.template.json"
+  "$ROOT_DIR/templates/publish-curl.template.sh"
+  "$ROOT_DIR/references/cli-workflows.md"
+  "$ROOT_DIR/references/data-access.md"
+  "$ROOT_DIR/references/mcp-optional-use.md"
+  "$ROOT_DIR/references/modeling-guidance.md"
+  "$ROOT_DIR/references/platform-surface.md"
+  "$ROOT_DIR/references/resilience-guidance.md"
+  "$ROOT_DIR/references/release-validation.md"
+)
+
+echo "[1/6] required file check"
+for path in "${required_files[@]}"; do
+  if [[ ! -f "$path" ]]; then
+    echo "Missing required file: $path" >&2
+    exit 1
+  fi
+done
+
+echo "[2/6] skill metadata check"
+rg -n '^name: oci-iot-platform$' "$ROOT_DIR/SKILL.md" >/dev/null
+rg -n '^description:' "$ROOT_DIR/SKILL.md" >/dev/null
+
+echo "[3/6] resilience guidance coverage check"
+rg -n 'references/resilience-guidance\.md' "$ROOT_DIR/SKILL.md" >/dev/null
+rg -n -i 'bounded|pagination|--limit' "$ROOT_DIR/references/resilience-guidance.md" >/dev/null
+rg -n -i 'lifecycle' "$ROOT_DIR/references/resilience-guidance.md" >/dev/null
+rg -n -i 'gateway' "$ROOT_DIR/references/resilience-guidance.md" >/dev/null
+rg -n -i 'relationship' "$ROOT_DIR/references/resilience-guidance.md" >/dev/null
+rg -n -i 'work.request|work-request' "$ROOT_DIR/references/resilience-guidance.md" >/dev/null
+rg -n -i 'publish|rejected' "$ROOT_DIR/references/resilience-guidance.md" >/dev/null
+rg -n 'inboundEnvelope\.referenceEndpoint' "$ROOT_DIR/references/cli-workflows.md" "$ROOT_DIR/references/resilience-guidance.md" >/dev/null
+rg -n '404 Not Found' "$ROOT_DIR/references/cli-workflows.md" "$ROOT_DIR/references/resilience-guidance.md" >/dev/null
+rg -n 'REFERENCE_ENDPOINT' "$ROOT_DIR/templates/publish-curl.template.sh" >/dev/null
+if rg -n 'TOPIC' "$ROOT_DIR/templates/publish-curl.template.sh" >/dev/null; then
+  echo "Publish template should use REFERENCE_ENDPOINT, not TOPIC." >&2
+  exit 1
+fi
+rg -n -i 'raw.command|raw-command' "$ROOT_DIR/references/resilience-guidance.md" >/dev/null
+rg -n -i 'sdk.*cli|cli.*sdk' "$ROOT_DIR/references/resilience-guidance.md" >/dev/null
+rg -n -i 'mcp.*optional|optional.*mcp' "$ROOT_DIR/references/resilience-guidance.md" >/dev/null
+rg -n 'references/mcp-optional-use\.md' "$ROOT_DIR/SKILL.md" >/dev/null
+rg -n -i 'fallback|cli|sdk' "$ROOT_DIR/references/mcp-optional-use.md" >/dev/null
+rg -n -i 'connectivity_type|gateways|INDIRECT|GATEWAY' "$ROOT_DIR/references/mcp-optional-use.md" >/dev/null
+rg -n 'never use `INDIRECT` as a shortcut' "$ROOT_DIR/SKILL.md" >/dev/null
+rg -n 'do not assume `INDIRECT` connectivity' "$ROOT_DIR/references/resilience-guidance.md" >/dev/null
+rg -n 'Do not default to `INDIRECT` connectivity' "$ROOT_DIR/references/cli-workflows.md" >/dev/null
+rg -n 'OCI_IOT_AUTH_TYPE=api_key' "$ROOT_DIR/references/mcp-optional-use.md" >/dev/null
+rg -n -i 'snapshot|historized|raw-command|rejected' "$ROOT_DIR/references/mcp-optional-use.md" >/dev/null
+rg -n 'references/platform-surface\.md' "$ROOT_DIR/SKILL.md" >/dev/null
+rg -n -i 'domain group|digital twin model|digital twin adapter|digital twin instance|relationship|work request|raw commands|Data API' "$ROOT_DIR/references/platform-surface.md" >/dev/null
+rg -n -i 'configure-apex-data-access|configure-direct-data-access|configure-ords-data-access|change-data-retention-period|MQTTs' "$ROOT_DIR/references/platform-surface.md" "$ROOT_DIR/references/cli-workflows.md" "$ROOT_DIR/references/data-access.md" >/dev/null
+rg -n -i 'snapshotData|rawData|historizedData|rejectedData|rawCommandData' "$ROOT_DIR/references/data-access.md" >/dev/null
+rg -n -- '--auth' "$ROOT_DIR/scripts/derive_domain_context.sh" >/dev/null
+rg -n -- '--auth <oci_cli_auth>' "$ROOT_DIR/references/cli-workflows.md" >/dev/null
+if rg -n -- '--file ' "$ROOT_DIR/references/cli-workflows.md" >/dev/null; then
+  echo "Unsupported OCI CLI --file option found in CLI workflows; use --from-json or parameter-specific file:// inputs." >&2
+  exit 1
+fi
+if rg -n 'lastValue' "$ROOT_DIR/templates/adapter.default.template.json" "$ROOT_DIR/templates/publish-curl.template.sh" >/dev/null; then
+  echo "Adapter and publish templates should use the same scalar temperature payload shape." >&2
+  exit 1
+fi
+
+echo "[4/6] bootstrap helper syntax check"
+bash -n "$ROOT_DIR/scripts/derive_domain_context.sh"
+
+echo "[5/6] twin tool syntax and help checks"
+python3 -m py_compile "$ROOT_DIR/scripts/twin_tools.py"
+python3 "$ROOT_DIR/scripts/twin_tools.py" --help >/dev/null
+python3 "$ROOT_DIR/scripts/twin_tools.py" telemetry-template \
+  --device-id test-device \
+  --twin-id test-twin \
+  --metric temperature=21.5 >/dev/null
+
+echo "[6/6] template sanity check"
+python3 -m json.tool "$ROOT_DIR/templates/adapter.default.template.json" >/dev/null
+python3 -m json.tool "$ROOT_DIR/templates/instance.template.json" >/dev/null
+python3 -m json.tool "$ROOT_DIR/templates/model.temperature-sensor.template.json" >/dev/null
+bash -n "$ROOT_DIR/templates/publish-curl.template.sh"
+
+echo "smoke checks passed"


### PR DESCRIPTION
## Summary

- Add an OCI IoT Platform nested skill under `oci/iot-platform/`.
- Add source-backed references for OCI IoT platform surface, CLI workflows, modeling, data access, optional MCP use, resilience guidance, and release validation.
- Add neutral templates, helper scripts, local validation tests, and OCI domain routing updates so the skill is discoverable when the OCI domain is installed.

Closes #71

## Validation

```bash
bash oci/iot-platform/tests/smoke.sh
bash oci/iot-platform/tests/redaction_scan.sh
python3 -m json.tool .claude-plugin/marketplace.json
git diff --check origin/main...HEAD
```
