### PR TITLE
fix(oci-iot): harden platform workflows

### DIFF
--- a/oci/iot-platform/SKILL.md
+++ b/oci/iot-platform/SKILL.md
@@ -12,7 +12,7 @@ description: Explore, create, and troubleshoot Oracle Cloud Infrastructure Inter
    - `IOT_DOMAIN_ID` when available
    - `OCI_CLI_PROFILE`
    - `OCI_CLI_AUTH` when the selected profile needs it, such as `security_token`
-   - `OCI_REGION` if it cannot be derived from the domain
+   - `OCI_REGION` when the selected profile does not already target the domain's region
    - intended operation: inspect, create, update, delete, or publish test telemetry
 3. Prefer this execution order:
    - discover the domain and current state
@@ -21,10 +21,16 @@ description: Explore, create, and troubleshoot Oracle Cloud Infrastructure Inter
    - make the smallest required change
    - verify the result with a fresh read
 
+## Prerequisites
+
+For the local operator workflows in this skill, install the OCI CLI, Bash, curl, jq, and Python 3. These are workflow prerequisites, not universal OCI IoT service requirements. When diagnosing CLI drift, capture `oci --version` and confirm the local IoT command surface with `oci iot --help`; do not hard-pin every operator to one OCI CLI patch release.
+
+Contributors running repository validation also need ripgrep (`rg`). Ripgrep is contributor-only and is not required merely to use the OCI IoT service.
+
 ## Default Workflow
 
 1. Start with read-only OCI CLI discovery.
-2. Use `scripts/derive_domain_context.sh` when the user only has `IOT_DOMAIN_ID`.
+2. Use `scripts/derive_domain_context.sh` when the user has `IOT_DOMAIN_ID` and a profile or explicit region that can reach the domain.
 3. Use [references/platform-surface.md](references/platform-surface.md) when the task needs orientation on OCI IoT resource families, data flow, connectivity types, or which surface to use.
 4. Use [references/cli-workflows.md](references/cli-workflows.md) for control-plane actions:
    - domains and domain groups
@@ -44,8 +50,9 @@ description: Explore, create, and troubleshoot Oracle Cloud Infrastructure Inter
    - publish rejection triage
    - raw-command final-state validation
    - cleanup or rollback planning
-7. Use [references/modeling-guidance.md](references/modeling-guidance.md) when the request involves DTDL authoring or adapter payload design.
-8. Use [references/data-access.md](references/data-access.md) only when the user explicitly needs Data API, ORDS, direct database access, or APEX-oriented workflows.
+   - OCI Monitoring service-health diagnosis
+7. Use [references/modeling-guidance.md](references/modeling-guidance.md) when the request involves DTDL authoring, adapter payload design, or compatible model-version migration.
+8. Use [references/data-access.md](references/data-access.md) only when the user explicitly needs Data API, ORDS, direct database access, APEX, Database Tools, Select AI, Data Pump, archive, or database-queue workflows.
 9. Use [references/release-validation.md](references/release-validation.md) before calling the skill package ready to share publicly.
 
 ## Bundled Resources
@@ -82,15 +89,6 @@ description: Explore, create, and troubleshoot Oracle Cloud Infrastructure Inter
 - Do not imply OCI IoT is a general-purpose MQTT broker.
 - Keep examples redacted and tenant-neutral.
 
-## Authoritative References
-
-- Oracle IoT service docs:
-  - `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/home.htm`
-- OCI CLI IoT command reference:
-  - `https://docs.oracle.com/en-us/iaas/tools/oci-cli/latest/oci_cli_docs/cmdref/iot.html`
-- Oracle sample repository:
-  - `https://github.com/oracle-samples/oci-iot-samples`
-
 ## Output Style
 
 For each task, return:
@@ -98,3 +96,20 @@ For each task, return:
 1. The exact command sequence with placeholders filled or called out.
 2. The key IDs, state, or timestamps that matter.
 3. The next verification step.
+
+## Sources
+
+- Oracle IoT service docs:
+  - `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/home.htm`
+- OCI CLI IoT command reference:
+  - `https://docs.oracle.com/en-us/iaas/tools/oci-cli/latest/oci_cli_docs/cmdref/iot.html`
+- Oracle sample repository:
+  - `https://github.com/oracle-samples/oci-iot-samples`
+- Official open-source OCI IoT MCP server:
+  - `https://github.com/oracle/mcp/tree/main/src/oci-iot-mcp-server`
+- Domain-group lifecycle and model-version guidance:
+  - `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/create-domain-group.htm`
+  - `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/create-new-model-version.htm`
+- OCI IoT Monitoring and advanced data access:
+  - `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/metrics-reference.htm`
+  - `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/connecting-to-data.htm`

--- a/oci/iot-platform/references/cli-workflows.md
+++ b/oci/iot-platform/references/cli-workflows.md
@@ -7,7 +7,7 @@ Use this file for the public, CLI-first operator path. For large fleets, gateway
 - `IOT_DOMAIN_ID`
 - `OCI_CLI_PROFILE`
 - `OCI_CLI_AUTH` when the profile requires a non-default auth mode, such as `security_token`
-- `OCI_REGION` when not derivable from the domain
+- `OCI_REGION` when the selected profile does not already target the domain's region
 - resource identifiers already known by the user:
   - digital twin model ID
   - digital twin adapter ID
@@ -21,10 +21,11 @@ If only `IOT_DOMAIN_ID` is known, derive the rest first:
 bash scripts/derive_domain_context.sh \
   --profile <oci_profile> \
   --auth <oci_cli_auth> \
+  --region <oci_region> \
   --iot-domain-id <iot_domain_ocid>
 ```
 
-Omit `--auth` only when the selected profile uses the CLI default auth mode. For security-token profiles, use `--auth security_token` and add the same global option to later OCI CLI commands.
+Omit `--auth` only when the selected profile uses the CLI default auth mode. Omit `--region` only when the profile already selects the IoT domain's region. The helper needs a valid regional endpoint for its first domain read before it can derive the region from the returned device host. For security-token profiles, use `--auth security_token` and add the same global option to later OCI CLI commands.
 
 ## Command Capability Check
 
@@ -38,6 +39,12 @@ oci iot digital-twin-instance invoke-raw-json-command --help
 ```
 
 If a documented CLI flag is missing locally, use the Python SDK or a narrower CLI fallback and call out the drift.
+
+## Domain-Group Type Selection
+
+For a new domain group, `DEVELOPMENT` is the default and is intended for development and testing with fewer resources and a higher recovery time objective (RTO). `PRODUCTION` is recommended for production workloads.
+
+`LIGHTWEIGHT` and `STANDARD` are deprecated aliases for `DEVELOPMENT` and `PRODUCTION`. Oracle's announced removal date is `2027-04-14`; do not use the aliases in new automation. Domain-group type is a creation-time topology decision and cannot be changed in place. Read the existing type before planning a migration, then create and validate a replacement group when a type change is required.
 
 ## Read-First Discovery
 
@@ -308,6 +315,8 @@ For vault-secret-backed basic auth, start from:
 bash templates/publish-curl.template.sh
 ```
 
+The template passes the Basic authorization header to curl over standard input so the device secret is not included in process arguments. It also uses `--fail-with-body`, so HTTP authentication and endpoint errors return a nonzero status while preserving the response body for diagnosis.
+
 For certificate-based publishing, switch to an mTLS client flow instead of `curl -u`.
 
 After publishing, verify the twin content again. For basic validation, `digital-twin-instance get-content` with metadata is enough to prove the publish updated the twin:
@@ -340,11 +349,20 @@ Verify final state through command response records, device-side evidence, or a 
 
 ## Cleanup Ordering
 
-For teardown, read dependencies first, then delete in this order:
+For teardown, read dependencies first and use this conservative runbook order. It minimizes dependency conflicts; it is not a claim that Oracle documents every step below as a service-mandated dependency chain.
 
-1. relationships
-2. digital twin instances
-3. adapters with no active dependent instances
-4. models with no active dependent adapters or instances
+1. Delete relationships associated with the target twins.
+2. Delete instances.
+3. Delete adapters only after no active instances depend on them.
+4. Delete models only after no active adapters or instances depend on them.
+5. Run a fresh active-resource inventory across relationships, instances, adapters, and models.
+6. After explicit approval, delete the IoT domain and verify that it disappears or reaches its documented terminal state.
+7. Confirm the domain group has no remaining domains; after separate explicit approval, delete the empty domain group and verify final state.
 
-Ask for explicit approval before destructive operations, and verify each resource reaches `DELETED` or disappears from active listings.
+The service rejects domain deletion while active digital twin resources remain. Oracle explicitly calls out deleting associated digital twin instances first; the fresh inventory above also prevents overlooked relationships, adapters, or models from being mistaken for a complete teardown. Ask for explicit approval before every destructive stage, and verify each resource reaches `DELETED` or disappears from active listings.
+
+## Sources
+
+- Domain-group types and migration: `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/create-domain-group.htm`
+- Deprecated type aliases and removal date: `https://docs.oracle.com/en-us/iaas/releasenotes/internet-of-things/update-04142026.htm`
+- Active-resource domain deletion rule: `https://docs.oracle.com/en-us/iaas/releasenotes/internet-of-things/update-06092026.htm`

--- a/oci/iot-platform/references/data-access.md
+++ b/oci/iot-platform/references/data-access.md
@@ -10,8 +10,14 @@ This reference covers advanced and optional paths:
 - ORDS-backed queries
 - direct database access
 - APEX-oriented workspace access
+- Oracle Database Tools connections
+- Select AI through APEX or SQLcl
+- Data Pump import/export and Object Storage archive workflows
+- raw and normalized database queue streaming
 
 These paths usually require separate authentication, networking, or tenancy setup beyond normal CLI usage.
+
+Every path in this reference is advanced and optional. Require explicit opt-in from the operator and complete a path-specific auth, network, IAM, database, retention, and data-handling review before giving executable setup or mutation steps. Never guess connection strings, proxy users, credentials, endpoints, or policies.
 
 ## When To Use This Path
 
@@ -22,6 +28,7 @@ Use advanced data access when the user asks for one of these:
 - rejected telemetry details
 - command round-trip data
 - APEX workspace changes
+- migration, backup, archive, generated-SQL, or queue-streaming workflows
 
 Do not default to this path for ordinary digital twin inspection.
 
@@ -51,8 +58,10 @@ If these prerequisites are missing, say so clearly before giving commands.
 Typical Data API base URL shape:
 
 ```text
-https://<domain_group_short_id>.data.iot.<region>.oci.oraclecloud.com/ords/<domain_short_id>
+https://<domain_group_short_id>.data.iot.<region>.oci.oraclecloud.com/ords/<domain_short_id>/20250531
 ```
+
+`20250531` is the current public IoT Data API version segment. Keep it between the domain short ID and the collection path.
 
 Common collection paths:
 
@@ -76,6 +85,24 @@ Typical prerequisites include:
 - the correct schema context for the requested task
 
 If the user only needs current twin state, prefer `digital-twin-instance get-content` instead.
+
+## Oracle Database Tools
+
+An Oracle Database Tools connection is an optional path to the IoT database after direct database access, private networking, IAM token authentication, and the documented IoT workspace proxy user are configured. Treat it as separately provisioned access, not an automatic Data API fallback. Read the current database-access configuration before proposing any connection change.
+
+## Select AI
+
+Select AI can translate natural-language IoT questions into SQL through APEX SQL Workshop or SQLcl after the documented database, provider, and IAM setup. Always review generated SQL, its target schema, and its data scope before execution. Do not present generated SQL as trusted merely because the prompt was natural language.
+
+## Data Pump And Archive Workflows
+
+Use Data Pump import/export as an advanced migration or backup path. For longer-term archive, Oracle documents exporting IoT domain data to Object Storage, including query-friendly formats such as Parquet and Data Pump format when BLOB content must be preserved. Verify archived objects and retention requirements before any separately approved source-data cleanup.
+
+The official sample repository includes an `archive-domain` SQL/Python workflow. `archive-domain` is a sample workflow name, not an OCI resource, API operation, or CLI command; follow the official sample instead of inventing an archive helper.
+
+## Database Queue Streaming
+
+After direct database connectivity is configured, advanced consumers can subscribe to the public raw database queue (`RAW_DATA_IN`) or normalized database queue (`NORMALIZED_DATA`). Use the official Java/Python samples, account for the documented queue-retention window, and remove subscribers when they are no longer needed. Do not add a queue helper to this skill.
 
 ## Data Access Configuration
 
@@ -108,3 +135,15 @@ When using this reference:
 3. Give the smallest command set needed for the task.
 4. Include a verification step.
 5. Say whether a CLI/API fallback exists if an optional MCP helper was used.
+
+## Sources
+
+- Connecting to IoT data: `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/connecting-to-data.htm`
+- Database Tools scenario: `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/query-iot-database-with-database-tools.htm`
+- Select AI from APEX: `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/select-ai-apex.htm`
+- Data Pump and Object Storage archive: `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/import-export-object-storage.htm`
+- Normalized queue streaming: `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/stream-normalized-queue.htm`
+- Official SQL archive sample: `https://github.com/oracle-samples/oci-iot-samples/tree/main/samples/sql/archive-domain`
+- Official Python archive sample: `https://github.com/oracle-samples/oci-iot-samples/tree/main/samples/python/archive-domain`
+- Official Python queue samples: `https://github.com/oracle-samples/oci-iot-samples/tree/main/samples/python/queues`
+- Official Java samples: `https://github.com/oracle-samples/oci-iot-samples/tree/main/samples/java`

--- a/oci/iot-platform/references/mcp-optional-use.md
+++ b/oci/iot-platform/references/mcp-optional-use.md
@@ -2,6 +2,10 @@
 
 Use this reference only when the user's environment already exposes an OCI IoT MCP server. The public skill must stay useful without MCP; do not make MCP installation, private server bootstrap, or private credentials part of the default workflow.
 
+## Official Implementation
+
+Oracle publishes the open-source OCI IoT MCP server at `https://github.com/oracle/mcp/tree/main/src/oci-iot-mcp-server`. Use its documented tool surface when that server is already installed and configured. It remains optional: retain direct OCI CLI or SDK fallbacks, and do not make MCP installation a prerequisite for this skill.
+
 ## When MCP Helps
 
 Prefer the OCI CLI for public, repeatable command sequences. Use MCP as an optional accelerator when the task needs joined context or operator-friendly wrappers, such as:
@@ -93,3 +97,8 @@ When using MCP, tell the user:
 2. Why MCP was useful compared with direct CLI.
 3. What final-state evidence was verified.
 4. Which direct CLI or SDK command would be the fallback if MCP is unavailable.
+
+## Sources
+
+- Official OCI IoT MCP server: `https://github.com/oracle/mcp/tree/main/src/oci-iot-mcp-server`
+- Oracle IoT data-access guidance: `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/connecting-to-data.htm`

--- a/oci/iot-platform/references/modeling-guidance.md
+++ b/oci/iot-platform/references/modeling-guidance.md
@@ -17,14 +17,26 @@ Use this file when the request involves digital twin model authoring, version ch
 - Use descriptive `displayName` values, but avoid depending on them for logic.
 - Keep schema choices simple unless the use case demands complexity.
 
-## Versioning
+OCI release guidance announces altitude support for point DTDL schemas. Confirm the current schema documentation and service capability before using altitude in a public executable example.
 
-Increment the DTMI version when behavior or meaning changes, such as:
+## Version Compatibility
 
-- adding or removing telemetry fields
-- changing units
-- changing validation constraints
-- changing relationship semantics
+An in-place instance upgrade candidate is a strictly additive next minor model version. It must preserve every existing name, type or schema class, meaning, unit, constraint, relationship, and command contract. Additive fields may be introduced, but existing behavior must remain compatible.
+
+Field removal or rename, type or unit changes, narrowed constraints, relationship or command-contract changes, major-version changes, and downgrades are incompatible and require a new twin instance. Do not relabel an incompatible change as a minor release to keep an existing instance.
+
+## Compatible Model Migration
+
+Use a read-first, approval-gated sequence; do not turn these steps into executable mutations until the operator approves the specific change.
+
+1. Read the current model, adapter, instance metadata, and twin content.
+2. Create the compatible minor model version.
+3. Create a new adapter that references the new model and preserves all existing mappings.
+4. Retain the old adapter for rollback until validation is complete.
+5. Update the instance to the new adapter.
+6. Publish a representative payload through the documented device path.
+7. Verify the instance metadata and run `get-content --should-include-metadata true` to confirm normalized content after the update.
+8. If validation fails, roll back by updating the instance to the old adapter and verify the restored state.
 
 ## Telemetry Design
 
@@ -39,6 +51,7 @@ Increment the DTMI version when behavior or meaning changes, such as:
 - Make the reference payload realistic enough to test mapping.
 - Map only the fields the model actually exposes.
 - Review publish auth and endpoint choices separately from payload mapping.
+- OCI release guidance announces JQ `has` support in adapter expressions. Verify the current JQ mapping reference and service capability before using `has` in a public executable example.
 
 ## Relationship Design
 
@@ -54,3 +67,11 @@ For public templates:
 - use placeholder identifiers
 - avoid tenant-specific topic paths unless clearly labeled as examples
 - avoid environment-specific assumptions about auth mode
+
+## Sources
+
+- Compatible model upgrade scenario: `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/create-new-model-version.htm`
+- Adapter updates: `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/update-digital-twin-adapter.htm`
+- Instance updates: `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/update-digital-twin-instance.htm`
+- Altitude and JQ `has` release announcement: `https://docs.oracle.com/en-us/iaas/releasenotes/internet-of-things/update-04142026.htm`
+- JQ mapping reference: `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/jq-adapter-mapping-reference.htm`

--- a/oci/iot-platform/references/platform-surface.md
+++ b/oci/iot-platform/references/platform-surface.md
@@ -30,7 +30,7 @@ device, gateway, or external application publish
 
 Raw commands are a control-plane request that must be verified through a data-plane or device-side final-state signal.
 
-Device connectivity is broader than the HTTPS template bundled with this skill. Oracle documents sending unstructured data over HTTPS, structured data over HTTPS, structured data over MQTTs, custom-format structured data over HTTPS, and receiving unstructured commands with MQTTs responses. Do not describe OCI IoT as a general-purpose MQTT broker; treat MQTTs as a documented device-connect path with its own auth, topic, and response semantics.
+Device connectivity is broader than the HTTPS template bundled with this skill. Oracle documents sending unstructured data over HTTPS, structured data over HTTPS, structured data over MQTTs, secure MQTT-over-WebSocket (WSS), custom-format structured data over HTTPS, and receiving unstructured commands with MQTTs responses. This skill bundles no WSS template. Use the official WebSocket sample for topic and authentication semantics rather than adapting the HTTPS template or guessing broker behavior. Do not describe OCI IoT as a general-purpose MQTT broker; treat MQTTs and WSS as documented device-connect paths with their own auth, topic, and response semantics.
 
 ## Function Families
 
@@ -88,3 +88,9 @@ For every function family:
 - Use Python SDK for programmatic pagination, typed fields, or structured reports.
 - Use optional MCP only when it is already available and helps join context, resolve selectors, poll state, or summarize Data API evidence.
 - Use direct Data API, ORDS, database, or APEX paths only when the user explicitly needs advanced data access.
+
+## Sources
+
+- OCI IoT overview: `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/overview.htm`
+- Official device-connect samples: `https://github.com/oracle-samples/oci-iot-samples`
+- Secure WebSocket sample: `https://github.com/oracle-samples/oci-iot-samples/tree/main/samples/python/publish-websockets`

--- a/oci/iot-platform/references/release-validation.md
+++ b/oci/iot-platform/references/release-validation.md
@@ -4,14 +4,25 @@ Use this checklist before calling the `oci-iot-platform` skill ready to share.
 
 ## Automated Checks
 
-Run:
+From the `oci/iot-platform` skill directory, run:
 
 ```bash
-bash oci-iot-platform/tests/smoke.sh
+oci --version
+oci iot --help >/dev/null
+```
+
+Record the OCI CLI version in the validation report. If a documented command differs from the installed command surface, record the documented-command drift and the verified fallback; do not silently rewrite the workflow around one local patch release.
+
+```bash
+bash tests/platform_currentness.sh
 ```
 
 ```bash
-bash oci-iot-platform/tests/redaction_scan.sh
+bash tests/smoke.sh
+```
+
+```bash
+bash tests/redaction_scan.sh
 ```
 
 ## Content Review
@@ -28,7 +39,7 @@ Check for:
 
 Validate at least one clean or minimally configured operator environment with public OCI CLI authentication. A separate tenancy is useful but not required when one is not available; the validation must prove the workflow can run without internal profiles, private setup, or MCP dependencies. Prefer a `security_token` auth profile or another documented public OCI CLI auth mode for this pass.
 
-1. `IOT_DOMAIN_ID` bootstrap, including `--auth security_token` when using a security-token profile
+1. `IOT_DOMAIN_ID` bootstrap, including `--auth security_token` when using a security-token profile and explicit `--region` when the profile does not already select the domain's region
 2. read-only discovery of domains and twins
 3. model creation and readback
 4. adapter creation and readback
@@ -72,3 +83,7 @@ Do not release if any of these are true:
 - publish examples omit the adapter reference endpoint path or imply that the bare device host is enough
 - instance creation examples use `INDIRECT` to avoid supplying a direct-auth resource
 - cleanup guidance omits dependency ordering or destructive-operation approval
+
+## Sources
+
+- OCI CLI IoT command reference: `https://docs.oracle.com/en-us/iaas/tools/oci-cli/latest/oci_cli_docs/cmdref/iot.html`

--- a/oci/iot-platform/references/resilience-guidance.md
+++ b/oci/iot-platform/references/resilience-guidance.md
@@ -156,6 +156,18 @@ oci iot --profile <oci_profile> --region <oci_region> work-request list-logs \
 
 Do not treat a queued or accepted work request as a completed operation. Verify the target resource state afterward.
 
+## OCI Monitoring Before Advanced Data Escalation
+
+For service-health diagnosis, start with read-only OCI Monitoring metrics in namespace `oci_iot` before escalating to the Data API or database. The operator needs Monitoring read IAM permission (`read metrics`) for the target compartment.
+
+Route the question to the narrowest signal family:
+
+- connection signals such as `HttpConnectionCount` and `MqttConnectionCount`
+- authentication signals such as `AuthFailureCount`
+- ingestion and normalization signals such as `ReceivedCount`, `NormalizedCount`, and `RejectedCount`
+
+Bound every query to a relevant time window and documented dimensions, then correlate it with the publish attempt or incident timestamp. These are service metrics, not digital twin content or business telemetry. Use a fresh instance-content read, bounded Data API query, or separately approved database access when the question is about actual twin values.
+
 ## Publish Failure Triage
 
 After a publish attempt, verify the latest content first. If content did not update:
@@ -205,3 +217,8 @@ For teardown or rollback:
 5. Verify each resource reaches `DELETED` or no longer appears in active listings.
 
 Never recommend broad deletion from a name match alone. Read the resource by OCID, confirm dependencies, and ask for explicit approval before destructive operations.
+
+## Sources
+
+- OCI IoT metrics reference: `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/metrics-reference.htm`
+- Viewing OCI IoT metrics and IAM policy: `https://docs.oracle.com/en-us/iaas/Content/internet-of-things/view-metrics.htm`

--- a/oci/iot-platform/scripts/derive_domain_context.sh
+++ b/oci/iot-platform/scripts/derive_domain_context.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 PROFILE=""
 AUTH_MODE=""
+REQUEST_REGION=""
 IOT_DOMAIN_ID=""
 
 while [[ $# -gt 0 ]]; do
@@ -13,6 +14,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --auth)
       AUTH_MODE="$2"
+      shift 2
+      ;;
+    --region)
+      REQUEST_REGION="$2"
       shift 2
       ;;
     --iot-domain-id)
@@ -37,6 +42,9 @@ if [[ -n "$PROFILE" ]]; then
 fi
 if [[ -n "$AUTH_MODE" ]]; then
   OCI_BASE+=(--auth "$AUTH_MODE")
+fi
+if [[ -n "$REQUEST_REGION" ]]; then
+  OCI_BASE+=(--region "$REQUEST_REGION")
 fi
 
 DOMAIN_JSON="$("${OCI_BASE[@]}" domain get --iot-domain-id "$IOT_DOMAIN_ID" --output json)"

--- a/oci/iot-platform/scripts/twin_tools.py
+++ b/oci/iot-platform/scripts/twin_tools.py
@@ -81,13 +81,30 @@ def iter_records(payload: Any) -> Iterable[Dict[str, Any]]:
                 yield item
         return
     if isinstance(payload, dict):
-        yield payload
-        for key in ("data", "items", "records"):
+        data = payload.get("data")
+        if isinstance(data, dict):
+            for key in ("items", "records"):
+                value = data.get(key)
+                if isinstance(value, list):
+                    for item in value:
+                        if isinstance(item, dict):
+                            yield item
+                    return
+            yield data
+            return
+        if isinstance(data, list):
+            for item in data:
+                if isinstance(item, dict):
+                    yield item
+            return
+        for key in ("items", "records"):
             value = payload.get(key)
             if isinstance(value, list):
                 for item in value:
                     if isinstance(item, dict):
                         yield item
+                return
+        yield payload
 
 
 def get_key_path(data: Dict[str, Any], path: Optional[str]) -> Any:

--- a/oci/iot-platform/templates/publish-curl.template.sh
+++ b/oci/iot-platform/templates/publish-curl.template.sh
@@ -27,7 +27,10 @@ PAYLOAD="$(cat <<JSON
 JSON
 )"
 
-curl -sS -u "${DEVICE_USER}:${DEVICE_SECRET}" \
+AUTHORIZATION="$(printf '%s:%s' "$DEVICE_USER" "$DEVICE_SECRET" | base64 | tr -d '\r\n')"
+
+printf 'Authorization: Basic %s\n' "$AUTHORIZATION" | curl --fail-with-body -sS \
+  --header @- \
   -H "Content-Type: application/json" \
   -d "${PAYLOAD}" \
   "${URL}"

--- a/oci/iot-platform/tests/platform_currentness.sh
+++ b/oci/iot-platform/tests/platform_currentness.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+failures=0
+
+require_text() {
+  local path="$1"
+  local needle="$2"
+  local description="$3"
+
+  if ! rg -Fqi -- "$needle" "$path"; then
+    printf 'Missing %s in %s (expected fixed text: %s)\n' \
+      "$description" "${path#"$ROOT_DIR"/}" "$needle" >&2
+    failures=1
+  fi
+}
+
+require_ordered_text() {
+  local path="$1"
+  local description="$2"
+  shift 2
+
+  local needle
+  local match
+  local line
+  local previous_line=0
+  for needle in "$@"; do
+    match="$(rg -Fni -m 1 -- "$needle" "$path" || true)"
+    if [[ -z "$match" ]]; then
+      printf 'Cannot verify %s in %s; missing fixed text: %s\n' \
+        "$description" "${path#"$ROOT_DIR"/}" "$needle" >&2
+      failures=1
+      continue
+    fi
+
+    line="${match%%:*}"
+    if (( line <= previous_line )); then
+      printf 'Incorrect %s in %s near fixed text: %s\n' \
+        "$description" "${path#"$ROOT_DIR"/}" "$needle" >&2
+      failures=1
+    fi
+    previous_line="$line"
+  done
+}
+
+skill="$ROOT_DIR/SKILL.md"
+cli="$ROOT_DIR/references/cli-workflows.md"
+modeling="$ROOT_DIR/references/modeling-guidance.md"
+resilience="$ROOT_DIR/references/resilience-guidance.md"
+data_access="$ROOT_DIR/references/data-access.md"
+platform="$ROOT_DIR/references/platform-surface.md"
+mcp="$ROOT_DIR/references/mcp-optional-use.md"
+release="$ROOT_DIR/references/release-validation.md"
+
+require_text "$skill" '## Prerequisites' 'prerequisite section'
+require_text "$skill" 'OCI CLI' 'OCI CLI operator prerequisite'
+require_text "$skill" 'Bash' 'Bash operator prerequisite'
+require_text "$skill" 'curl' 'curl operator prerequisite'
+require_text "$skill" 'jq' 'jq operator prerequisite'
+require_text "$skill" 'Python 3' 'Python 3 operator prerequisite'
+require_text "$skill" 'Contributors running repository validation' 'contributor-only validation prerequisite scope'
+require_text "$skill" 'contributor-only' 'contributor-only ripgrep scope'
+require_text "$skill" 'ripgrep' 'ripgrep contributor prerequisite'
+require_text "$skill" 'https://github.com/oracle/mcp/tree/main/src/oci-iot-mcp-server' 'official OCI IoT MCP source'
+
+require_text "$cli" 'DEVELOPMENT' 'development domain-group type'
+require_text "$cli" 'PRODUCTION' 'production domain-group type'
+require_text "$cli" 'LIGHTWEIGHT' 'deprecated lightweight domain-group alias'
+require_text "$cli" 'STANDARD' 'deprecated standard domain-group alias'
+require_text "$cli" '2027-04-14' 'domain-group alias removal date'
+require_text "$cli" 'creation-time topology decision' 'domain-group type immutability'
+require_text "$cli" 'rejects domain deletion while active digital twin resources remain' 'active-resource domain deletion rule'
+require_ordered_text "$cli" 'cleanup ordering' \
+  'Delete relationships' \
+  'Delete instances' \
+  'Delete adapters' \
+  'Delete models' \
+  'fresh active-resource inventory' \
+  'delete the IoT domain' \
+  'delete the empty domain group'
+
+require_text "$modeling" 'strictly additive next minor' 'compatible model-version rule'
+require_text "$modeling" 'major-version changes' 'incompatible major-version rule'
+require_text "$modeling" 'require a new twin instance' 'incompatible-version instance behavior'
+require_text "$modeling" 'Create a new adapter' 'upgraded adapter step'
+require_text "$modeling" 'Retain the old adapter for rollback' 'old-adapter rollback posture'
+require_text "$modeling" 'get-content --should-include-metadata true' 'post-update content verification'
+require_text "$modeling" 'altitude' 'altitude point schema awareness'
+require_text "$modeling" '`has`' 'JQ has capability awareness'
+
+require_text "$resilience" 'oci_iot' 'OCI Monitoring namespace'
+require_text "$resilience" 'connection signals' 'connection signal routing'
+require_text "$resilience" 'authentication signals' 'authentication signal routing'
+require_text "$resilience" 'normalization signals' 'normalization signal routing'
+require_text "$resilience" 'Monitoring read IAM' 'Monitoring IAM prerequisite'
+
+require_text "$data_access" 'Oracle Database Tools' 'Database Tools access path'
+require_text "$data_access" 'Select AI' 'Select AI access path'
+require_text "$data_access" 'Data Pump import/export' 'Data Pump migration path'
+require_text "$data_access" 'archive-domain' 'archive-domain workflow'
+require_text "$data_access" 'Object Storage' 'archive destination'
+require_text "$data_access" 'raw database queue' 'raw database queue streaming'
+require_text "$data_access" 'normalized database queue' 'normalized database queue streaming'
+require_text "$data_access" 'advanced and optional' 'advanced-data warning'
+require_text "$data_access" 'explicit opt-in' 'explicit advanced-data opt-in warning'
+require_text "$data_access" 'auth, network, IAM, database, retention, and data-handling review' 'advanced-data prerequisite review'
+
+require_text "$platform" 'secure MQTT-over-WebSocket' 'secure MQTT-over-WebSocket awareness'
+require_text "$platform" 'WSS' 'WSS awareness'
+require_text "$platform" 'general-purpose MQTT broker' 'broker-scope warning'
+
+require_text "$mcp" 'https://github.com/oracle/mcp/tree/main/src/oci-iot-mcp-server' 'official OCI IoT MCP implementation'
+
+require_text "$release" 'oci --version' 'OCI CLI version capture'
+require_text "$release" 'oci iot --help >/dev/null' 'OCI IoT CLI capability capture'
+require_text "$release" 'bash tests/platform_currentness.sh' 'focused currentness test command'
+require_text "$release" 'documented-command drift' 'documented command drift reporting'
+
+if (( failures != 0 )); then
+  exit 1
+fi
+
+echo 'platform currentness checks passed'

--- a/oci/iot-platform/tests/smoke.sh
+++ b/oci/iot-platform/tests/smoke.sh
@@ -13,6 +13,10 @@ required_files=(
   "$ROOT_DIR/templates/instance.template.json"
   "$ROOT_DIR/templates/model.temperature-sensor.template.json"
   "$ROOT_DIR/templates/publish-curl.template.sh"
+  "$ROOT_DIR/tests/test_derive_domain_context.sh"
+  "$ROOT_DIR/tests/platform_currentness.sh"
+  "$ROOT_DIR/tests/test_publish_curl.sh"
+  "$ROOT_DIR/tests/test_twin_tools.py"
   "$ROOT_DIR/references/cli-workflows.md"
   "$ROOT_DIR/references/data-access.md"
   "$ROOT_DIR/references/mcp-optional-use.md"
@@ -22,7 +26,7 @@ required_files=(
   "$ROOT_DIR/references/release-validation.md"
 )
 
-echo "[1/6] required file check"
+echo "[1/8] required file check"
 for path in "${required_files[@]}"; do
   if [[ ! -f "$path" ]]; then
     echo "Missing required file: $path" >&2
@@ -30,11 +34,12 @@ for path in "${required_files[@]}"; do
   fi
 done
 
-echo "[2/6] skill metadata check"
+echo "[2/8] skill metadata check"
 rg -n '^name: oci-iot-platform$' "$ROOT_DIR/SKILL.md" >/dev/null
 rg -n '^description:' "$ROOT_DIR/SKILL.md" >/dev/null
+[[ "$(rg '^## ' "$ROOT_DIR/SKILL.md" | tail -n 1)" == "## Sources" ]]
 
-echo "[3/6] resilience guidance coverage check"
+echo "[3/8] resilience guidance coverage check"
 rg -n 'references/resilience-guidance\.md' "$ROOT_DIR/SKILL.md" >/dev/null
 rg -n -i 'bounded|pagination|--limit' "$ROOT_DIR/references/resilience-guidance.md" >/dev/null
 rg -n -i 'lifecycle' "$ROOT_DIR/references/resilience-guidance.md" >/dev/null
@@ -64,8 +69,17 @@ rg -n 'references/platform-surface\.md' "$ROOT_DIR/SKILL.md" >/dev/null
 rg -n -i 'domain group|digital twin model|digital twin adapter|digital twin instance|relationship|work request|raw commands|Data API' "$ROOT_DIR/references/platform-surface.md" >/dev/null
 rg -n -i 'configure-apex-data-access|configure-direct-data-access|configure-ords-data-access|change-data-retention-period|MQTTs' "$ROOT_DIR/references/platform-surface.md" "$ROOT_DIR/references/cli-workflows.md" "$ROOT_DIR/references/data-access.md" >/dev/null
 rg -n -i 'snapshotData|rawData|historizedData|rejectedData|rawCommandData' "$ROOT_DIR/references/data-access.md" >/dev/null
+rg -n -F 'https://<domain_group_short_id>.data.iot.<region>.oci.oraclecloud.com/ords/<domain_short_id>/20250531' "$ROOT_DIR/references/data-access.md" >/dev/null
 rg -n -- '--auth' "$ROOT_DIR/scripts/derive_domain_context.sh" >/dev/null
 rg -n -- '--auth <oci_cli_auth>' "$ROOT_DIR/references/cli-workflows.md" >/dev/null
+rg -n -- '--region' "$ROOT_DIR/scripts/derive_domain_context.sh" >/dev/null
+rg -n -- '--region <oci_region>' "$ROOT_DIR/references/cli-workflows.md" >/dev/null
+rg -n '^bash tests/smoke\.sh$' "$ROOT_DIR/references/release-validation.md" >/dev/null
+rg -n '^bash tests/redaction_scan\.sh$' "$ROOT_DIR/references/release-validation.md" >/dev/null
+if rg -n 'oci-iot-platform/tests/' "$ROOT_DIR/references/release-validation.md" >/dev/null; then
+  echo "Stale standalone-repo validation path found." >&2
+  exit 1
+fi
 if rg -n -- '--file ' "$ROOT_DIR/references/cli-workflows.md" >/dev/null; then
   echo "Unsupported OCI CLI --file option found in CLI workflows; use --from-json or parameter-specific file:// inputs." >&2
   exit 1
@@ -75,10 +89,19 @@ if rg -n 'lastValue' "$ROOT_DIR/templates/adapter.default.template.json" "$ROOT_
   exit 1
 fi
 
-echo "[4/6] bootstrap helper syntax check"
+echo "[4/8] helper syntax checks"
 bash -n "$ROOT_DIR/scripts/derive_domain_context.sh"
+bash -n "$ROOT_DIR/tests/platform_currentness.sh"
 
-echo "[5/6] twin tool syntax and help checks"
+echo "[5/8] platform currentness check"
+bash "$ROOT_DIR/tests/platform_currentness.sh"
+
+echo "[6/8] helper behavior checks"
+PYTHONPYCACHEPREFIX="$PYTHONPYCACHEPREFIX" python3 "$ROOT_DIR/tests/test_twin_tools.py"
+bash "$ROOT_DIR/tests/test_derive_domain_context.sh"
+bash "$ROOT_DIR/tests/test_publish_curl.sh"
+
+echo "[7/8] twin tool syntax and help checks"
 python3 -m py_compile "$ROOT_DIR/scripts/twin_tools.py"
 python3 "$ROOT_DIR/scripts/twin_tools.py" --help >/dev/null
 python3 "$ROOT_DIR/scripts/twin_tools.py" telemetry-template \
@@ -86,7 +109,7 @@ python3 "$ROOT_DIR/scripts/twin_tools.py" telemetry-template \
   --twin-id test-twin \
   --metric temperature=21.5 >/dev/null
 
-echo "[6/6] template sanity check"
+echo "[8/8] template sanity check"
 python3 -m json.tool "$ROOT_DIR/templates/adapter.default.template.json" >/dev/null
 python3 -m json.tool "$ROOT_DIR/templates/instance.template.json" >/dev/null
 python3 -m json.tool "$ROOT_DIR/templates/model.temperature-sensor.template.json" >/dev/null

--- a/oci/iot-platform/tests/test_derive_domain_context.sh
+++ b/oci/iot-platform/tests/test_derive_domain_context.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/oci-iot-domain-context.XXXXXX")"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+mkdir -p "$TEST_DIR/bin"
+cat >"$TEST_DIR/bin/oci" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$OCI_MOCK_LOG"
+case " $* " in
+  *" domain get "*)
+    printf '%s\n' '{"data":{"device-host":"domain123.device.iot.us-phoenix-1.oci.oraclecloud.com","iot-domain-group-id":"ocid1.iotdomaingroup.oc1..example"}}'
+    ;;
+  *" domain-group get "*)
+    printf '%s\n' '{"data":{"data-host":"group123.data.iot.us-phoenix-1.oci.oraclecloud.com"}}'
+    ;;
+  *)
+    printf 'Unexpected mock OCI arguments: %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+MOCK
+chmod +x "$TEST_DIR/bin/oci"
+
+export OCI_MOCK_LOG="$TEST_DIR/oci.log"
+OUTPUT="$(PATH="$TEST_DIR/bin:$PATH" bash "$ROOT_DIR/scripts/derive_domain_context.sh" \
+  --profile test-profile \
+  --auth api_key \
+  --region us-phoenix-1 \
+  --iot-domain-id ocid1.iotdomain.oc1..example)"
+
+[[ "$(rg -c -- '--region us-phoenix-1' "$OCI_MOCK_LOG")" == "2" ]]
+rg -n '^REGION=us-phoenix-1$' <<<"$OUTPUT" >/dev/null
+rg -n '^DEVICE_HOST=domain123\.device\.iot\.us-phoenix-1\.oci\.oraclecloud\.com$' <<<"$OUTPUT" >/dev/null
+rg -n '^DATA_HOST=group123\.data\.iot\.us-phoenix-1\.oci\.oraclecloud\.com$' <<<"$OUTPUT" >/dev/null
+rg -n '^DOMAIN_SHORT_ID=domain123$' <<<"$OUTPUT" >/dev/null
+rg -n '^DOMAIN_GROUP_SHORT_ID=group123$' <<<"$OUTPUT" >/dev/null
+
+echo "derive domain context behavior passed"

--- a/oci/iot-platform/tests/test_publish_curl.sh
+++ b/oci/iot-platform/tests/test_publish_curl.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/oci-iot-publish-curl.XXXXXX")"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+mkdir -p "$TEST_DIR/bin"
+cat >"$TEST_DIR/bin/curl" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >"$CURL_MOCK_ARGS"
+cat >"$CURL_MOCK_STDIN"
+printf '%s\n' '{"accepted":true}'
+exit "${CURL_MOCK_EXIT:-0}"
+MOCK
+chmod +x "$TEST_DIR/bin/curl"
+
+export CURL_MOCK_ARGS="$TEST_DIR/curl.args"
+export CURL_MOCK_STDIN="$TEST_DIR/curl.stdin"
+DEVICE_USER="device-user"
+DEVICE_SECRET="device-secret-value"
+ENCODED_CREDENTIAL="$(printf '%s:%s' "$DEVICE_USER" "$DEVICE_SECRET" | base64 | tr -d '\r\n')"
+
+run_publish() {
+  PATH="$TEST_DIR/bin:$PATH" \
+    DEVICE_USER="$DEVICE_USER" \
+    DEVICE_SECRET="$DEVICE_SECRET" \
+    DOMAIN_SHORT_ID="domain123" \
+    OCI_REGION="us-phoenix-1" \
+    REFERENCE_ENDPOINT="${1:-/sampletopic}" \
+    CURL_MOCK_EXIT="${2:-0}" \
+    bash "$ROOT_DIR/templates/publish-curl.template.sh"
+}
+
+run_publish sampletopic >/dev/null
+
+rg -n -F -- '--fail-with-body' "$CURL_MOCK_ARGS" >/dev/null
+rg -n -F -- '--header @-' "$CURL_MOCK_ARGS" >/dev/null
+rg -n -F -- 'https://domain123.device.iot.us-phoenix-1.oci.oraclecloud.com/sampletopic' "$CURL_MOCK_ARGS" >/dev/null
+if rg -n -F -- "$DEVICE_SECRET" "$CURL_MOCK_ARGS" >/dev/null; then
+  echo "Plain device secret was exposed in curl arguments." >&2
+  exit 1
+fi
+if rg -n -F -- "$ENCODED_CREDENTIAL" "$CURL_MOCK_ARGS" >/dev/null; then
+  echo "Encoded device credentials were exposed in curl arguments." >&2
+  exit 1
+fi
+rg -n -F -- "Authorization: Basic $ENCODED_CREDENTIAL" "$CURL_MOCK_STDIN" >/dev/null
+
+set +e
+run_publish /custom-endpoint 22 >/dev/null
+STATUS=$?
+set -e
+[[ "$STATUS" == "22" ]]
+rg -n -F -- 'https://domain123.device.iot.us-phoenix-1.oci.oraclecloud.com/custom-endpoint' "$CURL_MOCK_ARGS" >/dev/null
+
+echo "publish curl behavior passed"

--- a/oci/iot-platform/tests/test_twin_tools.py
+++ b/oci/iot-platform/tests/test_twin_tools.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Behavior tests for the bundled OCI IoT JSON helpers."""
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT_DIR / "scripts" / "twin_tools.py"
+SPEC = importlib.util.spec_from_file_location("twin_tools", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+twin_tools = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(twin_tools)
+
+
+class IterRecordsTests(unittest.TestCase):
+    def test_unwrapped_record_is_returned_once(self) -> None:
+        record = {"deviceId": "sensor-1", "lastSeen": "2026-06-27T12:00:00Z"}
+
+        self.assertEqual(list(twin_tools.iter_records(record)), [record])
+
+    def test_data_object_is_unwrapped(self) -> None:
+        record = {
+            "_metadata": {"timeLastHeard": "2026-06-27T12:00:00Z"},
+            "temperature": 23.5,
+        }
+
+        self.assertEqual(list(twin_tools.iter_records({"data": record})), [record])
+
+    def test_top_level_items_are_unwrapped(self) -> None:
+        records = [{"deviceId": "sensor-1"}, {"deviceId": "sensor-2"}]
+
+        self.assertEqual(list(twin_tools.iter_records({"items": records})), records)
+
+    def test_nested_data_items_are_unwrapped(self) -> None:
+        records = [{"deviceId": "sensor-1"}, {"deviceId": "sensor-2"}]
+
+        self.assertEqual(
+            list(twin_tools.iter_records({"data": {"items": records}})),
+            records,
+        )
+
+
+class CommandTests(unittest.TestCase):
+    def test_last_known_reads_wrapped_get_content_output(self) -> None:
+        payload = {
+            "data": {
+                "_metadata": {"timeLastHeard": "2026-06-27T12:00:00Z"},
+                "temperature": 23.5,
+            }
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            input_path = Path(temp_dir) / "content.json"
+            input_path.write_text(json.dumps(payload), encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    "last-known",
+                    "--input",
+                    str(input_path),
+                    "--timestamp-key",
+                    "_metadata.timeLastHeard",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        rendered = json.loads(result.stdout)
+        self.assertEqual(rendered["latest_timestamp"], "2026-06-27T12:00:00+00:00")
+        self.assertEqual(rendered["record"]["temperature"], 23.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #74

## Summary

- Handle wrapped OCI CLI records and support explicit regional domain bootstrap.
- Correct the IoT Data API path and harden HTTPS publishing against credential exposure and silent HTTP failures.
- Align release validation and source formatting with the current repository structure.
- Add deterministic regression coverage for the corrected behavior.

## Validation

- [x] `bash oci/iot-platform/tests/smoke.sh`
- [x] `bash oci/iot-platform/tests/redaction_scan.sh`
- [x] `python3 -m json.tool .claude-plugin/marketplace.json >/dev/null`
- [x] `git diff --check main...HEAD`
- [x] Clean merge-tree check against `main`

The smoke suite covers wrapped CLI records, region forwarding, publish endpoint normalization, HTTP failure propagation, and credential exclusion from curl arguments.

## Scope

This change is limited to `oci/iot-platform`:

- 11 files changed
- 3 regression-test files added
- No changes to other skill domains
- No changes to optional MCP behavior
- No live OCI or ORDS operations performed

The redaction scan found no obvious secrets or internal provenance. The branch contains one signed-off commit.