### PR TITLE
Improve Oracle DB skill verification checkpoints

### DIFF
--- a/db/SKILL.md
+++ b/db/SKILL.md
@@ -76,9 +76,11 @@ db/
 
 | Task | Recommended Sequence |
 |------|----------------------|
-| Diagnose a slow query | `explain-plan` → `wait-events` → `optimizer-stats` → `awr-reports` |
-| Plan a migration | `migration-assessment` → `oracle-migration-tools` → source-specific `migrate-*.md` → `migration-cutover-strategy` |
+| Diagnose a slow query | `explain-plan` → `wait-events` → `optimizer-stats` → ✓ verify plan changed / stats gathered → `awr-reports` |
+| Plan a migration | `migration-assessment` → `oracle-migration-tools` → source-specific `migrate-*.md` → ✓ verify data integrity before cutover → `migration-cutover-strategy` |
 | Build RAG on Oracle Database | `ai-profiles` → `vector-search` → `dbms-vector` |
 | Build a Java JDBC service | `java-oracle-jdbc` → `java-oracle-jdbc/dependencies` → `java-oracle-jdbc/connections` → `java-oracle-jdbc/sql` → `java-oracle-jdbc/pooling-production` |
-| Perform agent-safe schema change | `schema-discovery` → `destructive-op-guards` → `idempotency-patterns` → `schema-migrations` |
+| Perform agent-safe schema change | `schema-discovery` → `destructive-op-guards` → `idempotency-patterns` → ✓ verify change applied cleanly → `schema-migrations` |
 | Set up AI-driven database access via MCP | `sqlcl-basics` (save connections) → `security/privilege-management` (least-privilege user) → `sqlcl-mcp-server` (configure + start) |
+
+A `✓ verify` checkpoint means: confirm the prior step's expected outcome before proceeding. If a step fails or verification does not pass, stop and remediate that step (re-run it, correct the input, or roll back the partial change) rather than advancing to the next one. This matters most for the migration-cutover and schema-change flows, which touch live data.


### PR DESCRIPTION
## Summary

- Adds explicit `✓ verify` checkpoints to Oracle Database multi-step flows that touch plans, stats, migrations, or schema changes.
- Documents what `✓ verify` means and instructs agents to stop/remediate before advancing when verification fails.

## Tessl review results

This skill was reviewed live with `tessl/default-skill-review@0.1.0`.

- Initial score: **95%**
- Validation: **passed** with no errors or warnings
- Main finding: multi-step/data-touching flows lacked explicit validation or verification checkpoints
- After `tessl review fix --threshold 100 --yes --json`: **100%**

The fix specifically addressed the reviewer feedback by adding verification checkpoints to:

- Slow query diagnosis: verify plan changed / stats gathered before AWR
- Migration planning: verify data integrity before cutover
- Agent-safe schema change: verify the change applied cleanly before migration guidance

## Note

This improvement was done live at **AI Engineer** with **Anders Swanson**.
