### PR TITLE
Ignore Python cache artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .claude/settings.local.json
+
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
## Summary
- Ignore Python __pycache__ directories
- Ignore generated .pyc/.pyo/.pyd bytecode files

## Testing
- Not run; ignore-only change