### PR TITLE
feat(oci): add paginated logging export skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Browse and toggle installed plugins anytime with `/plugin`. Enabled plugins are 
 ## Domains
 
 - `db/` is the active Oracle Database domain and includes database, ORDS, SQLcl, framework, container, and agent workflow skills.
-- `oci/` contains Oracle Cloud Infrastructure skills, including OCI Functions deployment and troubleshooting, OCI Kubernetes Engine cluster design and troubleshooting, OCI IoT Platform digital twin workflows, plus Enterprise AI guidance for OCI Generative AI, agents, RAG, governance, model endpoints, Autonomous Database, APEX, and integrations.
+- `oci/` contains Oracle Cloud Infrastructure skills, including OCI Functions deployment and troubleshooting, complete OCI Logging Search exports, OCI Kubernetes Engine cluster design and troubleshooting, OCI IoT Platform digital twin workflows, plus Enterprise AI guidance for OCI Generative AI, agents, RAG, governance, model endpoints, Autonomous Database, APEX, and integrations.
 - `fusion/` is the root for future Oracle Fusion skills.
 - `apex/` is the root for future Oracle APEX skills.
 - `graal/` contains GraalVM skills, starting with Native Image.
@@ -113,6 +113,12 @@ Browse and toggle installed plugins anytime with `/plugin`. Enabled plugins are 
     │   ├── scripts/
     │   ├── templates/
     │   └── tests/
+    ├── logging/
+    │   └── oci-export-large-logs/
+    │       ├── SKILL.md
+    │       ├── agents/
+    │       ├── scripts/
+    │       └── tests/
     └── oke/
         ├── cluster-design.md
         ├── troubleshooting.md
@@ -148,5 +154,6 @@ For stub domains, keep `SKILL.md` minimal and point users back to this `README.m
 
 - https://docs.oracle.com/en-us/iaas/Content/ContEng/home.htm
 - https://docs.oracle.com/en-us/iaas/Content/internet-of-things/home.htm
+- https://docs.oracle.com/en-us/iaas/Content/Logging/Concepts/searchinglogs.htm
 - https://github.com/oracle-samples/oci-iot-samples
 - https://www.graalvm.org/latest/reference-manual/native-image/

--- a/oci/SKILL.md
+++ b/oci/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: oci
-description: Oracle Cloud Infrastructure guidance for designing, operating, and troubleshooting OCI services, including OCI Kubernetes Engine (OKE), OCI Internet of Things Platform, OCI Functions deployment and troubleshooting, and Enterprise AI workflows for OCI Generative AI models, Responses API agents, RAG, cost estimation, governance, private endpoints, hosted agentic applications, and Oracle platform integrations. Use when the user asks about OKE cluster design, Terraform or Resource Manager planning, OKE incident troubleshooting, Generic VNIC Attachment, Multus, pod networking, node pools, add-ons, ingress, load balancers, OCIR image pulls, Workload Identity, Kubernetes workloads on OCI, OCI IoT domains or digital twins, device publish flows, OCI Functions setup, deployment, invocation, or troubleshooting, OCI Generative AI, Enterprise AI Models, Enterprise AI Agents, governed GenAI applications, agentic workflows, RAG on Oracle Cloud, or OCI Generative AI pricing.
+description: Oracle Cloud Infrastructure guidance for designing, operating, and troubleshooting OCI services, including OCI Kubernetes Engine (OKE), OCI Internet of Things Platform, OCI Functions, OCI Logging Search exports, and Enterprise AI workflows for OCI Generative AI models, Responses API agents, RAG, cost estimation, governance, private endpoints, hosted agentic applications, and Oracle platform integrations. Use when the user asks about OKE cluster design, Terraform or Resource Manager planning, OKE incident troubleshooting, Generic VNIC Attachment, Multus, pod networking, node pools, add-ons, ingress, load balancers, OCIR image pulls, Workload Identity, Kubernetes workloads on OCI, OCI IoT domains or digital twins, device publish flows, OCI Functions setup, deployment, invocation, or troubleshooting, complete or paginated OCI log exports, OCI Generative AI, Enterprise AI Models, Enterprise AI Agents, governed GenAI applications, agentic workflows, RAG on Oracle Cloud, or OCI Generative AI pricing.
 ---
 
 # Oracle Cloud Infrastructure Skills
 
-Use this domain for practical Oracle Cloud Infrastructure guidance. Current content covers OCI Kubernetes Engine (OKE): cluster design, operational troubleshooting, Generic VNIC Attachment (GVA), and Multus multi-interface pod validation. It covers OCI Internet of Things Platform resource discovery, digital twin lifecycle workflows, device publish flows, and optional MCP-assisted operation. It covers OCI Functions local deployment and diagnosis-first troubleshooting. It also covers Enterprise AI because that work is built around OCI Generative AI, OCI networking, IAM, cost estimation, hosted applications, and OCI platform integrations.
+Use this domain for practical Oracle Cloud Infrastructure guidance. Current content covers OCI Kubernetes Engine (OKE): cluster design, operational troubleshooting, Generic VNIC Attachment (GVA), and Multus multi-interface pod validation. It covers OCI Internet of Things Platform resource discovery, digital twin lifecycle workflows, device publish flows, and optional MCP-assisted operation. It covers OCI Functions local deployment, diagnosis-first troubleshooting, and complete paginated OCI Logging Search exports. It also covers Enterprise AI because that work is built around OCI Generative AI, OCI networking, IAM, cost estimation, hosted applications, and OCI platform integrations.
 
 ## How to Use This Domain
 
@@ -46,6 +46,12 @@ oci/
 │   ├── scripts/
 │   ├── templates/
 │   └── tests/
+├── logging/
+│   └── oci-export-large-logs/
+│       ├── SKILL.md
+│       ├── agents/
+│       ├── scripts/
+│       └── tests/
 └── oke/
     ├── cluster-design.md
     ├── troubleshooting.md
@@ -69,6 +75,7 @@ oci/
 | Deploy or validate Multus NetworkAttachmentDefinitions and multi-interface pods on OKE | Start with `oci/oke/multus-multihome.md`, then load `oci/oke/skills/oke-multihome-deployer/SKILL.md` |
 | Deploy an OCI Function from a local macOS or Linux workstation | `oci/functions/oci-functions-deploy/SKILL.md` |
 | Troubleshoot OCI Functions setup, deployment, invocation, or observability | `oci/functions/oci-functions-troubleshoot/SKILL.md` |
+| Export complete OCI Logging Search results across capped pages or high-volume time ranges | `oci/logging/oci-export-large-logs/SKILL.md` |
 | OCI IoT domains, domain groups, digital twin models, adapters, instances, relationships, raw commands, Data API access, or HTTPS publish flows | `oci/iot-platform/SKILL.md` |
 | OCI Generative AI models, custom/imported models, endpoints, or private endpoints | `oci/enterprise-ai/SKILL.md` |
 | OCI Responses API agents, tools, memory, File Search, Code Interpreter, MCP, or SQL Search | `oci/enterprise-ai/SKILL.md` |
@@ -85,6 +92,7 @@ oci/
 - `oci/functions/oci-functions-troubleshoot/SKILL.md`
 - `oci/functions/oci-functions-deploy/references/oci-functions-quickstart.md`
 - `oci/functions/oci-functions-troubleshoot/references/error-patterns.md`
+- `oci/logging/oci-export-large-logs/SKILL.md`
 - `oci/iot-platform/SKILL.md`
 - `oci/iot-platform/references/cli-workflows.md`
 - `oci/iot-platform/references/mcp-optional-use.md`
@@ -96,7 +104,7 @@ oci/
 
 ## Operational Tools
 
-The OKE operational skills include deterministic helper tools under `oci/oke/scripts/` and skill-specific helper scripts under `oci/oke/skills/*/scripts/`.
+The OKE operational skills include deterministic helper tools under `oci/oke/scripts/` and skill-specific helper scripts under `oci/oke/skills/*/scripts/`. The Logging export skill includes a read-only paginated exporter under `oci/logging/oci-export-large-logs/scripts/`.
 
 - Read-only discovery and evidence tools may be used to collect context.
 - Generate-only tools may produce manifests, commands, Terraform snippets, or reports.
@@ -116,6 +124,7 @@ The OKE operational skills include deterministic helper tools under `oci/oke/scr
 | Deploy a local function | `functions/oci-functions-deploy/SKILL.md` -> preflight -> Fn context validation -> OCIR auth check -> app selection -> scaffold -> deploy |
 | Troubleshoot a failed function deploy | `functions/oci-functions-troubleshoot/SKILL.md` -> `functions/oci-functions-troubleshoot/references/error-patterns.md` -> `functions/oci-functions-troubleshoot/references/deploy.md` |
 | Troubleshoot function invocation failures | `functions/oci-functions-troubleshoot/SKILL.md` -> `functions/oci-functions-troubleshoot/references/invoke.md` -> logs, traces, metrics, and limits |
+| Export a complete high-volume OCI Logging Search | `logging/oci-export-large-logs/SKILL.md` -> confirm scope and UTC bounds -> run exporter -> verify complete summary |
 | Explore or update OCI IoT digital twin resources | `iot-platform/SKILL.md` -> `iot-platform/references/cli-workflows.md` -> `iot-platform/references/resilience-guidance.md` |
 | Publish test telemetry to an OCI IoT twin | `iot-platform/SKILL.md` -> `iot-platform/references/cli-workflows.md` -> `iot-platform/templates/publish-curl.template.sh` |
 | Build a governed enterprise assistant | `enterprise-ai/SKILL.md` -> `enterprise-ai/agent-workflows/agent-tools.md` -> `enterprise-ai/data/rag-and-search.md` -> `enterprise-ai/governance/private-endpoints-and-governance.md` |
@@ -124,6 +133,7 @@ The OKE operational skills include deterministic helper tools under `oci/oke/scr
 
 - Keep OCI service, networking, IAM, agent hosting, and cost-estimation guidance in this domain.
 - Route OCI IoT domain, digital twin, adapter, device publish, raw command, and Data API workflows to `oci/iot-platform/`.
+- Route complete OCI Logging Search and Console-export workflows to `oci/logging/oci-export-large-logs/`.
 - Route Oracle Database-owned implementation details to `db/features/`.
 - Route APEX artifact generation to `apex/apexlang/`.
 - Prefer official Oracle documentation for OCI service limits, IAM verbs, endpoint formats, regions, and pricing inputs because these change frequently.
@@ -142,3 +152,5 @@ The OKE operational skills include deterministic helper tools under `oci/oke/scr
 - https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionsquickstartlocalhost.htm
 - https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionscreatingapps.htm
 - https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionstroubleshooting.htm
+- https://docs.oracle.com/en-us/iaas/Content/Logging/Concepts/searchinglogs.htm
+- https://docs.oracle.com/en-us/iaas/tools/oci-cli/latest/oci_cli_docs/cmdref/logging-search/search-logs.html

--- a/oci/logging/oci-export-large-logs/SKILL.md
+++ b/oci/logging/oci-export-large-logs/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: oci-export-large-logs
+description: Export complete OCI Logging Search results to JSON through native OCI CLI pagination. Use when Console or CLI results are capped or truncated, when service, custom, audit, load-balancer, or VCN flow logs span high-volume or multi-day intervals, or when an auditable read-only export must preserve every returned event, including repeated log IDs.
+---
+
+# Export Large OCI Logs
+
+## Overview
+
+Export every page returned by OCI Logging Search without assuming that a log event ID is globally unique. Use the bundled exporter to follow `opc-next-page`, stream results to disk, and atomically publish the output only after all pages succeed.
+
+The operation is read-only. Do not change log configuration, retention, capture filters, or monitored resources.
+
+## Workflow
+
+1. Confirm the OCI profile, region, exact search query, UTC start and end times, and output path.
+2. Prefer a deterministic raw-event query ending in `sort by datetime asc`.
+3. Run `scripts/export_oci_logs.py`. Request approval if OCI access must run outside the sandbox.
+4. Require an exit status of zero and a final summary with `"complete": true`.
+5. Report the requested UTC coverage, page count, result count, empty-result status, and first and last returned timestamps.
+6. Keep production log exports out of source control unless the user explicitly requests otherwise.
+
+## Query Scope
+
+Use the full compartment, log-group, and log scope when available:
+
+```text
+search "COMPARTMENT_OCID/LOG_GROUP_OCID/LOG_OCID" | sort by datetime asc
+```
+
+If only a log OCID is known, use a broader accessible compartment or tenancy and filter on `oracle.logid`:
+
+```text
+search "COMPARTMENT_OR_TENANCY_OCID"
+| where oracle.logid = 'LOG_OCID'
+| sort by datetime asc
+```
+
+A zero-result search is a valid export, but it does not prove that the supplied scope is correct. If the log should contain data, obtain the exact Advanced Mode query from the Console and verify `LOG_CONTENT_READ` plus read access to the containing log group.
+
+## Export
+
+```bash
+python3 <skill-dir>/scripts/export_oci_logs.py \
+  --profile PROFILE \
+  --region eu-frankfurt-1 \
+  --search-query 'search "COMPARTMENT_OCID/LOG_GROUP_OCID/LOG_OCID" | sort by datetime asc' \
+  --time-start 2026-07-01T00:00:00Z \
+  --time-end 2026-07-04T00:00:00Z \
+  --output complete-logs.json
+```
+
+Use `--help` for optional authentication, config-file, OCI executable, and per-page limit controls.
+
+The script writes progress to stderr and one machine-readable JSON summary to stdout. It writes one response page at a time to a temporary file, preserves every result in service order, rejects malformed responses and repeated page tokens, and replaces the destination only after successful completion.
+
+## Output Contract
+
+The output remains a JSON object with:
+
+- `results`: every raw search result, without ID-based deduplication or schema-specific rewriting
+- `summary.complete`: `true` only after the final page is written
+- `summary.empty`: whether the search returned zero results
+- `summary.pagesFetched` and `summary.resultCount`
+- `summary.timeStart`, `summary.timeEnd`, `summary.searchQuery`, `summary.profile`, and `summary.region`
+- `summary.firstResultTimestamp` and `summary.lastResultTimestamp` when a recognizable timestamp exists
+
+Do not require `summary.resultCount` to equal a count of unique `data.logContent.id` values. VCN flow logs can repeat that ID across distinct events.
+
+## Guardrails
+
+- Never treat one capped response as complete when `opc-next-page` is present.
+- Never deduplicate different results solely by `data.logContent.id`.
+- Preserve raw field values and repeated events.
+- Keep search scope and time bounds unchanged while traversing page tokens.
+- Surface OCI CLI stderr and exit nonzero without replacing an existing output.
+- Treat summarized or aggregated queries as query results, not as raw log-event exports.
+
+## Sources
+
+- https://docs.oracle.com/en-us/iaas/tools/oci-cli/latest/oci_cli_docs/cmdref/logging-search/search-logs.html
+- https://docs.oracle.com/en-us/iaas/Content/Logging/Concepts/searchinglogs.htm
+- https://docs.oracle.com/en-us/iaas/Content/Logging/Reference/query_language_specification.htm
+- https://docs.oracle.com/en-us/iaas/Content/API/Concepts/usingapi.htm#nine

--- a/oci/logging/oci-export-large-logs/agents/openai.yaml
+++ b/oci/logging/oci-export-large-logs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "OCI Large Log Export"
+  short_description: "Export complete paginated OCI Logging searches"
+  default_prompt: "Use $oci-export-large-logs to export every page of an OCI Logging Search to an auditable JSON file."

--- a/oci/logging/oci-export-large-logs/scripts/export_oci_logs.py
+++ b/oci/logging/oci-export-large-logs/scripts/export_oci_logs.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Export complete OCI Logging Search results by following native page tokens."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple
+
+
+Result = Dict[str, Any]
+FetchPage = Callable[[Optional[str]], Tuple[List[Result], Optional[str]]]
+
+
+def parse_utc(value: str) -> datetime:
+    """Parse an RFC 3339 timestamp and normalize it to UTC."""
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"Invalid RFC 3339 timestamp: {value}") from exc
+    if parsed.tzinfo is None:
+        raise argparse.ArgumentTypeError(
+            "Timestamp must include Z or an explicit UTC offset"
+        )
+    return parsed.astimezone(timezone.utc)
+
+
+def oci_timestamp(value: datetime) -> str:
+    """Format a datetime as an RFC 3339 UTC timestamp for OCI CLI."""
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def result_timestamp(result: Result) -> Any:
+    """Return a useful timestamp without requiring a log-type-specific schema."""
+    data = result.get("data")
+    if not isinstance(data, dict):
+        return None
+    if data.get("datetime") is not None:
+        return data["datetime"]
+
+    log_content = data.get("logContent")
+    if not isinstance(log_content, dict):
+        return None
+    if log_content.get("time") is not None:
+        return log_content["time"]
+
+    payload = log_content.get("data")
+    if isinstance(payload, dict):
+        return payload.get("timestamp")
+    return None
+
+
+def decode_page(response: Any) -> Tuple[List[Result], Optional[str]]:
+    """Validate one OCI CLI response and return results plus its next-page token."""
+    if not isinstance(response, dict):
+        raise RuntimeError("OCI response is not a JSON object")
+
+    body = response.get("data", response)
+    if not isinstance(body, dict):
+        raise RuntimeError("OCI response does not contain a data object")
+
+    results = body.get("results")
+    if not isinstance(results, list):
+        raise RuntimeError("OCI response does not contain a data.results list")
+    if not all(isinstance(result, dict) for result in results):
+        raise RuntimeError("OCI response contains a non-object search result")
+
+    next_page = response.get("opc-next-page")
+    if next_page is not None and (
+        not isinstance(next_page, str) or not next_page.strip()
+    ):
+        raise RuntimeError("OCI response contains an invalid opc-next-page token")
+    return results, next_page
+
+
+def make_oci_fetcher(args: argparse.Namespace) -> FetchPage:
+    """Build a function that submits one page of an OCI Logging Search."""
+
+    def fetch_page(page: Optional[str]) -> Tuple[List[Result], Optional[str]]:
+        command = [
+            args.oci_cli,
+            "logging-search",
+            "search-logs",
+            "--profile",
+            args.profile,
+            "--region",
+            args.region,
+            "--search-query",
+            args.search_query,
+            "--time-start",
+            oci_timestamp(args.time_start),
+            "--time-end",
+            oci_timestamp(args.time_end),
+            "--limit",
+            str(args.limit),
+            "--output",
+            "json",
+        ]
+        if page is not None:
+            command.extend(["--page", page])
+        if args.auth:
+            command.extend(["--auth", args.auth])
+        if args.config_file:
+            command.extend(["--config-file", args.config_file])
+
+        try:
+            completed = subprocess.run(
+                command,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"OCI CLI executable not found: {args.oci_cli}") from exc
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or "").strip()
+            raise RuntimeError(
+                f"OCI CLI failed with exit code {exc.returncode}: "
+                f"{stderr or 'no stderr returned'}"
+            ) from exc
+
+        try:
+            response = json.loads(completed.stdout)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("OCI CLI returned invalid JSON") from exc
+        return decode_page(response)
+
+    return fetch_page
+
+
+def write_result(
+    stream: Any,
+    result: Result,
+    *,
+    first: bool,
+) -> None:
+    """Write one result to the open JSON array."""
+    if not first:
+        stream.write(",")
+    stream.write("\n    ")
+    json.dump(
+        result,
+        stream,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def export_results(
+    args: argparse.Namespace,
+    *,
+    fetch_page: FetchPage | None = None,
+    progress: Callable[[str], None] | None = None,
+) -> Dict[str, Any]:
+    """Fetch every page and atomically write a complete JSON export."""
+    if args.time_start >= args.time_end:
+        raise ValueError("--time-start must be earlier than --time-end")
+    if args.limit <= 0:
+        raise ValueError("--limit must be positive")
+
+    output = args.output
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fetch = fetch_page or make_oci_fetcher(args)
+    progress = progress or (lambda message: print(message, file=sys.stderr, flush=True))
+
+    page_count = 0
+    result_count = 0
+    first_timestamp: Any = None
+    last_timestamp: Any = None
+    next_page: Optional[str] = None
+    seen_tokens: Set[str] = set()
+    temporary_path: Optional[Path] = None
+
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=output.parent,
+            prefix=f".{output.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as stream:
+            temporary_path = Path(stream.name)
+            stream.write('{\n  "results": [')
+            first_result = True
+
+            while True:
+                page_count += 1
+                progress(f"Fetching page {page_count}")
+                results, returned_token = fetch(next_page)
+
+                for result in results:
+                    write_result(stream, result, first=first_result)
+                    first_result = False
+                    timestamp = result_timestamp(result)
+                    if first_timestamp is None and timestamp is not None:
+                        first_timestamp = timestamp
+                    if timestamp is not None:
+                        last_timestamp = timestamp
+                    result_count += 1
+
+                if returned_token is None:
+                    break
+                if returned_token in seen_tokens:
+                    raise RuntimeError("OCI returned a repeated opc-next-page token")
+                seen_tokens.add(returned_token)
+                next_page = returned_token
+
+            if not first_result:
+                stream.write("\n  ")
+            stream.write("],\n")
+
+            summary = {
+                "complete": True,
+                "empty": result_count == 0,
+                "firstResultTimestamp": first_timestamp,
+                "lastResultTimestamp": last_timestamp,
+                "pagesFetched": page_count,
+                "profile": args.profile,
+                "region": args.region,
+                "responseLimit": args.limit,
+                "resultCount": result_count,
+                "searchQuery": args.search_query,
+                "timeEnd": oci_timestamp(args.time_end),
+                "timeStart": oci_timestamp(args.time_start),
+            }
+            stream.write('  "summary": ')
+            rendered_summary = json.dumps(
+                summary,
+                ensure_ascii=False,
+                indent=2,
+                sort_keys=True,
+            ).replace("\n", "\n  ")
+            stream.write(rendered_summary)
+            stream.write("\n}\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+
+        os.replace(temporary_path, output)
+        temporary_path = None
+        return summary
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Export every page of an OCI Logging Search to JSON."
+    )
+    parser.add_argument("--profile", required=True, help="OCI CLI profile name")
+    parser.add_argument("--region", required=True, help="OCI region")
+    parser.add_argument("--search-query", required=True, help="OCI Logging Search query")
+    parser.add_argument(
+        "--time-start",
+        required=True,
+        type=parse_utc,
+        help="RFC 3339 start time",
+    )
+    parser.add_argument(
+        "--time-end",
+        required=True,
+        type=parse_utc,
+        help="RFC 3339 end time",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="Destination JSON file",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=1000,
+        help="Results requested per page (default: 1000)",
+    )
+    parser.add_argument("--auth", help="Optional OCI CLI authentication mode")
+    parser.add_argument("--config-file", help="Optional OCI CLI config file")
+    parser.add_argument(
+        "--oci-cli",
+        default="oci",
+        help="OCI CLI executable (default: oci)",
+    )
+    return parser
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        summary = export_results(args)
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(summary, ensure_ascii=False, sort_keys=True), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/oci/logging/oci-export-large-logs/tests/test_export_oci_logs.py
+++ b/oci/logging/oci-export-large-logs/tests/test_export_oci_logs.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Regression tests for the paginated OCI Logging Search exporter."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import subprocess
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+from typing import Dict, List, Optional, Tuple
+from unittest import mock
+
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = SKILL_DIR / "scripts" / "export_oci_logs.py"
+
+
+def load_exporter() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("export_oci_logs", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load exporter module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+EXPORTER = load_exporter()
+
+
+def make_args(output: Path) -> argparse.Namespace:
+    return argparse.Namespace(
+        profile="TEST",
+        region="eu-frankfurt-1",
+        search_query='search "scope" | sort by datetime asc',
+        time_start=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        time_end=datetime(2026, 7, 2, tzinfo=timezone.utc),
+        output=output,
+        limit=1000,
+        auth=None,
+        config_file=None,
+        oci_cli="oci",
+    )
+
+
+def flow_result(index: int, identifier: str) -> Dict:
+    return {
+        "data": {
+            "datetime": 1782864000000 + index,
+            "logContent": {
+                "data": {
+                    "action": "ACCEPT",
+                    "destinationAddress": "192.0.2.20",
+                    "sourceAddress": "192.0.2.10",
+                },
+                "id": identifier,
+                "time": "2026-07-01T00:00:00Z",
+                "type": "com.oraclecloud.vcn.flowlogs.DataEvent",
+            },
+        }
+    }
+
+
+class ExportTests(unittest.TestCase):
+    def test_preserves_1000_results_with_only_490_unique_ids(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "flow-logs.json"
+            records = [flow_result(i, f"{i % 490:08x}") for i in range(1000)]
+
+            summary = EXPORTER.export_results(
+                make_args(output),
+                fetch_page=lambda page: (records, None),
+                progress=lambda message: None,
+            )
+
+            payload = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(summary["resultCount"], 1000)
+            self.assertEqual(len(payload["results"]), 1000)
+            self.assertEqual(
+                len({item["data"]["logContent"]["id"] for item in payload["results"]}),
+                490,
+            )
+
+    def test_follows_every_page_token(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "pages.json"
+            requested_pages: List[Optional[str]] = []
+            pages = {
+                None: ([flow_result(1, "same")], "page-2"),
+                "page-2": ([flow_result(2, "same")], "page-3"),
+                "page-3": ([flow_result(3, "same")], None),
+            }
+
+            def fetch(
+                page: Optional[str],
+            ) -> Tuple[List[Dict], Optional[str]]:
+                requested_pages.append(page)
+                return pages[page]
+
+            summary = EXPORTER.export_results(
+                make_args(output),
+                fetch_page=fetch,
+                progress=lambda message: None,
+            )
+
+            payload = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(requested_pages, [None, "page-2", "page-3"])
+            self.assertEqual(summary["pagesFetched"], 3)
+            self.assertEqual(summary["resultCount"], 3)
+            self.assertEqual(len(payload["results"]), 3)
+
+    def test_empty_export_is_complete(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "empty.json"
+            summary = EXPORTER.export_results(
+                make_args(output),
+                fetch_page=lambda page: ([], None),
+                progress=lambda message: None,
+            )
+
+            payload = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(payload["results"], [])
+            self.assertTrue(summary["complete"])
+            self.assertTrue(summary["empty"])
+            self.assertEqual(summary["pagesFetched"], 1)
+
+    def test_repeated_page_token_fails_without_replacing_output(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "existing.json"
+            output.write_text("existing\n", encoding="utf-8")
+
+            with self.assertRaisesRegex(RuntimeError, "repeated opc-next-page"):
+                EXPORTER.export_results(
+                    make_args(output),
+                    fetch_page=lambda page: ([flow_result(1, "id")], "repeat"),
+                    progress=lambda message: None,
+                )
+
+            self.assertEqual(output.read_text(encoding="utf-8"), "existing\n")
+            self.assertEqual(
+                list(Path(temp_dir).glob(".existing.json.*.tmp")),
+                [],
+            )
+
+    def test_decode_page_rejects_malformed_results(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "data.results list"):
+            EXPORTER.decode_page({"data": {"results": None}})
+
+    def test_cli_failure_surfaces_stderr(self) -> None:
+        args = make_args(Path("unused.json"))
+        failed = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["oci"],
+            stderr="NotAuthorizedOrNotFound",
+        )
+        with mock.patch.object(EXPORTER.subprocess, "run", side_effect=failed):
+            with self.assertRaisesRegex(RuntimeError, "NotAuthorizedOrNotFound"):
+                EXPORTER.make_oci_fetcher(args)(None)
+
+    def test_page_token_is_forwarded_to_oci_cli(self) -> None:
+        args = make_args(Path("unused.json"))
+        response = subprocess.CompletedProcess(
+            args=["oci"],
+            returncode=0,
+            stdout='{"data":{"results":[]},"opc-next-page":"next"}',
+            stderr="",
+        )
+        with mock.patch.object(EXPORTER.subprocess, "run", return_value=response) as run:
+            results, token = EXPORTER.make_oci_fetcher(args)("current")
+
+        command = run.call_args.args[0]
+        self.assertEqual(results, [])
+        self.assertEqual(token, "next")
+        self.assertIn("--page", command)
+        self.assertEqual(command[command.index("--page") + 1], "current")
+
+    def test_timestamp_requires_timezone(self) -> None:
+        with self.assertRaises(argparse.ArgumentTypeError):
+            EXPORTER.parse_utc("2026-07-01T00:00:00")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `oci-export-large-logs` under `oci/logging/`
- follow native OCI Logging Search page tokens without ID-based deduplication
- stream results to atomic JSON output and add regression coverage
- update OCI and repository navigation

Closes #89

## Validation

- `python3 -m unittest discover -s oci/logging/oci-export-large-logs/tests -p 'test_*.py' -v`
- `quick_validate.py oci/logging/oci-export-large-logs`
- live read-only TEST VCN flow-log smoke test: 1,387 records across two pages; 521 unique IDs; all records preserved