### PR TITLE
Add Oracle JDBC Driver Extensions skills

### DIFF
--- a/db/SKILL.md
+++ b/db/SKILL.md
@@ -42,7 +42,7 @@ db/
 |-------|-----------|
 | Data Guard, redo/undo logs, users | `db/admin/` |
 | Safe DML, destructive operation guards, idempotency, schema discovery, ORA- error handling | `db/agent/` |
-| JDBC, Python, .NET, pooling, JSON, XML, spatial, Oracle Text, transactions, MLE, language drivers | `db/appdev/` |
+| JDBC, JDBC Extensions, Python, .NET, pooling, JSON, XML, spatial, Oracle Text, transactions, MLE, language drivers | `db/appdev/` |
 | RAC, Multitenant, Exadata, In-Memory, OCI database services, Data Guard architecture | `db/architecture/` |
 | Backup, recovery, RMAN, Autonomous Recovery Service, Cloud Protect | `db/backup-recovery/` |
 | OCR database-category container images and pull guidance | `db/containers/` |
@@ -79,6 +79,6 @@ db/
 | Diagnose a slow query | `explain-plan` → `wait-events` → `optimizer-stats` → `awr-reports` |
 | Plan a migration | `migration-assessment` → `oracle-migration-tools` → source-specific `migrate-*.md` → `migration-cutover-strategy` |
 | Build RAG on Oracle Database | `ai-profiles` → `vector-search` → `dbms-vector` |
-| Build a Java JDBC service | `java-oracle-jdbc` → `java-oracle-jdbc/dependencies` → `java-oracle-jdbc/connections` → `java-oracle-jdbc/sql` → `java-oracle-jdbc/pooling-production` |
+| Build a Java JDBC service | `java-oracle-jdbc` → `java-oracle-jdbc/dependencies` → `java-oracle-jdbc/connections` → `java-oracle-jdbc/sql` → `java-oracle-jdbc/pooling-production` → `java-oracle-jdbc/providers` (cloud secrets, tracing, Spring, Pkl) |
 | Perform agent-safe schema change | `schema-discovery` → `destructive-op-guards` → `idempotency-patterns` → `schema-migrations` |
 | Set up AI-driven database access via MCP | `sqlcl-basics` (save connections) → `security/privilege-management` (least-privilege user) → `sqlcl-mcp-server` (configure + start) |

--- a/db/appdev/java-oracle-jdbc.md
+++ b/db/appdev/java-oracle-jdbc.md
@@ -14,6 +14,7 @@ Start here when you need to choose the right `ojdbc` artifact, build a JDBC URL,
 | Build JDBC URLs; use Easy Connect, EZConnect+, TNS aliases, wallets, or TLS | [JDBC Connections](java-oracle-jdbc/connections.md) |
 | Run queries, DML, batch operations, binds, and PL/SQL calls | [JDBC SQL and PL/SQL](java-oracle-jdbc/sql.md) |
 | Configure UCP, Spring Boot datasource settings, security, and production practices | [JDBC Pooling and Production](java-oracle-jdbc/pooling-production.md) |
+| Load connections/secrets from a cloud provider, add tracing, or use Spring/Pkl extensions | [Oracle JDBC Driver Extensions](java-oracle-jdbc/providers.md) |
 
 ## Quick Defaults
 
@@ -38,3 +39,4 @@ Start here when you need to choose the right `ojdbc` artifact, build a JDBC URL,
 - [Oracle Net Services Administrator's Guide 26ai - Configuring the Easy Connect Naming Method](https://docs.oracle.com/en/database/oracle/oracle-database/26/netag/configuring-easy-connect-naming-method.html)
 - [Oracle JDBC Downloads](https://www.oracle.com/database/technologies/appdev/jdbc-downloads.html)
 - [Spring Boot Oracle Configuration](https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#appendix.application-properties.data)
+- [oracle/ojdbc-extensions](https://github.com/oracle/ojdbc-extensions)

--- a/db/appdev/java-oracle-jdbc/dependencies.md
+++ b/db/appdev/java-oracle-jdbc/dependencies.md
@@ -24,7 +24,24 @@ Use the matching UCP artifact for the JDBC driver line:
 
 Keep `ojdbc` and `ucp` artifacts on the same version.
 
+## Dependency Versions
+
+Before generating a dependency, get the latest published version from
+`https://central.sonatype.com/artifact/com.oracle.database.jdbc/{artifact-id}`
+and use the latest version shown there. Do not assume a version shown in this
+skill is current.
+
 ## Maven
+
+The Maven snippets use a property so related artifacts remain aligned. Replace
+`RESOLVED_EXACT_VERSION` with the latest version shown on the Maven Central
+artifact page:
+
+```xml
+<properties>
+    <oracle.jdbc.version>RESOLVED_EXACT_VERSION</oracle.jdbc.version>
+</properties>
+```
 
 For modern JDK 17+ applications:
 
@@ -32,13 +49,13 @@ For modern JDK 17+ applications:
 <dependency>
     <groupId>com.oracle.database.jdbc</groupId>
     <artifactId>ojdbc17</artifactId>
-    <version>23.26.2.0.0</version>
+    <version>${oracle.jdbc.version}</version>
 </dependency>
 
 <dependency>
     <groupId>com.oracle.database.jdbc</groupId>
     <artifactId>ucp17</artifactId>
-    <version>23.26.2.0.0</version>
+    <version>${oracle.jdbc.version}</version>
 </dependency>
 ```
 
@@ -48,13 +65,13 @@ For JDK 11 applications:
 <dependency>
     <groupId>com.oracle.database.jdbc</groupId>
     <artifactId>ojdbc11</artifactId>
-    <version>23.26.2.0.0</version>
+    <version>${oracle.jdbc.version}</version>
 </dependency>
 
 <dependency>
     <groupId>com.oracle.database.jdbc</groupId>
     <artifactId>ucp11</artifactId>
-    <version>23.26.2.0.0</version>
+    <version>${oracle.jdbc.version}</version>
 </dependency>
 ```
 
@@ -64,25 +81,32 @@ For applications that intentionally use Oracle's production dependency bundle:
 <dependency>
     <groupId>com.oracle.database.jdbc</groupId>
     <artifactId>ojdbc17-production</artifactId>
-    <version>23.26.2.0.0</version>
+    <version>${oracle.jdbc.version}</version>
     <type>pom</type>
 </dependency>
 ```
 
 ## Gradle
 
+Set `oracleJdbcVersion` to the latest version shown on the Maven Central
+artifact page:
+
+```groovy
+def oracleJdbcVersion = 'RESOLVED_EXACT_VERSION'
+```
+
 For modern JDK 17+ applications:
 
 ```groovy
-implementation 'com.oracle.database.jdbc:ojdbc17:23.26.2.0.0'
-implementation 'com.oracle.database.jdbc:ucp17:23.26.2.0.0'
+implementation "com.oracle.database.jdbc:ojdbc17:${oracleJdbcVersion}"
+implementation "com.oracle.database.jdbc:ucp17:${oracleJdbcVersion}"
 ```
 
 For JDK 11 applications:
 
 ```groovy
-implementation 'com.oracle.database.jdbc:ojdbc11:23.26.2.0.0'
-implementation 'com.oracle.database.jdbc:ucp11:23.26.2.0.0'
+implementation "com.oracle.database.jdbc:ojdbc11:${oracleJdbcVersion}"
+implementation "com.oracle.database.jdbc:ucp11:${oracleJdbcVersion}"
 ```
 
 ## Dependency Practices
@@ -95,7 +119,7 @@ implementation 'com.oracle.database.jdbc:ucp11:23.26.2.0.0'
 
 ## Oracle Version Notes (19c vs 26ai)
 
-- The examples use the Oracle AI Database 26ai JDBC/UCP RU line.
+- Resolve the current compatible JDBC/UCP release line when generating examples.
 - Oracle Database 26ai JDBC drivers are certified with Oracle Database 26ai, 21c, and 19c servers.
 - Newer server features, such as JSON Relational Duality Views and `VECTOR`, require a compatible database release and a current JDBC driver line.
 

--- a/db/appdev/java-oracle-jdbc/pooling-production.md
+++ b/db/appdev/java-oracle-jdbc/pooling-production.md
@@ -48,11 +48,14 @@ spring:
 
 Use the Oracle production POM when you intentionally want Oracle's production dependency bundle:
 
+This assumes `oracle.jdbc.version` is set to the exact version from the
+[JDBC dependency version rule](dependencies.md#dependency-versions).
+
 ```xml
 <dependency>
     <groupId>com.oracle.database.jdbc</groupId>
     <artifactId>ojdbc17-production</artifactId>
-    <version>23.26.2.0.0</version>
+    <version>${oracle.jdbc.version}</version>
     <type>pom</type>
 </dependency>
 ```

--- a/db/appdev/java-oracle-jdbc/providers.md
+++ b/db/appdev/java-oracle-jdbc/providers.md
@@ -1,0 +1,128 @@
+# Oracle JDBC Driver Extensions
+
+## Overview
+
+Use this skill when a Java application needs Oracle JDBC to pull connection
+strings, credentials, wallets, or trace events from a cloud secret store,
+configuration service, or observability stack, instead of hardcoding them.
+
+Starting with the 23.3 release, Oracle JDBC defines Service Provider
+Interfaces (SPIs) in the `oracle.jdbc.spi` package. The
+[oracle/ojdbc-extensions](https://github.com/oracle/ojdbc-extensions) project
+implements these SPIs as "providers" that plug into the driver through
+`java.util.ServiceLoader`, with no application code changes. This skill
+distills the intent and configuration surface of those providers; consult the
+per-cloud pages below when configuring a specific one.
+
+For core JDBC usage (driver artifact selection, URLs, SQL, pooling), start
+with [Java Oracle JDBC Overview](../java-oracle-jdbc.md) instead.
+
+## Provider Types
+
+Most providers in this project are one of two kinds:
+
+| Type | What it gives the driver | Identified by |
+|------|---------------------------|----------------|
+| **Centralized Config Provider** | Everything needed to open a connection: connect descriptor, user, password, wallet, and JDBC properties, all in one payload | A JDBC URL prefix: `jdbc:oracle:thin:@config-{provider}://...` |
+| **Resource Provider** | One specific resource: a password, username, access token, TLS wallet, SEPS wallet, or `tnsnames.ora`-based connection string | A connection property: `oracle.jdbc.provider.{resource-type}={provider-name}` |
+
+A Resource Provider is selected per resource type. The property name to the
+left of `=` is fixed by Oracle JDBC (e.g. `oracle.jdbc.provider.password`,
+`oracle.jdbc.provider.accessToken`, `oracle.jdbc.provider.username`,
+`oracle.jdbc.provider.traceEventListener`); the value is the provider's
+registered name (e.g. `ojdbc-provider-oci-vault-password`). Provider-specific
+parameters are appended as `oracle.jdbc.provider.{resource-type}.{param}=...`.
+
+A third kind, the **JSON Provider** (`oracle.jdbc.spi.JsonProvider`), doesn't
+supply connection resources at all — it plugs into the driver's native JSON
+(OSON) handling. `ojdbc-provider-jackson-oson` is the one example in this
+project; see [Jackson OSON Provider](providers/jackson-oson.md).
+
+## Provider Map
+
+| Provider | Dependency | JDK | Skill |
+|----------|-----------|-----|-------|
+| OCI | `com.oracle.database.jdbc:ojdbc-provider-oci` | 8+ | [OCI Providers](providers/oci.md) |
+| Azure | `com.oracle.database.jdbc:ojdbc-provider-azure` | 8+ | [Azure Providers](providers/azure.md) |
+| HashiCorp Vault (HCP Dedicated) | `com.oracle.database.jdbc:ojdbc-provider-hashicorp` | 8+ | [HashiCorp Providers](providers/hashicorp.md) |
+| GCP | `com.oracle.database.jdbc:ojdbc-provider-gcp` | 8+ | [GCP Providers](providers/gcp.md) |
+| AWS | `com.oracle.database.jdbc:ojdbc-provider-aws` | 8+ | [AWS Providers](providers/aws.md) |
+| Observability (OpenTelemetry / JFR) | `com.oracle.database.jdbc:ojdbc-provider-observability` | 11+ | [Observability Provider](providers/observability.md) |
+| Spring (Deep Data Security end-user context) | `com.oracle.database.jdbc:ojdbc-provider-spring` | 17+ | [Spring Providers](providers/spring.md) |
+| Pkl parser (used by other providers) | `com.oracle.database.jdbc:ojdbc-provider-pkl` | 17+ | [Pkl Parser](providers/pkl.md) |
+| Jackson OSON (JSON mapping) | `com.oracle.database.jdbc:ojdbc-provider-jackson-oson` | 8+ (needs JDBC 23.6+) | [Jackson OSON Provider](providers/jackson-oson.md) |
+
+Keep every provider dependency you use on the same release line and version
+(e.g. all `1.1.0`) when combined in one application.
+
+## Shared Concepts Across Cloud Providers
+
+The OCI, Azure, HashiCorp, GCP, and AWS providers share one design, so
+learning it once transfers across clouds:
+
+- **Configuration payload.** A Centralized Config Provider's payload is JSON
+  by default, with four root keys: `connect_descriptor` (required), `user`,
+  `password`, `wallet_location` (all optional), plus a `jdbc` object whose
+  keys are properties from
+  [`OracleConnection`](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html)
+  (e.g. `"autoCommit": "false"`, `"oracle.jdbc.ReadTimeout": 1000`).
+- **Password / wallet_location as an object.** Instead of a raw string, both
+  fields can be an object: `{"type": "ocivault|azurevault|gcpsecretmanager|
+  awssecretsmanager|hcpvaultdedicated|base64", "value": "...", "authentication": {...}}`.
+  This lets a payload stored in one cloud reference a secret stored in
+  another. The wallet always goes in the top-level `wallet_location` object,
+  not inside the `jdbc` object.
+- **Pluggable payload parser.** Payloads are parsed as JSON unless a
+  `parser` query parameter names another parser provider on the classpath,
+  e.g. `?parser=pkl` with `ojdbc-provider-pkl` present. See
+  [Pkl Parser](providers/pkl.md).
+- **Auto-detect authentication.** Each cloud provider supports an
+  `authenticationMethod` (or `AUTHENTICATION`) parameter with an
+  `auto-detect` default that tries credential sources in a fixed order
+  (SDK config file/env vars first, workload identity last). Prefer pinning
+  an explicit method in production so a misconfigured environment fails
+  loudly instead of silently authenticating as the wrong identity.
+- **Common resource-provider parameters live on the property, not the URL.**
+  Parameters are appended to whichever `oracle.jdbc.provider.*` property
+  identifies the provider, and only work in a connection properties file or
+  programmatic configuration — not as JVM system properties.
+
+## Best Practices
+
+- Pick the Centralized Config Provider path when one secret/service should
+  own the *entire* connection (descriptor + credentials); pick Resource
+  Providers when only one piece (e.g. just the password, or just an access
+  token) should be externalized and the rest is static.
+- Put the wallet in the `wallet_location` object and a plaintext secret in
+  the `password` object — not inside the payload's `jdbc` object.
+- Pin an explicit `authenticationMethod` in production; reserve
+  `auto-detect` for local development.
+- Keep every provider dependency used in one application on the same
+  release version, and on the same line as `ojdbc17`/`ucp17` (see
+  [JDBC Dependencies](dependencies.md)).
+- Use least-privilege IAM/Vault policies for the identity each provider
+  authenticates as — these providers only fetch what the driver needs, they
+  do not authorize it.
+
+## Common Mistakes
+
+| Mistake | Problem | Fix |
+|---------|---------|-----|
+| Setting `oracle.net.wallet_password` outside the `jdbc` object | Provider ignores it or the wallet fails to decrypt | Put `oracle.net.wallet_password` inside the payload's `jdbc` object |
+| Configuring provider parameters as `-D` JVM system properties | Silently ignored for provider selection/config | Use a connection properties file or programmatic `Properties` |
+| Mixing provider dependency versions | Class or behavior mismatches | Align all provider versions with the driver/UCP line |
+| Relying on `auto-detect` in production | Non-deterministic identity if multiple credential sources are present | Set `authenticationMethod` explicitly |
+
+## Related Skills
+
+- [Java Oracle JDBC Overview](../java-oracle-jdbc.md)
+- [JDBC Connections](connections.md)
+- [JDBC Pooling and Production](pooling-production.md)
+- [Network Security](../../security/network-security.md)
+
+## Sources
+
+- [oracle/ojdbc-extensions](https://github.com/oracle/ojdbc-extensions)
+- [Oracle AI Database JDBC Developer's Guide 26ai](https://docs.oracle.com/en/database/oracle/oracle-database/26/jjdbc/index.html)
+- [OracleResourceProvider (SPI)](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/spi/OracleResourceProvider.html)
+- [OracleConnection connection properties](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html)

--- a/db/appdev/java-oracle-jdbc/providers.md
+++ b/db/appdev/java-oracle-jdbc/providers.md
@@ -52,8 +52,14 @@ project; see [Jackson OSON Provider](providers/jackson-oson.md).
 | Pkl parser (used by other providers) | `com.oracle.database.jdbc:ojdbc-provider-pkl` | 17+ | [Pkl Parser](providers/pkl.md) |
 | Jackson OSON (JSON mapping) | `com.oracle.database.jdbc:ojdbc-provider-jackson-oson` | 8+ (needs JDBC 23.6+) | [Jackson OSON Provider](providers/jackson-oson.md) |
 
-Keep every provider dependency you use on the same release line and version
-(e.g. all `1.1.0`) when combined in one application.
+## Provider Versions
+
+Follow the [JDBC dependency version rule](dependencies.md#dependency-versions)
+when selecting a provider version. If you use more than one provider, use the
+same version for all provider dependencies.
+
+The provider-page Maven snippets use `ojdbc.provider.version`; define that
+property with the resolved exact version in the consuming POM.
 
 ## Shared Concepts Across Cloud Providers
 

--- a/db/appdev/java-oracle-jdbc/providers/aws.md
+++ b/db/appdev/java-oracle-jdbc/providers/aws.md
@@ -1,0 +1,104 @@
+# JDBC Providers for AWS
+
+## Overview
+
+Use this skill to configure Oracle JDBC to load connection strings,
+credentials, or TLS wallets from AWS S3, Secrets Manager, Systems Manager
+Parameter Store, and AppConfig.
+
+For shared provider concepts (config vs resource providers, payload format,
+caching), see [Oracle JDBC Driver Extensions](../providers.md) first.
+
+## Installation
+
+```xml
+<dependency>
+  <groupId>com.oracle.database.jdbc</groupId>
+  <artifactId>ojdbc-provider-aws</artifactId>
+  <version>1.1.0</version>
+</dependency>
+```
+
+Compiled for JDK 8, forward compatible with later JDKs.
+
+## Centralized Config Providers
+
+| Provider | URL prefix | Identifies |
+|----------|-----------|------------|
+| S3 | `jdbc:oracle:thin:@config-awss3://{s3-uri}` (or `jdbc:oracle:thin:@config-aws{s3-uri}`) | A JSON (or Pkl) payload object in S3 |
+| Secrets Manager | `jdbc:oracle:thin:@config-awssecretsmanager://{secret-name}` | A JSON (or Pkl) payload stored as a secret |
+| Parameter Store | `jdbc:oracle:thin:@config-awsparameterstore://{parameter-name}` | A JSON (or Pkl) payload stored as a parameter value |
+| AppConfig Freeform | `jdbc:oracle:thin:@config-awsappconfig://{application-id}?appconfig_environment={env}&appconfig_profile={profile}` | A freeform configuration profile in AWS AppConfig |
+
+```java
+ds.setURL("jdbc:oracle:thin:@config-awss3://s3://mybucket/payload.json");
+```
+
+AppConfig's `environment` and `profile` may instead come from system
+properties (`aws.appconfig.environment`, `aws.appconfig.profile`) or
+environment variables (`AWS_APP_CONFIG_ENVIRONMENT`,
+`AWS_APP_CONFIG_PROFILE`). All four share the standard `connect_descriptor` /
+`user` / `password` / `wallet_location` / `jdbc` payload shape from
+[Oracle JDBC Driver Extensions](../providers.md). Add `?parser=pkl` (with
+`ojdbc-provider-pkl` on the classpath) for Pkl payloads — see
+[Pkl Parser](pkl.md).
+
+## Resource Providers
+
+| Provider | Name | Gives the driver |
+|----------|------|-------------------|
+| Secrets Manager Username | `ojdbc-provider-aws-secrets-manager-username` | Username from a secret (`secretName`, optional `fieldName`) |
+| Parameter Store Username | `ojdbc-provider-aws-parameter-store-username` | Username from a parameter (`parameterName`) |
+| Secrets Manager Password | `ojdbc-provider-aws-secrets-manager-password` | Password from a secret |
+| Parameter Store Password | `ojdbc-provider-aws-parameter-store-password` | Password from a parameter |
+| Secrets Manager TCPS Wallet | `ojdbc-provider-aws-secrets-manager-tls` | TLS wallet (`SSO`/`PKCS12`/`PEM`) from a secret |
+| Secrets Manager SEPS Wallet | `ojdbc-provider-aws-secrets-manager-seps` | Username+password from a SEPS wallet secret |
+| Parameter Store SEPS Wallet | `ojdbc-provider-aws-parameter-store-seps` | Same as above, sourced from Parameter Store |
+| Secrets Manager Connection String | `ojdbc-provider-aws-secrets-manager-tnsnames` | Connect string from a `tnsnames.ora` alias in a secret |
+| Parameter Store Connection String | `ojdbc-provider-aws-parameter-store-tnsnames` | Same, sourced from Parameter Store |
+
+`fieldName` selects a key when a secret/parameter stores multiple key-value
+pairs; it is an error to set it on a plain-text secret, and an error to omit
+it when multiple keys exist with no single unambiguous value.
+
+```properties
+oracle.jdbc.provider.password=ojdbc-provider-aws-secrets-manager-password
+oracle.jdbc.provider.password.authenticationMethod=aws-default
+oracle.jdbc.provider.password.awsRegion=us-west-2
+oracle.jdbc.provider.password.fieldName=password
+```
+
+## Authentication
+
+Providers use the AWS SDK [Default Credentials Provider
+Chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html):
+Java system properties → environment variables → web identity token (STS) →
+shared credentials/config files → ECS container credentials → EC2 instance
+role. The only provider-specific parameters are `authenticationMethod`
+(currently just `aws-default`) and `awsRegion`, which — if unset — falls
+back to the [default region provider
+chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html#automatically-determine-the-aws-region-from-the-environment).
+
+## Best Practices
+
+- On EC2/ECS/Lambda, rely on the instance/task/execution role instead of
+  static access keys.
+- Set `awsRegion` explicitly when the resource's region differs from the
+  environment's default region, to avoid cross-region latency or
+  `ResourceNotFoundException`.
+- Use `fieldName` rather than one secret per credential when several
+  related values (username, password, wallet) live together — it keeps
+  rotation atomic.
+
+## Related Skills
+
+- [Oracle JDBC Driver Extensions](../providers.md)
+- [Pkl Parser](pkl.md)
+- [Network Security](../../../security/network-security.md)
+
+## Sources
+
+- [ojdbc-provider-aws README](https://github.com/oracle/ojdbc-extensions/blob/main/ojdbc-provider-aws/README.md)
+- [ojdbc-provider-samples (AWS)](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/aws)
+- [AWS SDK Default Credentials Provider Chain](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-chain.html)
+- [Oracle AI Database JDBC Developer's Guide 26ai](https://docs.oracle.com/en/database/oracle/oracle-database/26/jjdbc/index.html)

--- a/db/appdev/java-oracle-jdbc/providers/aws.md
+++ b/db/appdev/java-oracle-jdbc/providers/aws.md
@@ -15,7 +15,7 @@ caching), see [Oracle JDBC Driver Extensions](../providers.md) first.
 <dependency>
   <groupId>com.oracle.database.jdbc</groupId>
   <artifactId>ojdbc-provider-aws</artifactId>
-  <version>1.1.0</version>
+  <version>${ojdbc.provider.version}</version>
 </dependency>
 ```
 

--- a/db/appdev/java-oracle-jdbc/providers/azure.md
+++ b/db/appdev/java-oracle-jdbc/providers/azure.md
@@ -1,0 +1,110 @@
+# JDBC Providers for Azure
+
+## Overview
+
+Use this skill to configure Oracle JDBC to load connection strings,
+credentials, TLS wallets, or access tokens from Azure App Configuration and
+Azure Key Vault.
+
+For shared provider concepts (config vs resource providers, payload format,
+caching, auto-detect auth), see [Oracle JDBC Driver Extensions](../providers.md) first.
+
+## Installation
+
+```xml
+<dependency>
+  <groupId>com.oracle.database.jdbc</groupId>
+  <artifactId>ojdbc-provider-azure</artifactId>
+  <version>1.1.0</version>
+</dependency>
+```
+
+Compiled for JDK 8, forward compatible with later JDKs.
+
+## Centralized Config Providers
+
+| Provider | URL prefix | Identifies |
+|----------|-----------|------------|
+| App Configuration | `jdbc:oracle:thin:@config-azure://{appconfig-name}?key={prefix}&label={value}` | Key/value pairs in an App Configuration store (values may reference Key Vault secrets) |
+| Vault | `jdbc:oracle:thin:@config-azurevault://{secret-identifier}` | A JSON (or Pkl) payload stored as the content of a Key Vault secret |
+
+```java
+ds.setURL("jdbc:oracle:thin:@config-azure://myappconfig?key=/sales_app1/&label=dev");
+```
+
+App Configuration keys map to payload fields by suffix: `{prefix}user`,
+`{prefix}connect_descriptor`, `{prefix}password`, `{prefix}wallet_location`,
+and `{prefix}jdbc/{property}` for JDBC connection properties (e.g.
+`/sales_app1/jdbc/oracle.jdbc.fanEnabled`). If `key`/`label` are omitted,
+unlabeled/unprefixed values are used. `password` and `wallet_location` may
+themselves be `{"uri": "https://myvault.vault.azure.net/secrets/..."}`
+references into Key Vault.
+
+Add `?parser=pkl` (plus `ojdbc-provider-pkl` on the classpath) to parse a Pkl
+payload for the Vault provider — see [Pkl Parser](pkl.md).
+
+## Resource Providers
+
+| Provider | Name | Gives the driver |
+|----------|------|-------------------|
+| Access Token | `ojdbc-provider-azure-token` | OAuth access token authorizing Azure AD-mapped logins to an Autonomous Database |
+| Key Vault Username | `ojdbc-provider-azure-key-vault-username` | Username from a Key Vault secret (`vaultUrl` + `secretName`) |
+| Key Vault Password | `ojdbc-provider-azure-key-vault-password` | Password from a Key Vault secret (`vaultUrl` + `secretName`) |
+| Key Vault TCPS Wallet | `ojdbc-provider-azure-key-vault-tls` | TLS wallet (`SSO`/`PKCS12`/`PEM`) stored base64 in a Key Vault secret |
+| Key Vault SEPS Wallet | `ojdbc-provider-azure-key-vault-seps` | Username+password from a SEPS wallet stored in a Key Vault secret |
+| Key Vault Connection String | `ojdbc-provider-azure-key-vault-tnsnames` | Connect string resolved from a `tnsnames.ora` alias stored in a Key Vault secret |
+
+```properties
+oracle.jdbc.provider.accessToken=ojdbc-provider-azure-token
+oracle.jdbc.provider.accessToken.scope=https://example.com/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx/.default
+```
+
+`scope` is the database's Application ID URI, optionally with a scope name
+appended (`.../session:scope:connect`) or `.default` for the default scope.
+Wallet providers require `type` (`SSO`/`PKCS12`/`PEM`) and, for
+password-protected wallets, `walletPassword`.
+
+## Authentication
+
+Common parameters: `authenticationMethod`, `tenantId`, `clientId`,
+`clientCertificatePath`, `clientCertificatePassword`, `clientSecret`,
+`username`, `password`, `redirectUri` (default `http://localhost`). All fall
+back to the matching Azure SDK environment variable (`AZURE_TENANT_ID`,
+`AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, etc.) when not set on the property.
+
+`authenticationMethod` values: `service-principal` (tenant + client ID with
+a certificate or secret), `managed-identity` (optionally with `clientId` for
+user-assigned identities), `password` (client ID + username/password),
+`device-code`, `interactive` (opens a browser), and `auto-detect` (default —
+tries `service-principal`, `password`, `managed-identity`, in that order).
+
+For Centralized Config Providers, `AUTHENTICATION` additionally accepts
+`AZURE_DEFAULT` (the SDK's `DefaultAzureCredential` chain: environment →
+managed identity → shared token cache → Visual Studio → Azure CLI →
+PowerShell → interactive browser).
+
+```properties
+oracle.jdbc.provider.password=ojdbc-provider-azure-key-vault-password
+oracle.jdbc.provider.password.authenticationMethod=service-principal
+oracle.jdbc.provider.password.tenantId=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+oracle.jdbc.provider.password.clientId=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+oracle.jdbc.provider.password.clientCertificatePath=/users/app/certificate.pem
+```
+
+## Best Practices
+
+- Reserve `AZURE_DEFAULT`/`auto-detect` for local development.
+
+## Related Skills
+
+- [Oracle JDBC Driver Extensions](../providers.md)
+- [OCI Providers](oci.md)
+- [Pkl Parser](pkl.md)
+- [Network Security](../../../security/network-security.md)
+
+## Sources
+
+- [ojdbc-provider-azure README](https://github.com/oracle/ojdbc-extensions/blob/main/ojdbc-provider-azure/README.md)
+- [ojdbc-provider-samples (Azure)](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/azure)
+- [Azure Identity SDK Credential Classes](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/identity/azure-identity#credential-classes)
+- [Oracle AI Database JDBC Developer's Guide 26ai](https://docs.oracle.com/en/database/oracle/oracle-database/26/jjdbc/index.html)

--- a/db/appdev/java-oracle-jdbc/providers/azure.md
+++ b/db/appdev/java-oracle-jdbc/providers/azure.md
@@ -15,7 +15,7 @@ caching, auto-detect auth), see [Oracle JDBC Driver Extensions](../providers.md)
 <dependency>
   <groupId>com.oracle.database.jdbc</groupId>
   <artifactId>ojdbc-provider-azure</artifactId>
-  <version>1.1.0</version>
+  <version>${ojdbc.provider.version}</version>
 </dependency>
 ```
 

--- a/db/appdev/java-oracle-jdbc/providers/gcp.md
+++ b/db/appdev/java-oracle-jdbc/providers/gcp.md
@@ -1,0 +1,98 @@
+# JDBC Providers for GCP
+
+## Overview
+
+Use this skill to configure Oracle JDBC to load connection strings,
+credentials, or TLS wallets from Google Cloud Storage and GCP Secret
+Manager.
+
+For shared provider concepts (config vs resource providers, payload format,
+caching), see [Oracle JDBC Driver Extensions](../providers.md) first.
+
+## Installation
+
+```xml
+<dependency>
+  <groupId>com.oracle.database.jdbc</groupId>
+  <artifactId>ojdbc-provider-gcp</artifactId>
+  <version>1.1.0</version>
+</dependency>
+```
+
+Compiled for JDK 8, forward compatible with later JDKs.
+
+## Authentication
+
+Providers use [Application Default Credentials
+(ADC)](https://cloud.google.com/docs/authentication/application-default-credentials).
+ADC resolves credentials in order: `GOOGLE_APPLICATION_CREDENTIALS`
+environment variable → user credentials from the `gcloud` CLI → the attached
+service account from the metadata server. There is no per-provider
+authentication parameter to configure — set up ADC once for the runtime
+environment:
+
+```bash
+gcloud auth application-default login
+```
+
+## Centralized Config Providers
+
+| Provider | URL prefix | Identifies |
+|----------|-----------|------------|
+| Cloud Storage | `jdbc:oracle:thin:@config-gcpstorage://project={project};bucket={bucket};object={object}` (also accepts `gs://{bucket}/{object}` or `https://storage.googleapis.com/{bucket}/{object}`) | A JSON (or Pkl) payload object in Cloud Storage |
+| Secret Manager | `jdbc:oracle:thin:@config-gcpsecretmanager:{resource-name}` | A JSON (or Pkl) payload stored as a Secret Manager secret |
+
+```java
+ds.setURL("jdbc:oracle:thin:@config-gcpstorage://project=myproject;bucket=mybucket;object=payload.json");
+```
+
+`project` is optional for the `project=;bucket=;object=` form; the `gs://`
+and `storage.googleapis.com` forms always use the SDK's default client
+project. The payload has 3 root fields: `connect_descriptor` (required),
+`user`, `password` — plus the shared `wallet_location` and `jdbc` object
+described in [Oracle JDBC Driver Extensions](../providers.md). Add `?parser=pkl` (with
+`ojdbc-provider-pkl` on the classpath) for Pkl payloads — see
+[Pkl Parser](pkl.md).
+
+## Resource Providers
+
+| Provider | Name | Gives the driver |
+|----------|------|-------------------|
+| Secret Manager Password | `ojdbc-provider-gcp-secretmanager-password` | Password from a secret version (`secretVersionName`) |
+| Secret Manager Username | `ojdbc-provider-gcp-secretmanager-username` | Username from a secret version |
+| Secret Manager TCPS Wallet | `ojdbc-provider-gcp-secretmanager-tls` | TLS wallet (`SSO`/`PKCS12`/`PEM`), stored base64 or as raw imported bytes |
+| Secret Manager SEPS Wallet | `ojdbc-provider-gcp-secretmanager-seps` | Username+password from a SEPS wallet secret |
+| Secret Manager Connection String | `ojdbc-provider-gcp-secretmanager-tnsnames` | Connect string resolved from a `tnsnames.ora` alias in a secret |
+
+`secretVersionName` has the form
+`projects/{project-id}/secrets/{secret-id}/versions/{version-id}`. Wallet
+providers auto-detect base64 vs raw imported bytes, and require `type`
+(`SSO`/`PKCS12`/`PEM`) plus `walletPassword` for protected wallets.
+
+```properties
+oracle.jdbc.provider.password=ojdbc-provider-gcp-secretmanager-password
+oracle.jdbc.provider.password.secretVersionName=projects/138028249883/secrets/test-secret/versions/1
+```
+
+## Best Practices
+
+- Grant the runtime's service account `roles/secretmanager.secretAccessor`
+  scoped to the specific secrets it needs, not project-wide access.
+- Prefer the attached service account (metadata server) over
+  `GOOGLE_APPLICATION_CREDENTIALS` key files on GCE/GKE/Cloud Run — it
+  avoids a long-lived key to rotate or leak.
+- Pin a `versions/{n}` in `secretVersionName` for reproducible deploys
+  instead of `versions/latest`, if your workflow supports it.
+
+## Related Skills
+
+- [Oracle JDBC Driver Extensions](../providers.md)
+- [Pkl Parser](pkl.md)
+- [Network Security](../../../security/network-security.md)
+
+## Sources
+
+- [ojdbc-provider-gcp README](https://github.com/oracle/ojdbc-extensions/blob/main/ojdbc-provider-gcp/README.md)
+- [ojdbc-provider-samples (GCP)](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/gcp)
+- [GCP Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
+- [Oracle AI Database JDBC Developer's Guide 26ai](https://docs.oracle.com/en/database/oracle/oracle-database/26/jjdbc/index.html)

--- a/db/appdev/java-oracle-jdbc/providers/gcp.md
+++ b/db/appdev/java-oracle-jdbc/providers/gcp.md
@@ -15,7 +15,7 @@ caching), see [Oracle JDBC Driver Extensions](../providers.md) first.
 <dependency>
   <groupId>com.oracle.database.jdbc</groupId>
   <artifactId>ojdbc-provider-gcp</artifactId>
-  <version>1.1.0</version>
+  <version>${ojdbc.provider.version}</version>
 </dependency>
 ```
 

--- a/db/appdev/java-oracle-jdbc/providers/hashicorp.md
+++ b/db/appdev/java-oracle-jdbc/providers/hashicorp.md
@@ -1,0 +1,118 @@
+# JDBC Providers for HashiCorp Vault
+
+## Overview
+
+Use this skill to configure Oracle JDBC to load connection strings,
+credentials, or TLS wallets from HashiCorp Vault, specifically **HCP Vault
+Dedicated**.
+
+For shared provider concepts (config vs resource providers, payload format,
+caching, auto-detect auth), see [Oracle JDBC Driver Extensions](../providers.md) first.
+
+## Installation
+
+```xml
+<dependency>
+  <groupId>com.oracle.database.jdbc</groupId>
+  <artifactId>ojdbc-provider-hashicorp</artifactId>
+  <version>1.1.0</version>
+</dependency>
+```
+
+Compiled for JDK 8, forward compatible with later JDKs.
+
+## Endpoint Security Policy
+
+This provider checks the Vault endpoint before sending any credential, so a
+misconfigured URL cannot leak a token to the wrong host:
+
+- `VAULT_ADDR` must be a valid URL with a host; HTTPS is required by default.
+- Sensitive credentials (`VAULT_TOKEN`, `VAULT_PASSWORD`, `SECRET_ID`,
+  `GITHUB_TOKEN`) are sent only when the target host is in
+  `TRUSTED_VAULT_HOSTS` (comma-separated `host` or `host:port` entries, set
+  as a system property or environment variable). Without it, sensitive-
+  credential requests are rejected outright.
+- `ALLOW_INSECURE_VAULT_ADDR=true` permits `http://` addresses — for
+  local/dev only.
+
+```bash
+# Production
+export VAULT_ADDR="https://vault.company.com:8200"
+export TRUSTED_VAULT_HOSTS="vault.company.com:8200"
+
+# Local/dev
+export ALLOW_INSECURE_VAULT_ADDR=true
+export VAULT_ADDR="http://127.0.0.1:8200"
+export TRUSTED_VAULT_HOSTS="127.0.0.1:8200"
+```
+
+## Centralized Config Provider
+
+| Provider | URL prefix | Identifies |
+|----------|-----------|------------|
+| HCP Vault Dedicated | `jdbc:oracle:thin:@config-hcpvaultdedicated://{secret-path}` | A JSON (or Pkl) payload stored at a Vault secret path |
+
+```java
+ds.setURL("jdbc:oracle:thin:@config-hcpvaultdedicated:///v1/namespace/secret/data/test_config");
+```
+
+`password` / `wallet_location` objects use `"type": "hcpvaultdedicated"` with
+`"value"` as the secret path and an optional `"field_name"` when the secret
+holds multiple key-value pairs. Add `?parser=pkl` (with `ojdbc-provider-pkl`
+on the classpath) for Pkl payloads — see [Pkl Parser](pkl.md).
+
+## Resource Providers
+
+| Provider | Name | Gives the driver |
+|----------|------|-------------------|
+| Dedicated Vault Username | `ojdbc-provider-hcpvault-dedicated-username` | Username from a secret path (`secretPath`, optional `fieldName`) |
+| Dedicated Vault Password | `ojdbc-provider-hcpvault-dedicated-password` | Password from a secret path |
+| Dedicated Vault TCPS Wallet | `ojdbc-provider-hcpvault-dedicated-tls` | TLS wallet (`SSO`/`PKCS12`/`PEM`) stored base64 in a secret |
+| Dedicated Vault SEPS Wallet | `ojdbc-provider-hcpvault-dedicated-seps` | Username+password from a SEPS wallet stored in a secret |
+| Dedicated Vault Connection String | `ojdbc-provider-hcpvault-dedicated-tnsnames` | Connect string resolved from a `tnsnames.ora` alias in a secret |
+
+All resource providers take `vaultAddr`, `secretPath`, and an optional
+`fieldName` when the secret JSON has more than one key; wallet providers
+additionally take `type` and, if protected, `walletPassword`.
+
+## Authentication
+
+Common parameters (each backed by a matching env var):
+`authenticationMethod`, `vaultAddr` (`VAULT_ADDR`), `vaultNamespace`
+(`VAULT_NAMESPACE`, default `admin`), `vaultToken` (`VAULT_TOKEN`),
+`vaultUsername`/`vaultPassword` (`VAULT_USERNAME`/`VAULT_PASSWORD`),
+`roleId`/`secretId` (`ROLE_ID`/`SECRET_ID`), `githubToken` (`GITHUB_TOKEN`),
+plus per-method auth-path overrides (`userPassAuthPath`, `appRoleAuthPath`,
+`githubAuthPath`).
+
+`authenticationMethod` values: `vault-token`, `userpass`, `approle` (needs
+`roleId` + `secretId`), `github`, and `auto-detect` (default — tries
+`vault-token`, `userpass`, `approle`, `github`, in that order). Tokens from
+`userpass`/`approle` are cached and reused until they expire;
+`TOKEN_CACHE_MAX_ENTRIES` (default `100`) bounds the cache size.
+
+```
+jdbc:oracle:thin:@config-hcpvaultdedicated:///v1/namespace/secret/data/secret_name?KEY=sales_app1&authentication=approle
+```
+
+## Best Practices
+
+- Always set `TRUSTED_VAULT_HOSTS` in any environment that uses token,
+  userpass, AppRole, or GitHub authentication — without it, those methods
+  are rejected by design.
+- Never set `ALLOW_INSECURE_VAULT_ADDR=true` outside local development.
+- Prefer AppRole for machine-to-machine authentication over static Vault
+  tokens, since AppRole credentials can be scoped and rotated independently.
+
+## Related Skills
+
+- [Oracle JDBC Driver Extensions](../providers.md)
+- [Pkl Parser](pkl.md)
+- [Network Security](../../../security/network-security.md)
+
+## Sources
+
+- [ojdbc-provider-hashicorp README](https://github.com/oracle/ojdbc-extensions/blob/main/ojdbc-provider-hashicorp/README.md)
+- [ojdbc-provider-samples (HashiCorp)](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/hashicorp)
+- [HashiCorp Vault Auth Methods](https://developer.hashicorp.com/vault/docs/auth)
+- [Oracle AI Database JDBC Developer's Guide 26ai](https://docs.oracle.com/en/database/oracle/oracle-database/26/jjdbc/index.html)

--- a/db/appdev/java-oracle-jdbc/providers/hashicorp.md
+++ b/db/appdev/java-oracle-jdbc/providers/hashicorp.md
@@ -15,7 +15,7 @@ caching, auto-detect auth), see [Oracle JDBC Driver Extensions](../providers.md)
 <dependency>
   <groupId>com.oracle.database.jdbc</groupId>
   <artifactId>ojdbc-provider-hashicorp</artifactId>
-  <version>1.1.0</version>
+  <version>${ojdbc.provider.version}</version>
 </dependency>
 ```
 

--- a/db/appdev/java-oracle-jdbc/providers/jackson-oson.md
+++ b/db/appdev/java-oracle-jdbc/providers/jackson-oson.md
@@ -1,0 +1,118 @@
+# JDBC Jackson OSON Provider
+
+## Overview
+
+Use this skill when a Java application reads or writes Oracle JSON (OSON)
+columns and you want direct POJO ↔ OSON mapping through Jackson, instead of
+hand-rolled `ObjectMapper`/`ObjectNode` marshaling around raw bytes.
+
+This provider implements
+[`oracle.jdbc.spi.OsonProvider`](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/spi/OsonProvider.html)
+(a `JsonProvider`) — a different SPI family from the Centralized
+Config/Resource Providers covered in [Oracle JDBC Driver Extensions](../providers.md).
+It plugs into the driver's native JSON handling rather than supplying
+connection resources.
+
+## Installation
+
+```xml
+<dependency>
+  <groupId>com.oracle.database.jdbc</groupId>
+  <artifactId>ojdbc-provider-jackson-oson</artifactId>
+  <version>1.1.0</version>
+</dependency>
+```
+
+Compiled for JDK 8, forward compatible with later JDKs. Requires JDBC Thin
+Driver **23.6 or newer**. This artifact pulls in `ojdbc8` transitively —
+exclude it if the application already depends on `ojdbc11`/`ojdbc17`, so two
+driver versions don't land on the classpath together:
+
+```xml
+<exclusions>
+  <exclusion>
+    <groupId>com.oracle.database.jdbc</groupId>
+    <artifactId>ojdbc8</artifactId>
+  </exclusion>
+</exclusions>
+```
+
+## Activation
+
+Set the JSON provider connection property before opening the connection:
+
+```java
+OracleDataSource ods = new OracleDataSource();
+ods.setURL(url);
+ods.setUser(user);
+ods.setPassword(password);
+ods.setConnectionProperty(OracleConnection.CONNECTION_PROPERTY_PROVIDER_JSON, "jackson-json-provider");
+Connection conn = ods.getConnection();
+```
+
+Unlike the cloud secret/config providers, this provider takes no further
+`.{param}` suffixes — one property turns it on for the connection. Once
+active, read/write JSON columns directly as POJOs:
+
+```java
+try (PreparedStatement pstmt = conn.prepareStatement(
+        "insert into jackson_oson_sample (id, json_value) values (?, ?)")) {
+    pstmt.setInt(1, 1);
+    pstmt.setObject(2, emp, OracleType.JSON);   // Emp is a plain POJO
+    pstmt.execute();
+}
+
+try (Statement stmt = conn.createStatement();
+     ResultSet rs = stmt.executeQuery("select id, json_value from jackson_oson_sample")) {
+    while (rs.next()) {
+        Emp emp = rs.getObject(2, Emp.class);   // deserialized straight to the POJO
+    }
+}
+```
+
+The same activation property works transparently under Hibernate/JPA —
+entities mapped to `JSON` columns get the same serialization path once the
+property is set on the underlying connection.
+
+## Java ↔ OSON Type Mapping
+
+| Java Type | OSON Type |
+|-----------|-----------|
+| `LocalDateTime` | `TIMESTAMP` |
+| `OffsetDateTime` | `TIMESTAMPTZ` |
+| `Period` | `INTERVALYM` |
+| `Duration` | `INTERVALDS` |
+| `BigInteger`, `Year` | `NUMBER` |
+| `byte[]` | `byte[]` |
+| `java.util.Date` | `TIMESTAMP` |
+| `java.sql.Date`, `LocalDate` | `DATE` |
+| `Timestamp` | `TIMESTAMP` |
+| `Boolean` | `BOOLEAN` |
+| `UUID` | `UUID` (as `byte[]`) |
+
+Standard Jackson annotations are supported on mapped POJOs; note that when
+`@JsonFormat` is used, values are processed as strings rather than their
+native OSON type.
+
+## Best Practices
+
+- Exclude the transitive `ojdbc8` dependency whenever the application
+  already pins `ojdbc11`/`ojdbc17` — see [JDBC Dependencies](../dependencies.md).
+- Prefer `setObject(..., OracleType.JSON)` / `getObject(..., Class)` over
+  manually building `ObjectNode`/byte arrays — that direct POJO mapping is
+  the reason to use this provider at all.
+- Confirm the target column is a native `JSON` (OSON) column, not
+  `VARCHAR2`/`CLOB` holding JSON text — this provider maps to OSON storage;
+  see [JSON in Oracle](../../json-in-oracle.md) for the database-side type.
+
+## Related Skills
+
+- [Oracle JDBC Driver Extensions](../providers.md)
+- [JSON in Oracle](../../json-in-oracle.md)
+- [JDBC SQL and PL/SQL](../sql.md)
+
+## Sources
+
+- [ojdbc-provider-jackson-oson README](https://github.com/oracle/ojdbc-extensions/blob/main/ojdbc-provider-jackson-oson/README.md)
+- [oracle.jdbc.spi.OsonProvider](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/spi/OsonProvider.html)
+- [ojdbc-provider-samples (OSON)](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/oson/sample)

--- a/db/appdev/java-oracle-jdbc/providers/jackson-oson.md
+++ b/db/appdev/java-oracle-jdbc/providers/jackson-oson.md
@@ -19,7 +19,7 @@ connection resources.
 <dependency>
   <groupId>com.oracle.database.jdbc</groupId>
   <artifactId>ojdbc-provider-jackson-oson</artifactId>
-  <version>1.1.0</version>
+  <version>${ojdbc.provider.version}</version>
 </dependency>
 ```
 

--- a/db/appdev/java-oracle-jdbc/providers/observability.md
+++ b/db/appdev/java-oracle-jdbc/providers/observability.md
@@ -1,0 +1,114 @@
+# JDBC Observability Provider
+
+## Overview
+
+Use this skill to trace Oracle JDBC activity — round trips, Application
+Continuity (AC) replay, VIP failover — into OpenTelemetry (OTEL) or Java
+Flight Recorder (JFR), without changing application code.
+
+The provider implements the driver's `TraceEventListener` SPI and is
+notified of driver-internal events, which it publishes to the enabled
+tracer(s).
+
+## Installation
+
+```xml
+<dependency>
+  <groupId>com.oracle.database.jdbc</groupId>
+  <artifactId>ojdbc-provider-observability</artifactId>
+  <version>1.1.0</version>
+</dependency>
+```
+
+Compiled for JDK 11, forward compatible with later JDKs.
+
+## Usage
+
+```properties
+oracle.jdbc.provider.traceEventListener=observability-trace-event-listener-provider
+oracle.jdbc.provider.traceEventListener.unique_identifier=<name>
+```
+
+Connections that share a `unique_identifier` share one listener instance and
+configuration; omit it to use the identifier `default`.
+
+## Configuring Which Tracers Run
+
+```java
+System.setProperty("oracle.jdbc.provider.observability.enabledTracers", "OTEL,JFR");
+System.setProperty("oracle.jdbc.provider.observability.sensitiveDataEnabled", "true");
+```
+
+Or via MBean at runtime:
+
+```java
+ObservabilityTraceEventListener listener = ObservabilityTraceEventListener.getTraceEventListener("<name>");
+ObjectName objectName = new ObjectName(listener.getMBeanObjectName());
+MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+server.setAttribute(objectName, new Attribute("EnabledTracers", "OTEL,JFR"));
+server.setAttribute(objectName, new Attribute("SensitiveDataEnabled", "true"));
+```
+
+`sensitiveDataEnabled` (default `false`) gates attributes like SQL text,
+database username, and full connection descriptors — leave it off in
+production unless your trace backend is access-controlled to the same
+standard as the database itself.
+
+## OpenTelemetry Semantic Conventions
+
+The OTEL tracer supports both the legacy (default) and the stable OTel
+Database Semantic Conventions, controlled by the
+`OTEL_SEMCONV_STABILITY_OPT_IN` environment variable:
+
+| Value | Behavior |
+|-------|----------|
+| unset (default) | Legacy/experimental attributes only |
+| `database` | Stable attributes only (`db.system.name`, `db.operation.name`, `oracle.db.*`, `server.address`, etc.) |
+| `database/dup` | Both, for gradual migration |
+
+```bash
+export OTEL_SEMCONV_STABILITY_OPT_IN=database
+```
+
+Stable roundtrip attributes include `db.system.name` (`"oracle.db"`),
+`oracle.db.service`, `db.operation.name`, `db.query.summary`,
+`server.address`/`server.port`, `oracle.db.instance.name`, `oracle.db.pdb`,
+`oracle.db.query.sql.id`, `oracle.db.session.id`; opt-in (sensitive)
+attributes include `db.user`, `db.query.text`, `db.response.returned_rows`;
+error attributes include `error.type` and `db.response.status_code`
+(`ORA-XXXXX`). AC replay and VIP retry events have analogous stable/legacy
+attribute sets — see the provider's README for the full list.
+
+## Backward Compatibility
+
+The older, OTEL-only provider name still works:
+
+```properties
+oracle.jdbc.provider.traceEventListener=open-telemetry-trace-event-listener-provider
+```
+
+This enables only OTEL (not JFR), and is configured via
+`oracle.jdbc.provider.opentelemetry.enabled` /
+`oracle.jdbc.provider.opentelemetry.sensitive-enabled` system properties or
+the equivalent `Enabled`/`SensitiveDataEnabled` MBean attributes.
+
+## Best Practices
+
+- Start with `enabledTracers=OTEL` in most stacks; add `JFR` only when you
+  need JVM-native profiling correlation.
+- Migrate to `OTEL_SEMCONV_STABILITY_OPT_IN=database/dup` before cutting
+  over dashboards/alerts built on the legacy attribute names, then drop to
+  `database` once consumers are updated.
+- Keep `sensitiveDataEnabled=false` unless the trace pipeline is as trusted
+  as the database connection itself.
+
+## Related Skills
+
+- [Oracle JDBC Driver Extensions](../providers.md)
+- [Java Oracle JDBC Overview](../../java-oracle-jdbc.md)
+- [AWR Reports](../../../performance/awr-reports.md)
+
+## Sources
+
+- [ojdbc-provider-observability README](https://github.com/oracle/ojdbc-extensions/blob/main/ojdbc-provider-observability/README.md)
+- [OpenTelemetry Database Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/database/database-spans/)

--- a/db/appdev/java-oracle-jdbc/providers/observability.md
+++ b/db/appdev/java-oracle-jdbc/providers/observability.md
@@ -16,7 +16,7 @@ tracer(s).
 <dependency>
   <groupId>com.oracle.database.jdbc</groupId>
   <artifactId>ojdbc-provider-observability</artifactId>
-  <version>1.1.0</version>
+  <version>${ojdbc.provider.version}</version>
 </dependency>
 ```
 

--- a/db/appdev/java-oracle-jdbc/providers/oci.md
+++ b/db/appdev/java-oracle-jdbc/providers/oci.md
@@ -1,0 +1,117 @@
+# JDBC Providers for OCI
+
+## Overview
+
+Use this skill to configure Oracle JDBC to load connection strings,
+credentials, TLS wallets, or access tokens from Oracle Cloud Infrastructure
+(OCI) services: Database Tools Connections, Object Storage, and Vault.
+
+For the shared provider concepts (config vs resource providers, payload
+format, caching, auto-detect auth), see [Oracle JDBC Driver Extensions](../providers.md)
+first.
+
+## Installation
+
+```xml
+<dependency>
+  <groupId>com.oracle.database.jdbc</groupId>
+  <artifactId>ojdbc-provider-oci</artifactId>
+  <version>1.1.0</version>
+</dependency>
+```
+
+Compiled for JDK 8, forward compatible with later JDKs.
+
+## Centralized Config Providers
+
+| Provider | URL prefix | Identifies |
+|----------|-----------|------------|
+| Database Tools Connections | `jdbc:oracle:thin:@config-ocidbtools://{ocid}` | An OCI Database Tools Connection resource (stores user, password, wallet) |
+| Object Storage | `jdbc:oracle:thin:@config-ociobject://{url-path}` | A JSON (or Pkl) payload object in Object Storage |
+| Vault | `jdbc:oracle:thin:@config-ocivault://{secret-ocid}` | A JSON (or Pkl) payload stored as the content of a Vault secret |
+
+```java
+OracleDataSource ds = new OracleDataSource();
+ds.setURL("jdbc:oracle:thin:@config-ociobject://mytenancy.objectstorage.us-phoenix-1.oci.customer-oci.com/n/mytenancy/b/bucket1/o/payload.json");
+try (Connection cn = ds.getConnection()) { ... }
+```
+
+Object Storage accepts standard, PAR-token, and `customer-oci.com` URL forms;
+see the [OCI Object Storage URI guide](https://docs.oracle.com/en/cloud/paas/autonomous-database/csgru/get-uri-access-object-store.html)
+for how to obtain one. Database Tools Connections also support Proxy
+Authentication when only a username (no password/roles) is set on the proxy
+info.
+
+To parse a Pkl payload instead of JSON, add `?parser=pkl` and put
+`ojdbc-provider-pkl` on the classpath (Object Storage and Vault providers
+only — see [Pkl Parser](pkl.md)).
+
+## Resource Providers
+
+| Provider | Name | Gives the driver |
+|----------|------|-------------------|
+| Database Connection String | `ojdbc-provider-oci-database-connection-string` | Connect string for an Autonomous Database, by `ocid` |
+| Database TLS | `ojdbc-provider-oci-database-tls` | mTLS keys/certs for an Autonomous Database, by `ocid` |
+| Vault Password | `ojdbc-provider-oci-vault-password` | Password from a Vault secret, by `ocid` |
+| Vault Username | `ojdbc-provider-oci-vault-username` | Username from a Vault secret, by `ocid` |
+| TCPS Wallet | `ojdbc-provider-oci-vault-tls` | TLS wallet (`SSO`/`PKCS12`/`PEM`) stored base64 in a Vault secret |
+| SEPS Wallet | `ojdbc-provider-oci-vault-seps` | Username+password from a SEPS wallet stored in a Vault secret |
+| Vault Connection String | `ojdbc-provider-oci-vault-tnsnames` | Connect string resolved from a `tnsnames.ora` alias stored in a Vault secret |
+| Access Token | `ojdbc-provider-oci-token` | OAuth access token authorizing IAM-mapped logins to an Autonomous Database |
+
+```properties
+oracle.jdbc.provider.accessToken=ojdbc-provider-oci-token
+oracle.jdbc.provider.accessToken.scope=urn:oracle:db::id::ocid1.compartment.oc1..aaaaaaaajx2fpr7szach4vpdsjegvkbjirronlnwkxiivwmp6qfrissxgyia
+```
+
+`scope` accepts a database OCID, a compartment OCID, or `*` (least to most
+privileged — see the provider's README for the URN forms). `Database Connection
+String` also accepts `consumerGroup` (`HIGH`/`MEDIUM`/`LOW`/`TP`/`TPURGENT`,
+default `MEDIUM`). `TCPS Wallet` / `SEPS Wallet` require `type`
+(`SSO`/`PKCS12`/`PEM`) and, for password-protected wallets, `walletPassword`.
+
+## Authentication
+
+Common parameters on every provider above:
+`authenticationMethod`, `configFile` (default `~/.oci/config`), `profile`
+(default `DEFAULT`), `region`, `username` (a caller-chosen cache-partition
+label, not a credential), `instancePrincipalTimeout` (default `5`s),
+`interactiveTimeout` (default `5`min).
+
+`authenticationMethod` values: `config-file`, `instance-principal`,
+`resource-principal`, `cloud-shell`, `interactive` (opens a browser, local
+callback server on port `8181`), and `auto-detect` (default — tries
+`config-file`, `cloud-shell`, `resource-principal`, `instance-principal`, in
+that order).
+
+```properties
+oracle.jdbc.provider.database=ojdbc-provider-oci-database-connection-string
+oracle.jdbc.provider.database.authenticationMethod=config-file
+oracle.jdbc.provider.database.configFile=/home/app/resources/oci-config
+oracle.jdbc.provider.database.profile=APP_PROFILE
+```
+
+## Best Practices
+
+- Use `instance-principal` or `resource-principal` for workloads running on
+  OCI compute/Functions instead of shipping a config file.
+- Set `region` explicitly for `interactive` auth against government realms
+  (e.g. `us-langley-1`), since the default login endpoint is
+  `login.oci.oraclecloud.com`.
+- Scope the Access Token Provider to a single database OCID, not `*`.
+- Set a distinct `username` label per end user when one process fetches the
+  same secret/token on behalf of multiple end users with `interactive` auth,
+  so their cached logins do not collide.
+
+## Related Skills
+
+- [Oracle JDBC Driver Extensions](../providers.md)
+- [Pkl Parser](pkl.md)
+- [Network Security](../../../security/network-security.md)
+
+## Sources
+
+- [ojdbc-provider-oci README](https://github.com/oracle/ojdbc-extensions/blob/main/ojdbc-provider-oci/README.md)
+- [ojdbc-provider-samples (OCI)](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/oci)
+- [OCI SDK Authentication Methods](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdk_authentication_methods.htm)
+- [Oracle AI Database JDBC Developer's Guide 26ai](https://docs.oracle.com/en/database/oracle/oracle-database/26/jjdbc/index.html)

--- a/db/appdev/java-oracle-jdbc/providers/oci.md
+++ b/db/appdev/java-oracle-jdbc/providers/oci.md
@@ -16,7 +16,7 @@ first.
 <dependency>
   <groupId>com.oracle.database.jdbc</groupId>
   <artifactId>ojdbc-provider-oci</artifactId>
-  <version>1.1.0</version>
+  <version>${ojdbc.provider.version}</version>
 </dependency>
 ```
 

--- a/db/appdev/java-oracle-jdbc/providers/pkl.md
+++ b/db/appdev/java-oracle-jdbc/providers/pkl.md
@@ -1,0 +1,116 @@
+# JDBC Pkl Parser
+
+## Overview
+
+Use this skill when a Centralized Config Provider's payload should be
+written in [Pkl](https://pkl-lang.org/index.html) (a typed configuration
+language with schema-checked templates) instead of raw JSON.
+
+This is a **parser**, not a config source on its own — it implements
+`OracleConfigurationParser` and plugs into any provider that extends
+`OracleConfigurationParsableProvider`: `file`, `https` (built into the
+driver), and the OCI Object Storage/Vault, Azure Vault, GCP Storage/Secret
+Manager, AWS S3/Secrets Manager/Parameter Store/AppConfig providers — see
+[Oracle JDBC Driver Extensions](../providers.md) for the full list.
+
+## Installation
+
+```xml
+<dependency>
+  <groupId>com.oracle.database.jdbc</groupId>
+  <artifactId>ojdbc-provider-pkl</artifactId>
+  <version>1.1.0</version>
+</dependency>
+```
+
+Compiled for JDK 17 (required by Pkl itself), forward compatible with later
+JDKs.
+
+## Usage
+
+Add `parser=pkl` to any supporting provider's URL; the default parser is
+`json` when this option is omitted.
+
+```
+jdbc:oracle:thin:@config-file://{pkl-file-name}?parser=pkl[&key=prefix&label=value]
+```
+
+## Writing a `.pkl` Configuration
+
+Two authoring styles are supported, both against the shared
+[`JdbcConfig.pkl`](https://github.com/oracle/ojdbc-extensions/blob/main/ojdbc-provider-pkl/template/JdbcConfig.pkl)
+template, which defines the same `connect_descriptor` / `user` / `password`
+/ `wallet_location` / `jdbc` shape used by the JSON payloads.
+
+**`amends`** — one config per file, the whole file *is* the config:
+
+```pkl
+amends "https://raw.githubusercontent.com/oracle/ojdbc-extensions/refs/heads/main/ojdbc-provider-pkl/template/JdbcConfig.pkl"
+
+connect_descriptor = "dbhost:1521/orclpdb1"
+user = "scott"
+
+password {
+  type = "ocivault"
+  value = "ocid1.vaultsecret..."
+  authentication { ["method"] = "OCI_DEFAULT" }
+}
+
+jdbc {
+  autoCommit = false
+  `oracle.jdbc.loginTimeout` = 60.s
+}
+```
+
+```
+jdbc:oracle:thin:@config-file://myJdbcConfig.pkl?parser=pkl
+```
+
+**`import`** — multiple named configs in one file, selected with `key`:
+
+```pkl
+import "https://raw.githubusercontent.com/oracle/ojdbc-extensions/refs/heads/main/ojdbc-provider-pkl/template/JdbcConfig.pkl"
+
+config1 = (JdbcConfig) {
+  connect_descriptor = "dbhost:1521/orclpdb1"
+  user = "scott"
+  password {
+    type = "ocivault"
+    value = "ocid1.vaultsecret..."
+    authentication { ["method"] = "OCI_DEFAULT" }
+  }
+  jdbc { autoCommit = false }
+}
+```
+
+```
+jdbc:oracle:thin:@config-file://myJdbcConfig.pkl?parser=pkl&key=config1
+```
+
+## Best Practices
+
+- Prefer `amends` for one-config-per-file setups (simplest, matches the
+  JSON single-payload model); use `import` with `key` only when several
+  environments/configs genuinely belong in one file.
+- Amend/import the template by a pinned commit or tag, not a moving branch
+  ref, so a template change upstream cannot silently alter parsing of an
+  already-deployed config.
+- Pkl's typed properties (e.g. `60.s` as a duration) catch malformed values
+  at parse time — prefer them over string-typed JDBC properties where Pkl's
+  schema supports it.
+
+## Related Skills
+
+- [Oracle JDBC Driver Extensions](../providers.md)
+- [OCI Providers](oci.md)
+- [Azure Providers](azure.md)
+- [AWS Providers](aws.md)
+- [GCP Providers](gcp.md)
+- [HashiCorp Providers](hashicorp.md)
+
+## Sources
+
+- [ojdbc-provider-pkl README](https://github.com/oracle/ojdbc-extensions/blob/main/ojdbc-provider-pkl/README.md)
+- [ojdbc-provider-samples (Pkl)](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-samples/src/main/java/oracle/jdbc/provider/pkl/configuration)
+- [Pkl language](https://pkl-lang.org/index.html)
+- [JdbcConfig.pkl template](https://github.com/oracle/ojdbc-extensions/blob/main/ojdbc-provider-pkl/template/JdbcConfig.pkl)

--- a/db/appdev/java-oracle-jdbc/providers/pkl.md
+++ b/db/appdev/java-oracle-jdbc/providers/pkl.md
@@ -19,7 +19,7 @@ Manager, AWS S3/Secrets Manager/Parameter Store/AppConfig providers — see
 <dependency>
   <groupId>com.oracle.database.jdbc</groupId>
   <artifactId>ojdbc-provider-pkl</artifactId>
-  <version>1.1.0</version>
+  <version>${ojdbc.provider.version}</version>
 </dependency>
 ```
 

--- a/db/appdev/java-oracle-jdbc/providers/spring.md
+++ b/db/appdev/java-oracle-jdbc/providers/spring.md
@@ -1,0 +1,111 @@
+# JDBC Providers for Spring
+
+## Overview
+
+Use this skill to give Oracle JDBC an end-user security context inside a
+Spring application, so Oracle Database's Deep Data Security features
+(`DATA GRANT`, `DATA ROLE`, `APPLICATION IDENTITY`) can authorize database
+operations per end user, not just per database account.
+
+This is the one provider in this skill that is a framework integration
+rather than a cloud secret/config source.
+
+## Installation
+
+```xml
+<dependency>
+  <groupId>com.oracle.database.jdbc</groupId>
+  <artifactId>ojdbc-provider-spring</artifactId>
+  <version>1.1.0</version>
+</dependency>
+```
+
+Compiled for JDK 17, forward compatible with later JDKs.
+
+## End User Security Context Provider
+
+Identified by `ojdbc-provider-spring-end-user-security-context`, a
+[Resource Provider](https://docs.oracle.com/en/database/oracle/oracle-database/26/jajdb/oracle/jdbc/spi/OracleResourceProvider.html)
+for `oracle.jdbc.EndUserSecurityContext`. Almost every JDBC network
+operation (SQL execution, fetch, commit/rollback, LOB access) becomes
+subject to `DATA GRANT` policy once this context is attached.
+
+```yaml
+spring:
+  security:
+    oauth2:
+      client:
+        provider:
+          azure:
+            token-uri: "https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token"
+        registration:
+          azure:
+            authorization-grant-type: client_credentials
+            client-id: "<client-id>"
+            client-secret: "<client-secret>"
+            scope: "https://<app>.onmicrosoft.com/<client-id>/.default"
+  datasource:
+    url: >
+      jdbc:oracle:thin:@example
+        ?oracle.jdbc.provider.endUserSecurityContext=ojdbc-provider-spring-end-user-security-context
+        &oracle.jdbc.provider.endUserSecurityContext.registrationId=azure
+    username: db_user
+    password: db_password
+```
+
+The provider assembles two tokens per operation:
+
+- **Database Access Token** — authorizes the Spring app itself, requested
+  from the OAuth 2.0 client registration named by `registrationId`.
+- **End User Token** — identifies the human end user, read from Spring
+  Security's `SecurityContextHolder` (typically the bearer token off the
+  inbound HTTP request's `Authorization` header).
+
+## Mapping Spring Authorities to Database Data Roles/Attributes
+
+The provider can derive `DATA ROLE` names and `END USER CONTEXT` attributes
+directly from the authenticated user's `GrantedAuthority` values:
+
+| Parameter | Effect |
+|-----------|--------|
+| `oracle.jdbc.provider.endUserSecurityContext.registrationId` | **Required.** OAuth2 client registration used for the Database Access Token. |
+| `oracle.jdbc.provider.endUserSecurityContext.dataRoles` | Fixed, comma-separated `DATA ROLE` names applied to every end user. |
+| `oracle.jdbc.provider.endUserSecurityContext.endUserContextAttributes` | Fixed JSON object of `END USER CONTEXT` attributes applied to every end user. |
+| `oracle.jdbc.provider.endUserSecurityContext.authorityRolePrefix` | Prefix identifying which `GrantedAuthority` strings are `DATA ROLE` names (e.g. prefix `ORACLE_DATA_ROLE_` + authority `ORACLE_DATA_ROLE_ADMIN` → role `ADMIN`). |
+| `oracle.jdbc.provider.endUserSecurityContext.authorityAttributesPrefix` | Prefix identifying which `GrantedAuthority` strings carry a JSON object of `END USER CONTEXT` attributes. |
+
+`END USER CONTEXT` attributes are namespaced by schema, e.g.:
+
+```json
+{
+  "app_schema.user_details": { "first_name": "George", "last_name": "Washington" },
+  "app_schema.location_info": { "City": "Mount Vernon", "State": "Virginia" }
+}
+```
+
+## Best Practices
+
+- Choose prefixes for `authorityRolePrefix`/`authorityAttributesPrefix` that
+  cannot collide with any other authority string your application issues
+  (e.g. Spring's own `ROLE_*` convention) — a collision silently grants or
+  attaches the wrong context.
+- Keep `dataRoles`/`endUserContextAttributes` (the fixed, all-users config)
+  minimal; prefer deriving per-user roles/attributes from authorities so
+  access reflects the authenticated identity, not a static default.
+- Design `DATA GRANT` policies assuming every JDBC operation is now
+  authorization-checked — test read, write, and LOB paths, not just simple
+  SELECTs.
+
+## Related Skills
+
+- [Oracle JDBC Driver Extensions](../providers.md)
+- [Spring Data JPA with Oracle](../../../frameworks/spring-data-jpa-oracle.md)
+- [Row-Level Security](../../../security/row-level-security.md)
+- [Privilege Management](../../../security/privilege-management.md)
+
+## Sources
+
+- [ojdbc-provider-spring README](https://github.com/oracle/ojdbc-extensions/blob/main/ojdbc-provider-spring/README.md)
+- [ojdbc-provider-samples (Spring/Deep Data Security)](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-spring/samples)
+- [Oracle Deep Data Security Guide 26ai](https://docs.oracle.com/en/database/oracle/oracle-database/26/ddscg/understand-oracle-deep-data-security.html)
+- [Spring Security OAuth2 Client Registration](https://docs.spring.io/spring-security/reference/servlet/oauth2/client/core.html#oauth2Client-client-registration)

--- a/db/appdev/java-oracle-jdbc/providers/spring.md
+++ b/db/appdev/java-oracle-jdbc/providers/spring.md
@@ -16,7 +16,7 @@ rather than a cloud secret/config source.
 <dependency>
   <groupId>com.oracle.database.jdbc</groupId>
   <artifactId>ojdbc-provider-spring</artifactId>
-  <version>1.1.0</version>
+  <version>${ojdbc.provider.version}</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Summary

Adding skills for the [oracle/ojdbc-extensions ](https://github.com/oracle/ojdbc-extensions)project, which ships a set of providers that plug secrets, config, and observability straight into the Oracle JDBC driver.

## Changes

 - Adds `providers.md `as a router for the Centralized Config Provider / Resource Provider / JSON Provider SPI concepts and the provider map.
 - Adds focused provider skill files:
    - `oci.md`
    - `azure.md`
    - `gcp.md`
    - `aws.md`
    - `hashicorp.md`
    - `observability.md`
    - `spring.md`
    - `pkl.md`
    - `jackson-oson.md`

-  Adds provider-name tables, config/resource URL and property references, authentication method breakdowns, and pointers to runnable samples in [ojdbc-provider-samples ](https://github.com/oracle/ojdbc-extensions/tree/main/ojdbc-provider-samples)for each provider.
- Updates `db/appdev/java-oracle-jdbc.md`'s skill map to link to the new provider router.
-  Updates `db/SKILL.md`'s category routing and adds a provider-loading step to the Java JDBC service flow.