### PR TITLE
Skill to write terraform configuration for oci landing zone terraform security zone module 

### DIFF
--- a/oci/SKILL.md
+++ b/oci/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: oci
-description: Oracle Cloud Infrastructure guidance for designing, operating, and troubleshooting OCI services, including OCI Kubernetes Engine (OKE), OCI Internet of Things Platform, OCI Functions deployment and troubleshooting, and Enterprise AI workflows for OCI Generative AI models, Responses API agents, RAG, cost estimation, governance, private endpoints, hosted agentic applications, and Oracle platform integrations. Use when the user asks about OKE cluster design, Terraform or Resource Manager planning, OKE incident troubleshooting, Generic VNIC Attachment, Multus, pod networking, node pools, add-ons, ingress, load balancers, OCIR image pulls, Workload Identity, Kubernetes workloads on OCI, OCI IoT domains or digital twins, device publish flows, OCI Functions setup, deployment, invocation, or troubleshooting, OCI Generative AI, Enterprise AI Models, Enterprise AI Agents, governed GenAI applications, agentic workflows, RAG on Oracle Cloud, or OCI Generative AI pricing.
+description: Oracle Cloud Infrastructure guidance for designing, operating, and troubleshooting OCI services, including OCI Kubernetes Engine (OKE), OCI Internet of Things Platform, OCI Functions deployment and troubleshooting, OCI Security Zones Terraform configuration, and Enterprise AI workflows for OCI Generative AI models, Responses API agents, RAG, cost estimation, governance, private endpoints, hosted agentic applications, and Oracle platform integrations. Use when the user asks about OKE cluster design, Terraform or Resource Manager planning, OCI Security Zone recipes or Security Zones, OKE incident troubleshooting, Generic VNIC Attachment, Multus, pod networking, node pools, add-ons, ingress, load balancers, OCIR image pulls, Workload Identity, Kubernetes workloads on OCI, OCI IoT domains or digital twins, device publish flows, OCI Functions setup, deployment, invocation, or troubleshooting, OCI Generative AI, Enterprise AI Models, Enterprise AI Agents, governed GenAI applications, agentic workflows, RAG on Oracle Cloud, or OCI Generative AI pricing.
 ---
 
 # Oracle Cloud Infrastructure Skills
 
-Use this domain for practical Oracle Cloud Infrastructure guidance. Current content covers OCI Kubernetes Engine (OKE): cluster design, operational troubleshooting, Generic VNIC Attachment (GVA), and Multus multi-interface pod validation. It covers OCI Internet of Things Platform resource discovery, digital twin lifecycle workflows, device publish flows, and optional MCP-assisted operation. It covers OCI Functions local deployment and diagnosis-first troubleshooting. It also covers Enterprise AI because that work is built around OCI Generative AI, OCI networking, IAM, cost estimation, hosted applications, and OCI platform integrations.
+Use this domain for practical Oracle Cloud Infrastructure guidance. Current content covers OCI Kubernetes Engine (OKE): cluster design, operational troubleshooting, Generic VNIC Attachment (GVA), and Multus multi-interface pod validation. It covers OCI Internet of Things Platform resource discovery, digital twin lifecycle workflows, device publish flows, and optional MCP-assisted operation. It covers OCI Functions local deployment and diagnosis-first troubleshooting. It includes a constrained Terraform Configuration generator for OCI Security Zone recipes and Security Zones. It also covers Enterprise AI because that work is built around OCI Generative AI, OCI networking, IAM, cost estimation, hosted applications, and OCI platform integrations.
 
 ## How to Use This Domain
 
@@ -46,6 +46,11 @@ oci/
 │   ├── scripts/
 │   ├── templates/
 │   └── tests/
+├── oci-landing-zone-terraform-module/
+│   └── terraform-oci-module-security-zone-skill/
+│       ├── SKILL.md
+│       ├── agents/
+│       └── references/
 └── oke/
     ├── cluster-design.md
     ├── troubleshooting.md
@@ -61,19 +66,20 @@ oci/
 
 ## Category Routing
 
-| Topic | Start With |
-|-------|------------|
-| Design or scaffold an OKE cluster, Terraform stack, or OCI Resource Manager stack | Start with `oci/oke/cluster-design.md`, then load `oci/oke/skills/oke-cluster-generator/SKILL.md` |
-| Troubleshoot OKE workloads, pods, services, DNS, add-ons, ingress, load balancers, image pulls, storage, Workload Identity, or cluster access | Start with `oci/oke/troubleshooting.md`, then load `oci/oke/skills/oke-troubleshooter/SKILL.md` |
-| Configure OKE managed node pools with Generic VNIC Attachment secondary VNIC profiles and Application Resources | Start with `oci/oke/gva-node-pools.md`, then load `oci/oke/skills/oke-gva-deployer/SKILL.md` |
-| Deploy or validate Multus NetworkAttachmentDefinitions and multi-interface pods on OKE | Start with `oci/oke/multus-multihome.md`, then load `oci/oke/skills/oke-multihome-deployer/SKILL.md` |
-| Deploy an OCI Function from a local macOS or Linux workstation | `oci/functions/oci-functions-deploy/SKILL.md` |
-| Troubleshoot OCI Functions setup, deployment, invocation, or observability | `oci/functions/oci-functions-troubleshoot/SKILL.md` |
+| Topic                                                                                                                                          | Start With |
+|------------------------------------------------------------------------------------------------------------------------------------------------|------------|
+| Design or scaffold an OKE cluster, Terraform stack, or OCI Resource Manager stack                                                              | Start with `oci/oke/cluster-design.md`, then load `oci/oke/skills/oke-cluster-generator/SKILL.md` |
+| Troubleshoot OKE workloads, pods, services, DNS, add-ons, ingress, load balancers, image pulls, storage, Workload Identity, or cluster access  | Start with `oci/oke/troubleshooting.md`, then load `oci/oke/skills/oke-troubleshooter/SKILL.md` |
+| Configure OKE managed node pools with Generic VNIC Attachment secondary VNIC profiles and Application Resources                                | Start with `oci/oke/gva-node-pools.md`, then load `oci/oke/skills/oke-gva-deployer/SKILL.md` |
+| Deploy or validate Multus NetworkAttachmentDefinitions and multi-interface pods on OKE                                                         | Start with `oci/oke/multus-multihome.md`, then load `oci/oke/skills/oke-multihome-deployer/SKILL.md` |
+| Deploy an OCI Function from a local macOS or Linux workstation                                                                                 | `oci/functions/oci-functions-deploy/SKILL.md` |
+| Troubleshoot OCI Functions setup, deployment, invocation, or observability                                                                     | `oci/functions/oci-functions-troubleshoot/SKILL.md` |
+| Generate or update Terraform Configuration for OCI Security Zone recipes or Security Zones                                                     | `oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/SKILL.md` |
 | OCI IoT domains, domain groups, digital twin models, adapters, instances, relationships, raw commands, Data API access, or HTTPS publish flows | `oci/iot-platform/SKILL.md` |
-| OCI Generative AI models, custom/imported models, endpoints, or private endpoints | `oci/enterprise-ai/SKILL.md` |
-| OCI Responses API agents, tools, memory, File Search, Code Interpreter, MCP, or SQL Search | `oci/enterprise-ai/SKILL.md` |
-| OCI Generative AI and OCI Generative AI Agents cost estimation | `oci/enterprise-ai/cost/cost-estimation.md` |
-| OCI Enterprise AI governance, IAM, API keys, OAuth, guardrails, or ZPR | `oci/enterprise-ai/governance/private-endpoints-and-governance.md` |
+| OCI Generative AI models, custom/imported models, endpoints, or private endpoints                                                              | `oci/enterprise-ai/SKILL.md` |
+| OCI Responses API agents, tools, memory, File Search, Code Interpreter, MCP, or SQL Search                                                     | `oci/enterprise-ai/SKILL.md` |
+| OCI Generative AI and OCI Generative AI Agents cost estimation                                                                                 | `oci/enterprise-ai/cost/cost-estimation.md` |
+| OCI Enterprise AI governance, IAM, API keys, OAuth, guardrails, or ZPR                                                                         | `oci/enterprise-ai/governance/private-endpoints-and-governance.md` |
 
 ## Key Starting Points
 
@@ -85,6 +91,7 @@ oci/
 - `oci/functions/oci-functions-troubleshoot/SKILL.md`
 - `oci/functions/oci-functions-deploy/references/oci-functions-quickstart.md`
 - `oci/functions/oci-functions-troubleshoot/references/error-patterns.md`
+- `oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/SKILL.md`
 - `oci/iot-platform/SKILL.md`
 - `oci/iot-platform/references/cli-workflows.md`
 - `oci/iot-platform/references/mcp-optional-use.md`
@@ -106,23 +113,25 @@ The OKE operational skills include deterministic helper tools under `oci/oke/scr
 
 ## Common Multi-Step Flows
 
-| Task | Recommended Sequence |
-|------|----------------------|
-| Plan a production OKE cluster | `oke/cluster-design.md` |
-| Diagnose an OKE service with no load balancer IP | `oke/troubleshooting.md` |
+| Task                                                             | Recommended Sequence |
+|------------------------------------------------------------------|----------------------|
+| Plan a production OKE cluster                                    | `oke/cluster-design.md` |
+| Diagnose an OKE service with no load balancer IP                 | `oke/troubleshooting.md` |
 | Build a node pool with workload-specific secondary VNIC profiles | `oke/gva-node-pools.md` -> `oke/multus-multihome.md` if pods need multiple interfaces |
-| Validate Multus pod networking on GVA-enabled nodes | `oke/multus-multihome.md` -> `oke/troubleshooting.md` if symptoms remain |
-| Investigate OKE workload access to OCI APIs | `oke/troubleshooting.md` |
-| Deploy a local function | `functions/oci-functions-deploy/SKILL.md` -> preflight -> Fn context validation -> OCIR auth check -> app selection -> scaffold -> deploy |
-| Troubleshoot a failed function deploy | `functions/oci-functions-troubleshoot/SKILL.md` -> `functions/oci-functions-troubleshoot/references/error-patterns.md` -> `functions/oci-functions-troubleshoot/references/deploy.md` |
-| Troubleshoot function invocation failures | `functions/oci-functions-troubleshoot/SKILL.md` -> `functions/oci-functions-troubleshoot/references/invoke.md` -> logs, traces, metrics, and limits |
-| Explore or update OCI IoT digital twin resources | `iot-platform/SKILL.md` -> `iot-platform/references/cli-workflows.md` -> `iot-platform/references/resilience-guidance.md` |
-| Publish test telemetry to an OCI IoT twin | `iot-platform/SKILL.md` -> `iot-platform/references/cli-workflows.md` -> `iot-platform/templates/publish-curl.template.sh` |
-| Build a governed enterprise assistant | `enterprise-ai/SKILL.md` -> `enterprise-ai/agent-workflows/agent-tools.md` -> `enterprise-ai/data/rag-and-search.md` -> `enterprise-ai/governance/private-endpoints-and-governance.md` |
+| Validate Multus pod networking on GVA-enabled nodes              | `oke/multus-multihome.md` -> `oke/troubleshooting.md` if symptoms remain |
+| Investigate OKE workload access to OCI APIs                      | `oke/troubleshooting.md` |
+| Deploy a local function                                          | `functions/oci-functions-deploy/SKILL.md` -> preflight -> Fn context validation -> OCIR auth check -> app selection -> scaffold -> deploy |
+| Troubleshoot a failed function deploy                            | `functions/oci-functions-troubleshoot/SKILL.md` -> `functions/oci-functions-troubleshoot/references/error-patterns.md` -> `functions/oci-functions-troubleshoot/references/deploy.md` |
+| Troubleshoot function invocation failures                        | `functions/oci-functions-troubleshoot/SKILL.md` -> `functions/oci-functions-troubleshoot/references/invoke.md` -> logs, traces, metrics, and limits |
+| Generate OCI Security Zone Terraform Configuration               | `oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/SKILL.md` -> validate inputs and authorization read-only -> generate `main.tf`, `variables.tf`, and `terraform.tfvars` without running Terraform |
+| Explore or update OCI IoT digital twin resources                 | `iot-platform/SKILL.md` -> `iot-platform/references/cli-workflows.md` -> `iot-platform/references/resilience-guidance.md` |
+| Publish test telemetry to an OCI IoT twin                        | `iot-platform/SKILL.md` -> `iot-platform/references/cli-workflows.md` -> `iot-platform/templates/publish-curl.template.sh` |
+| Build a governed enterprise assistant                            | `enterprise-ai/SKILL.md` -> `enterprise-ai/agent-workflows/agent-tools.md` -> `enterprise-ai/data/rag-and-search.md` -> `enterprise-ai/governance/private-endpoints-and-governance.md` |
 
 ## Scope Boundaries
 
 - Keep OCI service, networking, IAM, agent hosting, and cost-estimation guidance in this domain.
+- Route OCI Security Zone recipes and Security Zone Terraform configuration to `oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/`; it is generate-only and does not deploy or manage other Cloud Guard, IAM, or network resources.
 - Route OCI IoT domain, digital twin, adapter, device publish, raw command, and Data API workflows to `oci/iot-platform/`.
 - Route Oracle Database-owned implementation details to `db/features/`.
 - Route APEX artifact generation to `apex/apexlang/`.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/README.txt
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/README.txt
@@ -1,0 +1,102 @@
+Build OCI Security Zones Terraform Skill
+========================================
+
+This skill safely generates or updates Terraform root configuration for OCI
+Security Zones by using only the supported module folder:
+https://github.com/oci-landing-zones/terraform-oci-modules-security/tree/main/security-zones
+
+It supports Cloud Guard Security Zone recipes and Security Zones. It does not
+generate Cloud Guard targets, detector or responder recipes, responders,
+problem remediation, IAM, network, or other security-service resources. For
+unsupported requests, it reports that the Terraform module is not supported
+instead of inventing an alternative.
+
+How this skill works
+--------------------
+
+1. Inspects the target Terraform project before making changes.
+2. Checks module.md to confirm the requested capability is a supported recipe
+   or Security Zone resource.
+3. Collects tenancy, authorized group, recipe, and Security Zone inputs from
+   input-collection.md, preserving literal OCIDs and stable logical map keys.
+4. Asks whether the user wants documented optional parameters, then validates
+   the completed inputs and required Cloud Guard authorization with OCI MCP.
+5. Uses terraform-sources.md and main-tf-map.md to generate the smallest safe
+   configuration change.
+6. Does not run or install Terraform. It hands off terraform init, validate,
+   plan, and apply for the user to run; Terraform 1.3.0 or later is required,
+   and the plan must be reviewed before applying.
+
+
+How to use
+----------
+
+Unzip this folder and put the /references and SKILL.md in a folder named
+`build-oci-security-zones-main-tf`.
+
+Load this skill into an agent whenever the use case is to create or update OCI
+Security Zones Terraform using the
+`oci-landing-zones/terraform-oci-modules-security` repository's
+`security-zones` folder. Typical requests include creating Security Zone
+recipes and associating Security Zones with compartments.
+
+After loading, the agent reads `SKILL.md` first and follows its
+reference-routing workflow: confirm support, inspect the target, collect
+inputs, ask about optional parameters, validate the values and required IAM
+policy through OCI MCP, then generate the smallest safe Terraform change. The
+agent must not run or install Terraform, create adjacent Cloud Guard, IAM, or
+network resources, or place private keys, passwords, tokens, or other secrets
+in repository files.
+
+The skill is additive by default. It preserves existing project layout and
+does not modify Terraform state. Updates, moves, removals, recovery, and
+deletion requests require the extra lifecycle checks in lifecycle-safety.md.
+The module enables Cloud Guard if it is disabled, but does not disable it. A
+Security Zone applies to its compartment and subcompartments and replaces any
+existing Cloud Guard target for that compartment, so the user must review the
+Terraform plan before applying it.
+
+
+Reference files
+---------------
+
+module.md
+  The upstream support allowlist for Security Zone recipes and Security Zones,
+  unsupported-capability response, Cloud Guard side effects, CIS levels, and
+  tenancy-root safeguards.
+
+input-collection.md
+  Module-specific input checklist and structural checks. It covers tenancy
+  resolution, authorized IAM group validation metadata, recipe and zone maps,
+  compartment dependencies, optional inputs, and stable logical keys.
+
+terraform-sources.md
+  The canonical Git module source format, Terraform version requirement, and
+  integration rules for existing repositories or a new minimal Terraform
+  workspace.
+
+validation.md
+  The validation contract: mandatory OCI MCP policy verification for
+  `manage cloud-guard-family in tenancy`, tenancy and compartment OCID checks,
+  recipe-to-zone relationships, root-compartment safety, and lifecycle gates.
+
+main-tf-map.md
+  Rules for mapping validated values into main.tf, variables.tf, and
+  terraform.tfvars. It explains the required nested recipes and Security Zones
+  object shape while preserving repository conventions.
+
+lifecycle-safety.md
+  Additional guardrails for updates, map-key changes, remove-from-
+  configuration, and deletes. It covers Terraform state ownership, dependent
+  recipe references, compartment scope, potential target replacement, and the
+  required plan-review warning.
+
+Quick reference flow
+--------------------
+
+request -> module.md -> input-collection.md + terraform-sources.md ->
+validation.md -> main-tf-map.md -> generate safely
+
+For lifecycle changes, read lifecycle-safety.md before collecting inputs and
+apply its state-ownership requirements together with validation.md before
+proposing a configuration change.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/SKILL.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: build-oci-security-zones-main-tf
+description: "Generate or update Terraform configuration only for OCI Security Zones with the upstream `oci-landing-zones/terraform-oci-modules-security/tree/main/security-zones` folder. Use for Cloud Guard Security Zone recipes and Security Zones when requests must be mapped to the documented module, inputs collected and validated, and `main.tf`, `variables.tf`, and `terraform.tfvars` produced. Never deploy, run Terraform, or generate other security services, Cloud Guard targets, detectors, responders, IAM, or network resources."
+---
+
+# Build OCI Security Zones Terraform
+
+Generate only the upstream Security Zones module configuration. Default to additive-only changes. Never invent a module path, input name, resource model, policy OCID, compartment relationship, or prerequisite value. Never mutate, replace, rename, move, or delete an existing resource unless the user explicitly and unambiguously requests that exact change. Never install or execute Terraform.
+
+## Required workflow
+
+1. Inspect the target before writing.
+   - Inspect the project root, Terraform files, provider/backend setup, established layout, and existing module blocks.
+   - For an update, removal, or deletion, inspect accessible local Terraform state read-only for the exact state address. Never modify state or run Terraform state commands.
+   - Treat it as an existing project when a project or configuration is in scope. Otherwise ask for a target directory; do not hardcode one or overwrite unrelated files.
+   - Read [references/module.md](references/module.md) first. If the request is outside Security Zone recipes or Security Zones, say: **"The Terraform module for `<capability>` is not supported by `oci-landing-zones/terraform-oci-modules-security/tree/main/security-zones`."**
+   - Read [references/lifecycle-safety.md](references/lifecycle-safety.md) for any non-additive request.
+
+2. Collect exact inputs.
+   - Read [references/input-collection.md](references/input-collection.md). Collect `tenancy_ocid` or a supplied compartment OCID from which to resolve it through OCI MCP, the named OCI group authorized to apply this configuration, at least one Security Zone definition, its recipe key, and the matching recipe definition first.
+   - For every recipe, explicitly explain the CIS choices before collecting `cis_level`: the module default is `"1"` unless a supplied top-level `default_cis_level` overrides it; Level 1 enables `deny public_buckets` and `deny db_instance_public_access`; Level 2 enables the Level 1 policies plus `deny block_volume_without_vault_key`, `deny boot_volume_without_vault_key`, `deny buckets_without_vault_key`, and `deny file_system_without_vault_key`. Ask the user to select Level 1 or Level 2, or explicitly accept the applicable default.
+   - Then ask whether the user has specific Oracle Security Zone policies to add beyond the selected CIS baseline or wants to choose from the complete available-policy catalog. If they provide specific policy names or OCIDs, validate only those values through OCI MCP and add only the selected returned OCIDs to `security_policies_ocids`. If they choose the catalog, use OCI MCP read-only calls to list active policies and present every active returned policy in a Markdown table of policy name, description, services, category, and OCID before asking for their selection. Never infer policy relevance from the authorized group or any other input, and never omit catalog entries. If the user declines extra policies, omit `security_policies_ocids`.
+   - Preserve literal OCIDs and stable logical map keys. Do not infer a compartment OCID, policy OCID, reporting region, CIS level, or a recipe-to-zone association from a name.
+   - Collect `compartments_dependency` only when a recipe or Security Zone uses a compartment-reference key instead of a literal compartment OCID.
+   - Ask whether the user wants documented optional inputs only after all required values are present. If declined, use documented defaults; never invent optional values.
+   - Read the upstream `SPEC.md` before writing configuration so the generated object matches the approved module revision's exact shape.
+   - Read [references/terraform-sources.md](references/terraform-sources.md) before writing a module block.
+
+3. Validate before producing usable configuration.
+   - Read [references/validation.md](references/validation.md) only after input collection.
+   - Apply every non-placeholder rule. Pause for a corrected value when a required or supplied optional input is missing or known invalid.
+   - Use OCI MCP read-only commands to verify that the supplied group has an active tenancy policy granting either `manage cloud-guard-family in tenancy` or `manage all-resources in tenancy`. This policy check is mandatory; stop if OCI MCP is unavailable, policy listing fails, or neither authorization is found. Validate tenancy and supplied literal compartment OCIDs through OCI MCP when available; never use local OCI CLI or claim OCI-side validation.
+   - For an existing-resource mutation, require confirmed Terraform-state ownership before proposing it.
+
+4. Generate after validation succeeds.
+   - Read [references/main-tf-map.md](references/main-tf-map.md).
+   - In an existing project, preserve its layout, provider/backend blocks, naming, variables, and secret-handling approach. Make the smallest scoped change; do not add a duplicate module block.
+   - In a new project, create exactly `main.tf`, `variables.tf`, and `terraform.tfvars`. Include the OCI provider baseline and module block in `main.tf`; typed declarations in `variables.tf`; only validated non-secret values in `terraform.tfvars`.
+
+5. Hand off without execution.
+   - Tell the user this upstream module requires Terraform 1.3.0 or later and either `manage cloud-guard-family in tenancy` or `manage all-resources in tenancy` permission.
+   - State clearly that the module enables Cloud Guard when it is disabled and does not disable it.
+   - Provide, but never run: `terraform init`, `terraform validate`, `terraform plan`, and `terraform apply`.
+   - State that the plan requires review before apply, especially because associating a Security Zone with a compartment replaces any existing Cloud Guard target there and applies to its subcompartments.
+
+## Boundaries
+
+- Use only `git::https://github.com/oci-landing-zones/terraform-oci-modules-security.git//security-zones?ref=<ref>`; default `<ref>` to `main` unless the user provides a release tag or commit SHA. Treat `https://github.com/oci-landing-zones/terraform-oci-modules-security/tree/main/security-zones` as the canonical upstream folder path.
+- Support only Security Zone recipes and Security Zones defined by `security_zones_configuration`. Do not generate Cloud Guard targets, detector recipes, responder recipes, responders, problem remediation, IAM, networks, Vault keys, or raw `oci_*` substitutes.
+- Do not run `terraform`, `tofu`, package-manager, provider-login, OCI write, or install commands.
+- Do not create, modify, replace, move, delete, import, or unlock Terraform state; do not create a lock file or `.terraform` directory.
+- Do not put private-key material, passwords, tokens, or other secrets in `terraform.tfvars`, examples, or repository files.
+
+## Reference routing
+
+| Need at this stage | Read |
+| --- | --- |
+| Confirm supported capabilities and side effects | [module.md](references/module.md) |
+| Collect recipes, zones, and optional inputs | [input-collection.md](references/input-collection.md) |
+| Update, remove, or destroy a resource | [lifecycle-safety.md](references/lifecycle-safety.md) |
+| Create the source, provider, or minimal project baseline | [terraform-sources.md](references/terraform-sources.md) |
+| Validate values and relationships | [validation.md](references/validation.md) |
+| Map validated values to Terraform files | [main-tf-map.md](references/main-tf-map.md) |

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/agents/openai.yaml
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Build OCI Security Zones Terraform"
+  short_description: "Generate OCI Security Zones Terraform safely"
+  default_prompt: "Use $build-oci-security-zones-main-tf to create a Terraform Security Zone configuration."

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/references/input-collection.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/references/input-collection.md
@@ -1,0 +1,57 @@
+# Security Zones input collection
+
+Use this reference only after `module.md` confirms the request is supported. Map values exactly to `security_zones_configuration`.
+
+## Required inputs
+
+- `tenancy_ocid`, or a literal `scope_compartment_ocid` from which OCI MCP can resolve the tenancy root. Keep the resolved tenancy OCID as `tenancy_ocid` for module wiring; `scope_compartment_ocid` is validation metadata only and must not be emitted as a module input;
+- `authorized_group_name`: the exact OCI IAM group name expected to apply the configuration. It is validation metadata only and must not be emitted as a module input;
+- at least one `security_zones` entry, each with a stable logical key, `name`, `compartment_id`, and `recipe_key`;
+- a `recipes` entry with the exact matching `recipe_key`, a stable logical key, `name`, and `compartment_id`.
+
+`compartment_id` may be a literal compartment OCID or a key that resolves through `compartments_dependency`. Do not accept a display name as either one.
+
+## Optional configuration
+
+- Top-level: `default_cis_level` (`"1"` or `"2"`), `default_security_policies_ocids`, default tags, `reporting_region`, `self_manage_resources`, and `enable_obp_checks`.
+- Recipe: `description`, `cis_level` (`"1"` or `"2"`), `security_policies_ocids`, and tags.
+- Security Zone: `description` and tags.
+- Module: `compartments_dependency`, `enable_output` (default `true`), and `module_name` (default `security-zones`).
+
+## Required CIS and additional-policy conversation
+
+For each recipe, before asking about any other optional inputs, state:
+
+| Choice | Included Security Zone policies |
+| --- | --- |
+| Omit `cis_level` / choose `"1"` | `deny public_buckets`; `deny db_instance_public_access` (module default unless `default_cis_level` is supplied) |
+| Choose `"2"` | All Level 1 policies, plus `deny block_volume_without_vault_key`, `deny boot_volume_without_vault_key`, `deny buckets_without_vault_key`, and `deny file_system_without_vault_key` |
+
+Ask: `Do you want CIS Level 1 (the module default, unless you set default_cis_level) or CIS Level 2 for each recipe?` Do not infer the selection. The user may explicitly accept the applicable default; then omit `cis_level` or emit the chosen value consistently with the repository's style.
+
+After the CIS selection, ask: `Do you have specific Oracle Security Zone policies to add beyond this CIS baseline, or do you want to choose from the complete available-policy catalog?`
+
+- If the user declines, omit `security_policies_ocids`.
+- If the user supplies specific policy names or OCIDs, use OCI MCP read-only commands to validate each requested policy. Do not list or tabulate the catalog unless they explicitly ask to choose from it.
+- If the user asks to choose from the catalog, first call `get_oci_command_help` for `cloud-guard security-policy-collection list-security-policies`; then call `run_oci_command` with `cloud-guard security-policy-collection list-security-policies --compartment-id <TENANCY_OCID> --all`. Present every active returned policy in a Markdown table with columns `Name`, `Description`, `Services`, `Category`, and `OCID`; do not fabricate, abbreviate, substitute OCIDs, select policies on the user's behalf, or omit entries based on the authorized group or apparent relevance. Ask the user which listed policies to add. Add only their selected OCIDs as the recipe's `security_policies_ocids`.
+- Security Zone policies are Oracle-defined. Do not offer to create a new policy or confuse them with IAM policies.
+
+## Mandatory optional-input question
+
+After collecting required values and before reading `validation.md`, ask:
+
+> After choosing the CIS baseline and whether to add extra Security Zone policies, do you want to provide any other documented optional Security Zones inputs—descriptions, tags, reporting region, Cloud Guard self-management, root-compartment override, compartment dependencies, outputs, or module name?
+
+If the user declines, use upstream defaults only.
+
+## Structural checks before validation
+
+- Require unique recipe and Security Zone logical keys and names.
+- Require every `security_zones[*].recipe_key` to resolve to a declared recipe key in the same configuration.
+- Require each reference-style `compartment_id` to resolve to a `compartments_dependency` entry with a non-empty `id`.
+- Preserve the map keys: they identify created recipes and zones and must not be casually renamed.
+- Treat a Security Zone targeting the root compartment as a high-impact exception requiring explicit `enable_obp_checks = false`.
+
+## Output discipline
+
+Put non-secret topology data in the repository's established variable-data location, normally `terraform.tfvars`; pass `var.security_zones_configuration`, `var.tenancy_ocid`, and selected documented module inputs into one module block.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/references/lifecycle-safety.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/references/lifecycle-safety.md
@@ -1,0 +1,12 @@
+# Security Zones lifecycle safety
+
+Read this reference for every update, removal, deletion, or map-key change.
+
+- Treat removing a recipe or Security Zone from module configuration as a Terraform destroy, not source cleanup.
+- Require the exact module map key, Terraform state address, and intended action before proposing a mutation. Renaming a key is normally destroy/create; do not do it unless the user explicitly requests it and accepts the plan effect.
+- Before creating, moving, or changing a Security Zone's compartment association, warn that it applies to the compartment and subcompartments and replaces an existing Cloud Guard target in that compartment.
+- Before deleting a Security Zone, warn that the compartment will no longer have that zone's preventative policies. Do not say that Cloud Guard will be disabled; this module does not disable it.
+- Before deleting or changing a recipe, identify all Security Zones that reference its key. Do not remove a referenced recipe without an explicit ordered migration or deletion request.
+- Never run Terraform, OCI writes, imports, state commands, or Cloud Guard enable/disable operations.
+
+For any lifecycle change, state the exact object(s), expected update/replacement/destroy effect, compartment scope, possible target replacement, and requirement to review `terraform plan` before apply.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/references/main-tf-map.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/references/main-tf-map.md
@@ -1,0 +1,49 @@
+# Security Zones Terraform file map
+
+Use after support and validation succeed.
+
+## Module block
+
+```hcl
+module "security_zones" {
+  source = "git::https://github.com/oci-landing-zones/terraform-oci-modules-security.git//security-zones?ref=<approved-ref>"
+
+  tenancy_ocid                 = var.tenancy_ocid
+  security_zones_configuration = var.security_zones_configuration
+  compartments_dependency      = var.compartments_dependency
+}
+```
+
+Include `compartments_dependency` only when selected. Add `enable_output` or `module_name` only when the user supplies them. Do not add a second module block when one already exists.
+
+## Object shape
+
+```hcl
+security_zones_configuration = {
+  recipes = {
+    RECIPE_KEY = {
+      name           = "example-recipe"
+      compartment_id = "ocid1.compartment..."
+      cis_level      = "1"
+    }
+  }
+
+  security_zones = {
+    ZONE_KEY = {
+      name           = "example-zone"
+      compartment_id = "ocid1.compartment..."
+      recipe_key     = "RECIPE_KEY"
+    }
+  }
+}
+```
+
+This is a shape-only example. Replace neither existing user data nor placeholders with guessed values.
+
+## File placement
+
+- `main.tf`: Terraform/provider blocks and module wiring.
+- `variables.tf`: typed `tenancy_ocid`, `security_zones_configuration`, and selected optional module inputs.
+- `terraform.tfvars`: validated non-secret OCIDs, logical keys, names, CIS level, tags, and region values.
+
+In an existing repository, retain its established file placement and formatting instead of forcing this layout.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/references/module.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/references/module.md
@@ -1,0 +1,26 @@
+# Security Zones module contract
+
+Canonical upstream folder: `oci-landing-zones/terraform-oci-modules-security/tree/main/security-zones`.
+
+## Allowlist
+
+| Capability | Status | Configuration location |
+| --- | --- | --- |
+| Security Zone recipes | Supported | `security_zones_configuration.recipes` |
+| Security Zones | Supported | `security_zones_configuration.security_zones` |
+| Cloud Guard enablement when currently disabled | Module side effect | Module-managed; never configure it separately |
+| Cloud Guard targets, detector/responder recipes, responders, remediation, IAM, or networking | Not supported | — |
+
+For an unsupported request, say:
+
+> The Terraform module for `<capability>` is not supported by `oci-landing-zones/terraform-oci-modules-security/tree/main/security-zones`.
+
+## Material module effects
+
+- The module enables Cloud Guard if it is disabled. It does not disable Cloud Guard.
+- A Security Zone is scoped to its compartment and subcompartments.
+- Creating a Security Zone for a compartment replaces any existing Cloud Guard target for that compartment.
+- CIS level `1` adds the upstream module's Level 1 policy set; CIS level `2` adds Level 1 plus Level 2 policies. Do not hardcode or guess policy OCIDs: the module resolves its CIS policies.
+- With default `enable_obp_checks = true`, recipes and Security Zones cannot target the tenancy root. Set it to `false` only when the user explicitly authorizes root-compartment deployment.
+
+Re-check upstream `README.md`, `SPEC.md`, and `variables.tf` before generation when a requested field is not covered here.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/references/terraform-sources.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/references/terraform-sources.md
@@ -1,0 +1,23 @@
+# Terraform source and project integration
+
+## Canonical module source
+
+Use exactly:
+
+```hcl
+source = "git::https://github.com/oci-landing-zones/terraform-oci-modules-security.git//security-zones?ref=<ref>"
+```
+
+Default `<ref>` to `main`; use a release tag or commit SHA only when the user supplies one. Confirm current upstream `SPEC.md` and `variables.tf` before emitting arguments.
+
+## Existing project
+
+Inspect and preserve provider aliases, required-provider constraints, backend, naming, file layout, and variable-data convention. Reuse a compatible OCI provider. Add to the existing Security Zones module when present; do not add a duplicate module, provider, or backend.
+
+Do not write API private-key contents, tokens, or other secrets into source or variable files.
+
+## New project baseline
+
+Only after the user provides a target directory, create `main.tf`, `variables.tf`, and `terraform.tfvars`. Require Terraform `>= 1.3.0`, declare OCI provider authentication variables without embedding secrets, and use the typed Security Zones configuration in `variables.tf`.
+
+The executing OCI principal requires `manage cloud-guard-family in tenancy`; explain it as an apply-time requirement, not a reason to generate configuration.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/references/validation.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-module-security-zone-skill/references/validation.md
@@ -1,0 +1,60 @@
+# Security Zones validation contract
+
+Read only after required values and optional choices are collected. Never generate usable configuration with a missing, empty, unresolved, malformed, or known-invalid supplied value.
+
+## Mandatory OCI MCP policy validation
+
+Before generating usable configuration, require an exact `authorized_group_name` and resolve the tenancy OCID before using OCI MCP to prove that an active tenancy policy grants the required permission.
+
+### Resolve the tenancy root
+
+Use a supplied literal `tenancy_ocid` only when it starts with `ocid1.tenancy.`. Otherwise, require a literal `scope_compartment_ocid` beginning with `ocid1.compartment.` and resolve it through OCI MCP:
+
+1. Call `get_oci_command_help` for `iam compartment get` before the first read.
+2. Call `run_oci_command` with `iam compartment get --compartment-id <CURRENT_OCID>`.
+3. Read the returned compartment's parent identifier (`data.compartment-id` / `data.compartmentId`). If it begins with `ocid1.tenancy.`, it is the resolved `tenancy_ocid`; otherwise it must be a different `ocid1.compartment.` OCID, which becomes `<CURRENT_OCID>` for the next read.
+4. Repeat until the root tenancy OCID is reached. Reject a missing parent, malformed OCID, repeated OCID, authorization/API error, or more than the documented hierarchy depth. Do not infer a tenancy OCID from a compartment name.
+
+Use the resolved root only as `tenancy_ocid` in the Terraform module; do not emit traversal metadata.
+
+### Verify the policy
+
+1. Call `get_oci_command_help` for `iam policy list`.
+2. Call `run_oci_command` with `iam policy list --compartment-id <TENANCY_OCID> --all`.
+3. Inspect every returned active policy statement, including every response page when the MCP result does not automatically aggregate pages.
+4. Normalize statement whitespace and compare case-insensitively. Require either exact, unqualified statement for the supplied group:
+
+   ```text
+   allow group <AUTHORIZED_GROUP_NAME> to manage cloud-guard-family in tenancy
+
+   allow group <AUTHORIZED_GROUP_NAME> to manage all-resources in tenancy
+   ```
+
+If OCI MCP is unavailable, the list fails, the group name is absent, or no matching statement is returned, stop and tell the user that the required authorization could not be verified. Do not generate a policy, use the local OCI CLI, assume an inherited or related permission is enough, or claim the apply principal belongs to the named group. A matching policy proves the group's grant; it does not prove the current credentials are a member of that group.
+
+## OCI resource validation
+
+When OCI MCP provides `get_oci_command_help` and `run_oci_command`, use it for read-only validation. Confirm syntax with `get_oci_command_help` before the first use of `iam compartment get`, then use `run_oci_command` with:
+
+```text
+iam compartment get --compartment-id <OCID>
+```
+
+Pass only the command text after `oci`; do not pass profiles, credentials, or write flags. Validate the exact supplied `tenancy_ocid`, literal recipe/zone compartment OCIDs, and every `compartments_dependency[*].id`. A not-found, authorization, authentication, service error, or mismatched ID is a validation failure.
+
+After the mandatory policy check passes, if OCI MCP cannot perform a later OCID read, say only that OCID validation was skipped and continue with structural checks. Do not fall back to the local OCI CLI or claim an OCID was validated.
+
+## Configuration rules
+
+- `tenancy_ocid` must be supplied and non-empty.
+- Every requested Security Zone must have non-empty `name`, `compartment_id`, and `recipe_key`; every requested recipe must have non-empty `name` and `compartment_id`.
+- `default_cis_level` and each supplied recipe `cis_level` must be exactly `"1"` or `"2"`.
+- Every supplied `security_policies_ocids` value must be a non-empty security-policy OCID; validate OCI-side only when a documented read is available. Never manufacture a policy ID.
+- Every literal `compartment_id` must resolve through the OCI MCP compartment read. Every key reference must resolve through a supplied external dependency with a validated `id`.
+- If `enable_obp_checks` is omitted or true, reject a recipe or zone whose effective compartment is the tenancy root. Permit root deployment only after the user explicitly sets it to false and acknowledges its scope.
+- For every Security Zone, verify that its recipe key exists in `recipes`; do not look up a recipe that the same module will create.
+- Treat `reporting_region` as an exact OCI region identifier; do not infer it. When omitted, the module uses tenancy home region.
+
+## Lifecycle gate
+
+For updates, removals, or replacements, inspect accessible local state read-only and require the exact Terraform address to exist. If no accessible state proves ownership, ask the user to confirm it through their approved state-inspection process. Do not import, adopt, recreate, or alter state.


### PR DESCRIPTION
## Summary

Adds the **OCI Security Zones Landing Zones Terraform skill**.

The skill supports safe, module-constrained Terraform configuration for:

* **Cloud Guard Security Zone recipes**
* **Security Zones** (associated with compartments)

It strictly uses `oci-landing-zones/terraform-oci-modules-security/tree/main/security-zones`, preserves existing repository patterns, and validates OCIDs and required IAM policies via read-only OCI MCP operations. It explicitly avoids local Terraform execution, secret storage, and managing non-Security Zone resources (such as Cloud Guard targets, responders, network, or IAM).

---

## Changes

* ** Includes `SKILL.md` and all standard reference routing docs (`module.md`, `input-collection.md`, `terraform-sources.md`, `validation.md`, `main-tf-map.md`, and `lifecycle-safety.md`).

---

## Capabilities & Scope Boundaries

* **In Scope:** Creating/updating Security Zone recipes and associating Security Zones with targeted compartments.
* **Explicitly Out of Scope:** Local execution (`terraform init/plan/apply`), Cloud Guard targets/detectors/responders, problem remediation, network, or IAM resource creation. Unsupported capability requests gracefully report module limitations rather than inventing alternatives.