### PR TITLE
Skill to write terraform configuration for oci landing zone terraform Exadata module

### DIFF
--- a/oci/SKILL.md
+++ b/oci/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: oci
-description: Oracle Cloud Infrastructure guidance for designing, operating, and troubleshooting OCI services, including OCI Kubernetes Engine (OKE), OCI Internet of Things Platform, OCI Functions deployment and troubleshooting, and Enterprise AI workflows for OCI Generative AI models, Responses API agents, RAG, cost estimation, governance, private endpoints, hosted agentic applications, and Oracle platform integrations. Use when the user asks about OKE cluster design, Terraform or Resource Manager planning, OKE incident troubleshooting, Generic VNIC Attachment, Multus, pod networking, node pools, add-ons, ingress, load balancers, OCIR image pulls, Workload Identity, Kubernetes workloads on OCI, OCI IoT domains or digital twins, device publish flows, OCI Functions setup, deployment, invocation, or troubleshooting, OCI Generative AI, Enterprise AI Models, Enterprise AI Agents, governed GenAI applications, agentic workflows, RAG on Oracle Cloud, or OCI Generative AI pricing.
+description: Oracle Cloud Infrastructure guidance for designing, operating, and troubleshooting OCI services, including OCI Kubernetes Engine (OKE), OCI Internet of Things Platform, OCI Functions deployment and troubleshooting, OCI Exadata Database Service Terraform configuration, and Enterprise AI workflows for OCI Generative AI models, Responses API agents, RAG, cost estimation, governance, private endpoints, hosted agentic applications, and Oracle platform integrations. Use when the user asks about OKE cluster design, Terraform or Resource Manager planning, Cloud Exadata Infrastructure, Cloud VM Clusters, DB Homes, Container Databases, Pluggable Databases, OKE incident troubleshooting, Generic VNIC Attachment, Multus, pod networking, node pools, add-ons, ingress, load balancers, OCIR image pulls, Workload Identity, Kubernetes workloads on OCI, OCI IoT domains or digital twins, device publish flows, OCI Functions setup, deployment, invocation, or troubleshooting, OCI Generative AI, Enterprise AI Models, Enterprise AI Agents, governed GenAI applications, agentic workflows, RAG on Oracle Cloud, or OCI Generative AI pricing.
 ---
 
 # Oracle Cloud Infrastructure Skills
 
-Use this domain for practical Oracle Cloud Infrastructure guidance. Current content covers OCI Kubernetes Engine (OKE): cluster design, operational troubleshooting, Generic VNIC Attachment (GVA), and Multus multi-interface pod validation. It covers OCI Internet of Things Platform resource discovery, digital twin lifecycle workflows, device publish flows, and optional MCP-assisted operation. It covers OCI Functions local deployment and diagnosis-first troubleshooting. It also covers Enterprise AI because that work is built around OCI Generative AI, OCI networking, IAM, cost estimation, hosted applications, and OCI platform integrations.
+Use this domain for practical Oracle Cloud Infrastructure guidance. Current content covers OCI Kubernetes Engine (OKE): cluster design, operational troubleshooting, Generic VNIC Attachment (GVA), and Multus multi-interface pod validation. It covers OCI Internet of Things Platform resource discovery, digital twin lifecycle workflows, device publish flows, and optional MCP-assisted operation. It covers OCI Functions local deployment and diagnosis-first troubleshooting. It includes a constrained Terraform Configuration generator for OCI Exadata Database Service on Dedicated Infrastructure. It also covers Enterprise AI because that work is built around OCI Generative AI, OCI networking, IAM, cost estimation, hosted applications, and OCI platform integrations.
 
 ## How to Use This Domain
 
@@ -46,6 +46,11 @@ oci/
 │   ├── scripts/
 │   ├── templates/
 │   └── tests/
+├── oci-landing-zone-terraform-module/
+│   └── terraform-oci-modules-exadata-database-skill/
+│       ├── SKILL.md
+│       ├── agents/
+│       └── references/
 └── oke/
     ├── cluster-design.md
     ├── troubleshooting.md
@@ -61,19 +66,20 @@ oci/
 
 ## Category Routing
 
-| Topic | Start With |
-|-------|------------|
-| Design or scaffold an OKE cluster, Terraform stack, or OCI Resource Manager stack | Start with `oci/oke/cluster-design.md`, then load `oci/oke/skills/oke-cluster-generator/SKILL.md` |
-| Troubleshoot OKE workloads, pods, services, DNS, add-ons, ingress, load balancers, image pulls, storage, Workload Identity, or cluster access | Start with `oci/oke/troubleshooting.md`, then load `oci/oke/skills/oke-troubleshooter/SKILL.md` |
-| Configure OKE managed node pools with Generic VNIC Attachment secondary VNIC profiles and Application Resources | Start with `oci/oke/gva-node-pools.md`, then load `oci/oke/skills/oke-gva-deployer/SKILL.md` |
-| Deploy or validate Multus NetworkAttachmentDefinitions and multi-interface pods on OKE | Start with `oci/oke/multus-multihome.md`, then load `oci/oke/skills/oke-multihome-deployer/SKILL.md` |
-| Deploy an OCI Function from a local macOS or Linux workstation | `oci/functions/oci-functions-deploy/SKILL.md` |
-| Troubleshoot OCI Functions setup, deployment, invocation, or observability | `oci/functions/oci-functions-troubleshoot/SKILL.md` |
+| Topic                                                                                                                                          | Start With |
+|------------------------------------------------------------------------------------------------------------------------------------------------|------------|
+| Design or scaffold an OKE cluster, Terraform stack, or OCI Resource Manager stack                                                              | Start with `oci/oke/cluster-design.md`, then load `oci/oke/skills/oke-cluster-generator/SKILL.md` |
+| Troubleshoot OKE workloads, pods, services, DNS, add-ons, ingress, load balancers, image pulls, storage, Workload Identity, or cluster access  | Start with `oci/oke/troubleshooting.md`, then load `oci/oke/skills/oke-troubleshooter/SKILL.md` |
+| Configure OKE managed node pools with Generic VNIC Attachment secondary VNIC profiles and Application Resources                                | Start with `oci/oke/gva-node-pools.md`, then load `oci/oke/skills/oke-gva-deployer/SKILL.md` |
+| Deploy or validate Multus NetworkAttachmentDefinitions and multi-interface pods on OKE                                                         | Start with `oci/oke/multus-multihome.md`, then load `oci/oke/skills/oke-multihome-deployer/SKILL.md` |
+| Deploy an OCI Function from a local macOS or Linux workstation                                                                                 | `oci/functions/oci-functions-deploy/SKILL.md` |
+| Troubleshoot OCI Functions setup, deployment, invocation, or observability                                                                     | `oci/functions/oci-functions-troubleshoot/SKILL.md` |
+| Generate or update Terraform Configuration for OCI Exadata Database Service on Dedicated Infrastructure                                        | `oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/SKILL.md` |
 | OCI IoT domains, domain groups, digital twin models, adapters, instances, relationships, raw commands, Data API access, or HTTPS publish flows | `oci/iot-platform/SKILL.md` |
-| OCI Generative AI models, custom/imported models, endpoints, or private endpoints | `oci/enterprise-ai/SKILL.md` |
-| OCI Responses API agents, tools, memory, File Search, Code Interpreter, MCP, or SQL Search | `oci/enterprise-ai/SKILL.md` |
-| OCI Generative AI and OCI Generative AI Agents cost estimation | `oci/enterprise-ai/cost/cost-estimation.md` |
-| OCI Enterprise AI governance, IAM, API keys, OAuth, guardrails, or ZPR | `oci/enterprise-ai/governance/private-endpoints-and-governance.md` |
+| OCI Generative AI models, custom/imported models, endpoints, or private endpoints                                                              | `oci/enterprise-ai/SKILL.md` |
+| OCI Responses API agents, tools, memory, File Search, Code Interpreter, MCP, or SQL Search                                                     | `oci/enterprise-ai/SKILL.md` |
+| OCI Generative AI and OCI Generative AI Agents cost estimation                                                                                 | `oci/enterprise-ai/cost/cost-estimation.md` |
+| OCI Enterprise AI governance, IAM, API keys, OAuth, guardrails, or ZPR                                                                         | `oci/enterprise-ai/governance/private-endpoints-and-governance.md` |
 
 ## Key Starting Points
 
@@ -85,6 +91,7 @@ oci/
 - `oci/functions/oci-functions-troubleshoot/SKILL.md`
 - `oci/functions/oci-functions-deploy/references/oci-functions-quickstart.md`
 - `oci/functions/oci-functions-troubleshoot/references/error-patterns.md`
+- `oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/SKILL.md`
 - `oci/iot-platform/SKILL.md`
 - `oci/iot-platform/references/cli-workflows.md`
 - `oci/iot-platform/references/mcp-optional-use.md`
@@ -106,23 +113,25 @@ The OKE operational skills include deterministic helper tools under `oci/oke/scr
 
 ## Common Multi-Step Flows
 
-| Task | Recommended Sequence |
-|------|----------------------|
-| Plan a production OKE cluster | `oke/cluster-design.md` |
-| Diagnose an OKE service with no load balancer IP | `oke/troubleshooting.md` |
+| Task                                                             | Recommended Sequence |
+|------------------------------------------------------------------|----------------------|
+| Plan a production OKE cluster                                    | `oke/cluster-design.md` |
+| Diagnose an OKE service with no load balancer IP                 | `oke/troubleshooting.md` |
 | Build a node pool with workload-specific secondary VNIC profiles | `oke/gva-node-pools.md` -> `oke/multus-multihome.md` if pods need multiple interfaces |
-| Validate Multus pod networking on GVA-enabled nodes | `oke/multus-multihome.md` -> `oke/troubleshooting.md` if symptoms remain |
-| Investigate OKE workload access to OCI APIs | `oke/troubleshooting.md` |
-| Deploy a local function | `functions/oci-functions-deploy/SKILL.md` -> preflight -> Fn context validation -> OCIR auth check -> app selection -> scaffold -> deploy |
-| Troubleshoot a failed function deploy | `functions/oci-functions-troubleshoot/SKILL.md` -> `functions/oci-functions-troubleshoot/references/error-patterns.md` -> `functions/oci-functions-troubleshoot/references/deploy.md` |
-| Troubleshoot function invocation failures | `functions/oci-functions-troubleshoot/SKILL.md` -> `functions/oci-functions-troubleshoot/references/invoke.md` -> logs, traces, metrics, and limits |
-| Explore or update OCI IoT digital twin resources | `iot-platform/SKILL.md` -> `iot-platform/references/cli-workflows.md` -> `iot-platform/references/resilience-guidance.md` |
-| Publish test telemetry to an OCI IoT twin | `iot-platform/SKILL.md` -> `iot-platform/references/cli-workflows.md` -> `iot-platform/templates/publish-curl.template.sh` |
-| Build a governed enterprise assistant | `enterprise-ai/SKILL.md` -> `enterprise-ai/agent-workflows/agent-tools.md` -> `enterprise-ai/data/rag-and-search.md` -> `enterprise-ai/governance/private-endpoints-and-governance.md` |
+| Validate Multus pod networking on GVA-enabled nodes              | `oke/multus-multihome.md` -> `oke/troubleshooting.md` if symptoms remain |
+| Investigate OKE workload access to OCI APIs                      | `oke/troubleshooting.md` |
+| Deploy a local function                                          | `functions/oci-functions-deploy/SKILL.md` -> preflight -> Fn context validation -> OCIR auth check -> app selection -> scaffold -> deploy |
+| Troubleshoot a failed function deploy                            | `functions/oci-functions-troubleshoot/SKILL.md` -> `functions/oci-functions-troubleshoot/references/error-patterns.md` -> `functions/oci-functions-troubleshoot/references/deploy.md` |
+| Troubleshoot function invocation failures                        | `functions/oci-functions-troubleshoot/SKILL.md` -> `functions/oci-functions-troubleshoot/references/invoke.md` -> logs, traces, metrics, and limits |
+| Generate OCI Exadata Database Service Terraform Configuration    | `oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/SKILL.md` -> validate only requested-object inputs read-only -> generate `main.tf`, `variables.tf`, and `terraform.tfvars` without running Terraform |
+| Explore or update OCI IoT digital twin resources                 | `iot-platform/SKILL.md` -> `iot-platform/references/cli-workflows.md` -> `iot-platform/references/resilience-guidance.md` |
+| Publish test telemetry to an OCI IoT twin                        | `iot-platform/SKILL.md` -> `iot-platform/references/cli-workflows.md` -> `iot-platform/templates/publish-curl.template.sh` |
+| Build a governed enterprise assistant                            | `enterprise-ai/SKILL.md` -> `enterprise-ai/agent-workflows/agent-tools.md` -> `enterprise-ai/data/rag-and-search.md` -> `enterprise-ai/governance/private-endpoints-and-governance.md` |
 
 ## Scope Boundaries
 
 - Keep OCI service, networking, IAM, agent hosting, and cost-estimation guidance in this domain.
+- Route Exadata Database Service Terraform configuration to `oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/`; it supports only Cloud Exadata Infrastructure, Cloud VM Clusters, DB Homes, Container Databases, and Pluggable Databases, and does not create IAM or network prerequisites.
 - Route OCI IoT domain, digital twin, adapter, device publish, raw command, and Data API workflows to `oci/iot-platform/`.
 - Route Oracle Database-owned implementation details to `db/features/`.
 - Route APEX artifact generation to `apex/apexlang/`.
@@ -134,6 +143,7 @@ The OKE operational skills include deterministic helper tools under `oci/oke/scr
 - https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengAttaching_Multiple_VNICs.htm
 - https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contenggrantingworkloadaccesstoresources.htm
 - https://github.com/oracle-terraform-modules/terraform-oci-oke
+- https://github.com/oci-landing-zones/terraform-oci-modules-oracle-database/tree/main/exadata-database
 - https://docs.oracle.com/en-us/iaas/Content/internet-of-things/home.htm
 - https://github.com/oracle-samples/oci-iot-samples
 - https://docs.oracle.com/en-us/iaas/Content/generative-ai/overview.htm

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/README.txt
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/README.txt
@@ -1,0 +1,105 @@
+Build OCI Exadata Database Terraform Skill
+===========================================
+
+This skill safely generates or updates Terraform root configuration for OCI
+Exadata Database Service on Dedicated Infrastructure by using only:
+https://github.com/oci-landing-zones/terraform-oci-modules-oracle-database/tree/main/exadata-database
+
+It supports Cloud Exadata Infrastructure, Cloud VM Clusters, DB Homes,
+Container Databases, and Pluggable Databases. It does not create IAM, VCN,
+subnet, route-table, gateway, NSG, or Object Storage prerequisite resources.
+For unsupported requests, it reports that the Terraform module is not
+supported instead of inventing an alternative.
+
+How this skill works
+--------------------
+
+1. Inspects the target Terraform project before making changes.
+2. Checks module.md to confirm the requested resource family is supported.
+3. Collects required inputs in infrastructure -> VM cluster -> DB home ->
+   container database -> PDB order, using input-collection.md.
+4. Treats network, security, and Object Storage requirements in reference.md
+   as non-blocking deployment context; it never creates or remediates them.
+5. Validates required and supplied configuration inputs with validation.md
+   through OCI MCP before producing usable Terraform configuration.
+6. Uses terraform-sources.md and main-tf-map.md to generate the smallest safe
+   configuration change.
+7. Does not run or install Terraform. It hands off terraform init, validate,
+   plan, and apply for the user to run; Terraform 1.5.0 or later is required,
+   and the plan must be reviewed before applying.
+
+
+How to use
+----------
+
+Unzip this folder and put the /references and SKILL.md in a folder named
+`build-oci-exadata-database-main-tf`.
+
+Load this skill into an agent whenever the use case is to create or update OCI
+Exadata Database Service on Dedicated Infrastructure Terraform using the
+`oci-landing-zones/terraform-oci-modules-oracle-database` repository's
+`exadata-database` folder. Typical requests include Cloud Exadata
+Infrastructure, Cloud VM Clusters, DB Homes, Container Databases, and
+Pluggable Databases.
+
+After loading, the agent reads `SKILL.md` first and follows its
+reference-routing workflow: confirm support, inspect the target, collect
+resource-specific inputs, ask about documented optional inputs, validate with
+OCI MCP, then generate the smallest safe Terraform change. The agent must not
+run or install Terraform, create prerequisite IAM or network resources, or
+place private keys, passwords, wallet secrets, or tokens in repository files.
+
+The skill is additive by default. It preserves existing project layout and
+does not modify Terraform state. Updates, moves, removals, recovery, and
+deletion requests require the additional lifecycle checks in
+lifecycle-safety.md. Exadata operations can take many hours; the user must
+review the Terraform plan before applying it.
+
+
+Reference files
+---------------
+
+module.md
+  The upstream support allowlist, exact module folder, supported resource
+  families, unsupported-capability response, and resource dependency model.
+
+reference.md
+  Informational deployment context for tenancy access, API-key authentication,
+  VCNs, client and backup subnets, security controls, and Object Storage
+  connectivity. These are not configuration-generation gates.
+
+input-collection.md
+  Module-specific input checklist and object-shape rules. Its sections cover
+  Cloud Exadata Infrastructure, Cloud VM Clusters, DB Homes, Container
+  Databases, and Pluggable Databases, including secret-handling requirements.
+
+terraform-sources.md
+  The canonical Git module source format, approved module folder, Terraform
+  version requirement, and integration rules for existing repositories or a
+  new minimal Terraform workspace.
+
+validation.md
+  The validation contract: mandatory OCI MCP checks, identifier validation,
+  dependency readiness, configuration scope, lifecycle validation, and secure
+  handling of credentials and passwords.
+
+main-tf-map.md
+  Rules for mapping validated values into main.tf, variables.tf, and
+  terraform.tfvars. It explains how to retain the Exadata Infrastructure ->
+  VM Cluster -> DB Home -> Container Database -> PDB dependency chain while
+  preserving repository conventions.
+
+lifecycle-safety.md
+  Additional guardrails for updates, moves, recovery, remove-from-
+  configuration, and deletes. It covers state ownership, dependencies,
+  immutable fields, and the required two-stage DB Home/database deletion flow.
+
+Quick reference flow
+--------------------
+
+request -> module.md -> relevant input-collection.md section + reference.md +
+terraform-sources.md -> validation.md -> main-tf-map.md -> generate safely
+
+For lifecycle changes, read lifecycle-safety.md before collecting inputs and
+apply its state-ownership requirements together with validation.md before
+proposing a configuration change.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/SKILL.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: build-oci-exadata-database-main-tf
+description: "Generate or update Terraform configuration only for OCI Exadata Database Service on Dedicated Infrastructure with the upstream `oci-landing-zones/terraform-oci-modules-oracle-database/tree/main/exadata-database` folder. Use for Cloud Exadata Infrastructure, Cloud VM Clusters, DB Homes, Container Databases, and Pluggable Databases. Validate only required and supplied inputs of the requested module objects through OCI MCP; never deploy, run Terraform, or gate configuration generation on operational deployment prerequisites. Explain relevant VCN, subnet, route, security-control, and Object Storage requirements as non-blocking deployment context only. Never create IAM or network prerequisite resources."
+---
+
+# Build OCI Exadata Database Terraform
+
+Generate Exadata resource configurations only. Default to additive-only changes. Never invent a module path, input name, resource model, or prerequisite value. Never create or remediate IAM, API keys, VCNs, subnets, route tables, gateways, NSGs, or Object Storage connectivity. Do create only the Exadata resource families supported by the module: Cloud Exadata Infrastructure, Cloud VM Clusters, DB Homes, Container Databases, and Pluggable Databases. Never mutate, replace, rename, move, or delete an existing resource unless the user explicitly and unambiguously requests that exact change. Never install or execute Terraform.
+
+## Required workflow
+
+1. Inspect the target before writing.
+   - Inspect the project root, Terraform files, provider/backend setup, established layout, and any existing module blocks.
+   - For an update, recovery, removal, or deletion, inspect accessible local Terraform state read-only for the exact state address. Never modify state or run Terraform state commands.
+   - Treat it as an existing project when a project or configuration is in scope. Otherwise ask for a target directory; do not hardcode one or overwrite unrelated files.
+   - Read [references/module.md](references/module.md) first. If the request is outside the module's five resource families, say: **"The Terraform module for `<capability>` is not supported by `oci-landing-zones/terraform-oci-modules-oracle-database/tree/main/exadata-database`."**
+   - Read [references/lifecycle-safety.md](references/lifecycle-safety.md) for any non-additive request.
+
+2. Collect inputs in dependency order.
+   - Read [references/reference.md](references/reference.md) before collecting inputs. Treat it as informational deployment context, not a generation gate.
+   - Validate only values supplied by, or required in, the requested module object. Never request VCN, subnet, route, NSG, or Object Storage values for a standalone `cloud_exadata_infrastructures_configuration`. Do not block generation for any operational deployment prerequisite that is not a requested-object input.
+   - Read the applicable sections in [references/input-collection.md](references/input-collection.md). Collect shared tenancy and compartment values first; collect VCN/subnet, subscription, and SSH-key values only for the resource families that use them, in infrastructure → VM cluster → DB home → database → PDB order.
+   - Read the upstream `SPEC.md` before writing any resource objects so the generated configuration matches the module's exact structure and nested attributes.
+   - Preserve literal OCIDs and map-key references. Do not infer an OCID, availability domain, database/GI/system version, capacity, or network topology.
+   - Ask whether the user wants documented optional inputs only after all required inputs are present. If declined, use documented defaults; never invent optional values.
+   - Treat database passwords, TDE wallet passwords, API private-key passwords, and remote-clone credentials as secrets. Do not place them in tracked files or echo them back; use a secure secret-injection mechanism already established by the project.
+   - Read [references/terraform-sources.md](references/terraform-sources.md) before writing a module block.
+
+3. Validate before producing usable configuration.
+   - Read [references/validation.md](references/validation.md) only after inputs are collected.
+   - Apply every non-placeholder rule. OCI MCP validation is mandatory: pause if the `get_oci_command_help` and `run_oci_command` OCI MCP tools are unavailable or cannot be invoked. Pause for a corrected value when an input is missing or known invalid. Do not claim OCI-side availability, quota, capacity, version compatibility, or IAM access has been verified unless it was actually verified through the required OCI MCP read.
+   - For an existing-resource mutation, require confirmed Terraform-state ownership before proposing it.
+4. Generate after validation succeeds.
+   - Read [references/main-tf-map.md](references/main-tf-map.md).
+   - In an existing project, preserve its layout, provider/backend blocks, naming, variables, and secret-handling approach. Make the smallest scoped change; do not add a duplicate module block.
+   - In a new project, create exactly `main.tf`, `variables.tf`, and `terraform.tfvars`. Include the OCI provider baseline and module block in `main.tf`; typed declarations in `variables.tf`; only validated non-secret literal values in `terraform.tfvars`. Never place Terraform functions, interpolations, traversals, or dynamic expressions (including `file()`, `templatefile()`, `${...}`, or `path.module`) in a `.tfvars` file. Resolve repository-local public-key files in `main.tf` with a local value or module-argument merge; make the corresponding variable attribute optional when that expression supplies it.
+   - Default the module source to `ref=main`. Use a release tag or commit SHA only when the user explicitly provides one; do not ask the user to approve the default.
+
+5. Hand off without execution.
+   - Tell the user this upstream module requires Terraform 1.5.0 or later.
+   - Provide, but never run: `terraform init`, `terraform validate`, `terraform plan`, and `terraform apply`.
+   - Explain that an Exadata operation can take many hours, and the plan must be reviewed before apply. The upstream documentation notes that a later apply may resume after certain transient provisioning conflicts; do not promise that it will.
+
+## Boundaries
+
+- Use only `git::https://github.com/oci-landing-zones/terraform-oci-modules-oracle-database.git//exadata-database?ref=<ref>` for the module source; default `<ref>` to `main` unless the user explicitly provides a release tag or commit SHA. Treat `https://github.com/oci-landing-zones/terraform-oci-modules-oracle-database/tree/main/exadata-database` as the canonical upstream folder path.
+- Support only Cloud Exadata Infrastructure, Cloud VM Clusters, DB Homes, Container Databases, and Pluggable Databases. Do not generate IAM, VCN, subnet, route-table, gateway, NSG, or Object Storage prerequisite resources. Do not substitute direct `oci_*` resources or a different module.
+- Do not run `terraform`, `tofu`, package-manager, provider-login, OCI write, or install commands.
+- Do not create, modify, replace, move, delete, import, or unlock Terraform state; do not create a lock file or `.terraform` directory.
+- Do not put private-key material, passwords, tokens, or wallet secrets in `terraform.tfvars`, examples, or repository files.
+
+## Reference routing
+
+| Need at this stage | Read |
+| --- | --- |
+| Confirm supported capabilities and module contract | [module.md](references/module.md) |
+| Confirm deployment prerequisites and network baseline | [reference.md](references/reference.md) |
+| Collect resource-family inputs | [input-collection.md](references/input-collection.md) |
+| Update, remove, recover, or destroy a resource | [lifecycle-safety.md](references/lifecycle-safety.md) |
+| Create the source, provider, or minimal project baseline | [terraform-sources.md](references/terraform-sources.md) |
+| Validate values and dependencies | [validation.md](references/validation.md) |
+| Map validated values to Terraform files | [main-tf-map.md](references/main-tf-map.md) |

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/agents/openai.yaml
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Build OCI Exadata main.tf"
+  short_description: "Generate OCI Exadata Database Terraform"
+  default_prompt: "Use $build-oci-exadata-database-main-tf to create validated Terraform root files for OCI Exadata Database Service."

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/references/input-collection.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/references/input-collection.md
@@ -1,0 +1,86 @@
+# Exadata input collection
+
+Read the section for every requested resource family, in order. Confirm the approved upstream pin and consult `SPEC.md` for the full object type before generating advanced options.
+
+All top-level module inputs are optional (`null` or a documented default). The tables below distinguish the attributes Terraform requires *when a corresponding configuration object is supplied*. “Conditional” means required by the workflow or relevant source mode, rather than by the static object type alone.
+
+## Top-level module inputs
+
+| Input | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `cloud_exadata_infrastructures_configuration` | No | `null` | Cloud Exadata Infrastructure configuration object containing the `cloud_exadata_infrastructures` map. |
+| `cloud_vm_clusters_configuration` | No | `null` | Cloud VM Cluster map. |
+| `cloud_db_homes_configuration` | No | `null` | DB Home map. |
+| `databases_configuration` | No | `null` | Container Database map. |
+| `pluggable_databases_configuration` | No | `null` | Pluggable Database map. |
+| `default_compartment_id` | Conditional | `null` | Default compartment; provide it or a resource-level `compartment_id`. |
+| `compartments_dependency` | No | `null` | Map of externally managed compartment objects containing `id`. |
+| `network_dependency` | Conditional | `null` | Supply when using subnet or NSG keys instead of literal OCIDs. |
+| `subscription_dependency` | Conditional | `null` | Supply when using subscription keys instead of literal IDs. |
+| `default_defined_tags` / `default_freeform_tags` | No | `{}` | Default tags. |
+| `module_name` | No | `"exadata-cloud-service"` | Module identifier. |
+| `enable_output` | No | `true` | Enable outputs. |
+
+## Shared prerequisites
+
+Use the OCI provider authentication variables used by the existing project. For a new API-key-authenticated project: `tenancy_ocid`, `user_ocid`, `fingerprint`, `private_key_path`, and `region`. Never collect private-key contents.
+
+Collect one of `default_compartment_id` or a per-resource `compartment_id`, as a literal OCID or `compartments_dependency` key. For Exadata resources, prefer an actual `ocid1.compartment...` value for `compartment_id`; a tenancy OCID does not satisfy the module's compartment check for Exadata infrastructure or VM clusters. For VM clusters, collect a client `subnet_id` and `backup_subnet_id` as literal OCIDs or `network_dependency.subnets` keys. `ssh_public_keys` must be a non-empty `list(string)`. A `.tfvars` file may contain a literal public-key string, but never `file()`, `${path.module}`, or any other Terraform expression. When a user supplies a key outside the repository, copy the public key into a distinct repo-local file and resolve it with `file("${path.module}/...")` in `main.tf` through a local value or module-argument merge; make the raw variable attribute optional if it is omitted from `.tfvars`. Do not reference external absolute paths such as `Downloads`, because the Terraform execution environment may not be permitted to read them. A dependency object must contain its literal `id`.
+
+Ask for tags only after the required topology is known. `subscription_id` may be a literal or a `subscription_dependency` key when the documented resource supports it.
+
+## Required object shape
+
+Generate each configuration object in the module's dependency order and keep the nested structure intact:
+
+- `cloud_exadata_infrastructures_configuration.cloud_exadata_infrastructures`
+- `cloud_vm_clusters_configuration`
+- `cloud_db_homes_configuration`
+- `databases_configuration`
+- `pluggable_databases_configuration`
+
+Do not flatten a top-level object into a bare map when generating Terraform.
+
+## Cloud Exadata Infrastructure
+
+Collect one top-level `cloud_exadata_infrastructures_configuration` object containing a `cloud_exadata_infrastructures` map. For each map key inside `cloud_exadata_infrastructures`, require `display_name` and `shape`. Current allowed shapes: `Exadata.X11M`, `Exadata.X9M`, and `Exadata.X8M`. Collect compartment, availability domain, compute/storage counts, customer contact, server types, subscription, tags, and maintenance window only when requested.
+
+| Required attributes | Optional attributes |
+| --- | --- |
+| `display_name`, `shape` | `compartment_id`, `availability_domain`, `compute_count`, `customer_contacts.email`, `database_server_type`, `storage_count`, `storage_server_type`, `subscription_id`, `defined_tags`, `freeform_tags`, `maintenance_window`, `default_maintenance_window` |
+
+## Cloud VM Cluster
+
+For each map key, require `backup_subnet_id`, `cpu_core_count`, `display_name`, `gi_version`, `hostname`, `ssh_public_keys`, and `subnet_id`. Collect an Exadata Infrastructure OCID or local map key, sizing, storage/server selection, NSGs, version, license, backup, filesystem, automation, tags, and subscription inputs only when requested. The client and backup subnets are baseline prerequisites and must already be OCI MCP-validated before this resource is generated.
+
+| Required attributes | Optional attributes |
+| --- | --- |
+| `backup_subnet_id`, `cpu_core_count`, `display_name`, `gi_version`, `hostname`, `ssh_public_keys`, `subnet_id` | `exadata_infrastructure_id`, `compartment_id`, `backup_network_nsg_ids`, `cloud_automation_update_details`, `cluster_name`, `data_collection_options`, `data_storage_percentage`, `data_storage_size_in_tbs`, `db_node_storage_size_in_gbs`, `db_servers`, `defined_tags`, `freeform_tags`, `domain`, `file_system_configuration_details`, `is_local_backup_enabled`, `is_sparse_diskgroup_enabled`, `license_model`, `memory_size_in_gbs`, `nsg_ids`, `ocpu_count`, `private_zone_id`, `scan_listener_port_tcp`, `scan_listener_port_tcp_ssl`, `security.zpr_attributes`, `subscription_id`, `system_version`, `time_zone`, `vm_cluster_type` |
+
+## DB Home
+
+For every DB-home map key, collect the VM-cluster OCID or map key and the DB-home source. The documented default source is `VM_CLUSTER_NEW`; allowed values include `NONE`, `DB_BACKUP`, and `VM_CLUSTER_NEW`. Collect DB version, display name, software image, KMS settings, backup/restore details, tags, and auditing options only when needed. If the nested `database` object is used, its `admin_password` is required and secret.
+
+| Required attributes | Optional attributes |
+| --- | --- |
+| None at the DB-home object level | `compartment_id`, `database_software_image_id`, `db_system_id`, `db_version`, `defined_tags`, `display_name`, `enable_database_delete`, `freeform_tags`, `is_desupported_version`, `is_unified_auditing_enabled`, `kms_key_id`, `kms_key_version_id`, `source` (default `VM_CLUSTER_NEW`), `vm_cluster_id`, `database` |
+
+When `database` is supplied, require `database[*].admin_password` through secure injection. Its optional fields are `backup_id`, `backup_tde_password`, `character_set`, `database_id`, `database_software_image_id`, `db_backup_config`, `db_name`, `db_workload`, tags, encryption-key details, key-store/KMS values, `ncharacter_set`, `pdb_name`, `pluggable_databases`, `sid_prefix`, source encryption-key details, `tde_wallet_password`, point-in-time recovery timestamp, and `vault_id`.
+
+## Container Database
+
+For each database map key, require `db_home_id`, `source`, and a `database` object with `admin_password` and `db_name`. The upstream `SPEC.md` declares `databases_configuration[*].source` as a required string; the upstream `README.md` specifies `NONE`, `DB_BACKUP`, and `DATAGUARD`, with `NONE` as the default for a new container database. Do not use the DB Home-specific `VM_CLUSTER_NEW` value for a CDB. For `cloud_db_homes_configuration[*].source`, the upstream spec documents `NONE`, `DB_BACKUP`, and `VM_CLUSTER_NEW`, with a default of `VM_CLUSTER_NEW`. Collect source-specific restore or Data Guard fields only for the selected source. Collect backup policy, character sets, KMS/Vault, initial PDB, and tags only when relevant.
+
+| Required attributes | Optional attributes |
+| --- | --- |
+| `db_home_id`, `source`, `database.admin_password` (secret), `database.db_name` | Top-level: `key_store_id`, `db_version`, `kms_key_id`, `kms_key_version_id`. Database: `backup_id`, `backup_tde_password`, `character_set`, `database_admin_password`, `database_software_image_id`, `db_backup_config`, `db_unique_name`, `db_workload`, tags, encryption-key details, `freeform_tags`, `is_active_data_guard_enabled`, KMS/key-store values, `ncharacter_set`, `pdb_name`, `pluggable_databases`, `protection_mode`, `sid_prefix`, source-database/encryption/wallet values, `tde_wallet_password`, `transport_type`, `vault_id` |
+
+## Pluggable Database
+
+For each PDB map key, require `container_database_id` and `pdb_name`. Collect PDB creation details only for clone/refresh workflows. `pdb_admin_password`, container admin password, and TDE wallet password are secrets and must use secure injection.
+
+| Required attributes | Optional attributes |
+| --- | --- |
+| `container_database_id`, `pdb_name` | `container_database_admin_password`, `defined_tags`, `freeform_tags`, `kms_key_version_id`, `pdb_admin_password`, `pdb_creation_type_details`, `should_create_pdb_backup`, `should_pdb_admin_account_be_locked`, `tde_wallet_password` |
+
+When `pdb_creation_type_details` is supplied, require its `creation_type` and `source_pluggable_database_id`; its remaining clone and refresh attributes are optional.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/references/lifecycle-safety.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/references/lifecycle-safety.md
@@ -1,0 +1,69 @@
+# Exadata lifecycle safety
+
+Use this reference for every update, remove-from-configuration, delete, move, recovery, or replacement request. This module uses Terraform's standard declarative state reconciliation: change configuration, inspect the resulting plan, then apply only after the user approves. Never run Terraform commands for the user.
+
+## State ownership gate
+
+Before proposing any lifecycle mutation:
+
+1. Require the user to name the exact object, its logical map key, and intended change.
+2. Inspect accessible local Terraform state read-only and identify the exact state address. Configuration presence alone does not establish Terraform ownership.
+3. Require the exact object to exist at that address. If no local state is accessible, ask the user to confirm the address through their approved state-inspection process.
+4. Validate an existing OCI resource's literal ID and lifecycle state through OCI MCP, as required by `validation.md`.
+
+If state ownership, resource identity, or readiness cannot be confirmed, stop. Do not import, adopt, recreate, replace, move state, or edit a state file as a workaround.
+
+## Updates
+
+Treat updates as a deliberate configuration change followed by Terraform reconciliation:
+
+1. Change only the documented input or module parameter for the confirmed object.
+2. Re-check the approved upstream module specification and provider documentation to determine whether the field is in-place, forces replacement, or is immutable.
+3. Preserve stable map keys and all unrelated configuration. A map-key change alters a Terraform address; never present it as an in-place update.
+
+Examples that may be supported only when the approved module/provider accepts them include VM-cluster compute or storage scaling, adding a child resource such as a PDB, and updating mutable tags or display names. Do not promise in-place behavior before confirming it at the approved module/provider version.
+
+The upstream module documents these as not updatable after creation:
+
+| Resource | Do not treat as in-place |
+| --- | --- |
+| Cloud VM Cluster | `gi_version`, `system_version`, `defined_tags` |
+| DB Home | `db_version`, `database_software_image_id` |
+| Container Database | `db_home_id`, `db_version`, `database.admin_password` |
+
+## Delete and remove-from-configuration
+
+- Treat removing a map entry from the module configuration as a requested Terraform destroy, not source-code cleanup.
+- Require explicit confirmation of the exact logical key, state address, OCI ID, and intended deletion before removing it.
+- Trace dependent references first. Removing an infrastructure, VM cluster, DB Home, CDB, or PDB can affect all downstream entries in the infrastructure → VM cluster → DB home → CDB → PDB chain.
+- For DB Home/database deletion, use this required two-stage sequence only after the user explicitly confirms the exact DB Home/database scope:
+  1. Retain the confirmed DB Home entry in configuration and set its documented `enable_database_delete = true` option. The user must run and review an isolated `terraform plan`, then run `terraform apply` themselves to persist that lifecycle setting.
+  2. Remove only the confirmed DB Home entry from configuration. This is the Terraform destroy request. The user must again run and review `terraform plan`, confirm that it shows only the intended destroy, then run `terraform apply` themselves.
+  Do not combine these stages, and never run either command for the user.
+- Do not use a replacement resource to bypass a failed deletion. Do not delete baseline IAM/network resources; they are outside this skill.
+
+## Move and rename
+
+First distinguish the requested operation:
+
+- **OCI relocation** (for example, changing compartment, region, availability domain, VCN/subnet, or parent resource): do not assume it is supported. Confirm the exact resource's documented move capability and lifecycle impact at the approved module/provider version. If unsupported, report that this module cannot perform the requested move.
+- **Terraform address refactor** (for example, changing a module path or map key): require exact current and destination state addresses. Use a documented Terraform `moved` block only when the user explicitly requests this refactor and the mapping is one-to-one; never run `terraform state mv` or any state command.
+- **Display-name change:** treat it as an update only after confirming the field is mutable; do not rename a logical map key merely to match it.
+
+## Required user-facing handoff
+
+For every lifecycle mutation, state:
+
+- exact object(s), logical key(s), OCI ID(s), and state address(es) expected to change;
+- whether the expected action is update, replacement, destroy, Terraform-address move, or unsupported OCI move;
+- dependent Exadata resources and operational prerequisites;
+- that the user must review `terraform plan` before `terraform apply`.
+
+Provide, but never execute:
+
+```bash
+terraform init
+terraform validate
+terraform plan
+terraform apply
+```

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/references/main-tf-map.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/references/main-tf-map.md
@@ -1,0 +1,101 @@
+# File mapping
+
+## Module block
+
+Use one block, with only the requested configuration inputs and dependency maps. Keep the Exadata Infrastructure input as the full top-level object, not a flattened map:
+
+```hcl
+module "exadata_database" {
+  source = "git::https://github.com/oci-landing-zones/terraform-oci-modules-oracle-database.git//exadata-database?ref=main"
+
+  default_compartment_id                      = var.default_compartment_id
+  compartments_dependency                     = var.compartments_dependency
+  network_dependency                          = var.network_dependency
+  subscription_dependency                     = var.subscription_dependency
+  cloud_exadata_infrastructures_configuration = var.cloud_exadata_infrastructures_configuration
+  cloud_vm_clusters_configuration             = var.cloud_vm_clusters_configuration
+  cloud_db_homes_configuration                = var.cloud_db_homes_configuration
+  databases_configuration                     = var.databases_configuration
+  pluggable_databases_configuration           = var.pluggable_databases_configuration
+}
+```
+
+Confirm every selected argument against the approved revision's `variables.tf`; the example is a wiring pattern, not permission to include unavailable values.
+
+For `cloud_exadata_infrastructures_configuration`, preserve the nested object shape from the upstream module contract:
+
+```hcl
+cloud_exadata_infrastructures_configuration = {
+  cloud_exadata_infrastructures = {
+    EXAINFRA = {
+      display_name = "..."
+      shape        = "Exadata.X11M"
+    }
+  }
+}
+```
+
+For the full Exadata chain, preserve the nested object and map structure for each layer:
+
+```hcl
+cloud_vm_clusters_configuration = {
+  EXAVM = {
+    exadata_infrastructure_id = "EXAINFRA"
+    backup_subnet_id          = "ocid1.subnet..."
+    cpu_core_count            = 8
+    display_name              = "..."
+    gi_version                = "..."
+    hostname                  = "..."
+    ssh_public_keys           = ["<literal-public-key>"]
+    subnet_id                 = "ocid1.subnet..."
+  }
+}
+
+cloud_db_homes_configuration = {
+  EXADBHOME = {
+    vm_cluster_id = "EXAVM"
+    source        = "VM_CLUSTER_NEW"
+  }
+}
+
+databases_configuration = {
+  EXACDB = {
+    db_home_id = "EXADBHOME"
+    source     = "NONE"
+    database = {
+      admin_password = "<secret>"
+      db_name        = "..."
+    }
+  }
+}
+
+pluggable_databases_configuration = {
+  EXAPDB = {
+    container_database_id = "EXACDB"
+    pdb_name              = "..."
+  }
+}
+```
+
+## Files
+
+- `main.tf`: Terraform and OCI provider blocks, the module source/wiring, and no secret values.
+- `variables.tf`: typed module inputs copied from the approved upstream `variables.tf` only as needed. Mark secret variables `sensitive = true`.
+- `terraform.tfvars`: validated non-secret literal OCIDs, map keys, region, topology, shapes, tags, and optionally literal public keys. Never include Terraform expressions or functions such as `file()`, `${...}`, `path.module`, or `templatefile()`, or include private-key contents, passwords, TDE wallet values, or tokens.
+
+## Repository-local SSH public-key files
+
+When resolving a repo-local SSH public-key file, keep the expression in `main.tf`, not `terraform.tfvars`. If the input variable otherwise requires `ssh_public_keys`, declare it optional with an empty-list default and merge the resolved key into the matching VM-cluster object at module wiring:
+
+```hcl
+cloud_vm_clusters_configuration = {
+  for key, cluster in var.cloud_vm_clusters_configuration :
+  key => key == "VM_CLUSTER_KEY" ? merge(cluster, {
+    ssh_public_keys = [trimspace(file("${path.module}/ssh-keys/example_public.pem"))]
+  }) : cluster
+}
+```
+
+Use the actual stable VM-cluster key and verified repository-relative path; do not invent either value.
+
+For the Exadata dependency chain, retain stable local keys from Exadata Infrastructure to VM Cluster to DB Home to CDB to PDB. Do not hardcode a guessed OCID. Do not generate the prerequisite network or IAM resources; the client/backup subnets and associated connectivity must already satisfy `reference.md`.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/references/module.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/references/module.md
@@ -1,0 +1,33 @@
+# Upstream Exadata Database module
+
+Source repository: `https://github.com/oci-landing-zones/terraform-oci-modules-oracle-database`
+
+Canonical upstream folder: `https://github.com/oci-landing-zones/terraform-oci-modules-oracle-database/tree/main/exadata-database`
+
+Exact supported submodule: `exadata-database`.
+
+Upstream revision used when this skill was created: `e587bbbaf0bcc3635d2789c965d4ec8d05e40877`. Re-check the current `README.md`, `SPEC.md`, and `variables.tf` at the user's approved pin before emitting any input not covered here.
+
+## Supported resource families
+
+| Capability | Module input | Dependency order |
+| --- | --- | --- |
+| Cloud Exadata Infrastructure | `cloud_exadata_infrastructures_configuration` | 1 |
+| Cloud VM Cluster | `cloud_vm_clusters_configuration` | 2 |
+| DB Home | `cloud_db_homes_configuration` | 3 |
+| Container Database | `databases_configuration` | 4 |
+| Pluggable Database | `pluggable_databases_configuration` | 5 |
+
+The skill may use `compartments_dependency`, `subscription_dependency`, `network_dependency`, `default_compartment_id`, default tags, `module_name`, and `enable_output` as documented. It must not generate prerequisite IAM or network resources.
+
+## Unsupported request handling
+
+Reject a requested feature that cannot be expressed by these documented inputs or requires a separate upstream module. Use this exact pattern:
+
+> The Terraform module for `<capability>` is not supported by `oci-landing-zones/terraform-oci-modules-oracle-database/tree/main/exadata-database`, so I cannot generate a module block for it.
+
+If a request mixes supported and unsupported work, ask whether to continue with the supported portion only.
+
+## Dependency model
+
+OCID-valued inputs can be literal OCIDs or keys into dependency maps. A VM Cluster can refer to an Exadata Infrastructure key; a DB Home to a VM-cluster key; a database to a DB-home key; and a PDB to a database key. Preserve those keys exactly and do not replace a declared key with a guessed OCID.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/references/reference.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/references/reference.md
@@ -1,0 +1,27 @@
+# Exadata deployment context
+
+Source: [upstream Exadata Database module folder](https://github.com/oci-landing-zones/terraform-oci-modules-oracle-database/tree/main/exadata-database).
+
+Read this before collecting module inputs. These are operational deployment prerequisites, not optional Terraform configuration values. Mention them only as non-blocking context; validate through OCI MCP only IDs supplied by or required in the requested module object. Never block configuration generation because an operational prerequisite is absent or cannot be verified. This skill never creates, remediates, or deploys prerequisites.
+
+## Tenancy access and authentication
+
+- Require an active OCI tenancy and IAM permissions sufficient to create the requested database resources. See [Exadata Cloud Service IAM policies](https://docs.oracle.com/en-us/iaas/exadatacloud/doc/ecs-policy-details.html).
+- Require configured OCI API-key authentication. The user must create and retain their RSA private key securely; reference only its local path and never place key contents or its password in Terraform files. See [OCI Terraform provider authentication preparation](https://docs.oracle.com/en-us/iaas/Content/dev/terraform/tutorials/tf-provider.htm#prepare).
+
+## Network deployment context
+
+- Before deploying an Exadata Cloud Service environment, ensure a VCN exists in the target region. It may be created through the [OCI Core Landing Zone Exadata VCN template](https://github.com/oci-landing-zones/terraform-oci-core-landingzone/tree/main/templates/standalone-three-tier-vcn-custom) or the [OCI Console VCN workflow](https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/create_vcn.htm#top).
+- Before deploying an environment with a VM Cluster, ensure two available subnets exist: a **client subnet** for database client connections and a **backup subnet** for Object Storage and backup operations.
+- Prefer private subnets. Confirm the supplied subnets are appropriate for the target Exadata availability domain, have valid route tables, and have security lists or NSGs covering the required ingress and egress.
+- Require a route from the attached subnet to OCI Object Storage for backups and wallet access. Use a [Service Gateway](https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/servicegateway.htm) for private access, or an [Internet Gateway](https://docs.oracle.com/en-us/iaas/Content/Network/Tasks/managingIGs.htm) only when the network design calls for public access.
+
+## Required OCI MCP checks
+
+Before generation, use OCI MCP to validate supplied tenancy/compartment IDs and all supplied optional IDs. Validate VCN, subnet, and NSG IDs only when they are inputs to the requested configuration object, such as a VM Cluster. Do not infer route-table, gateway, security-list, or NSG configuration from a supplied subnet ID: inspect it with the applicable read-only OCI MCP commands or ask the user for the approved network evidence.
+
+## Configuration input failure response
+
+If a required configuration input is missing or unusable, stop before writing Terraform and use this pattern:
+
+> I cannot generate the requested Exadata configuration yet. The following required configuration inputs are missing or unusable: `<list only missing or invalid inputs for the requested module object>`. This skill does not create, remediate, or deploy resources.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/references/terraform-sources.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/references/terraform-sources.md
@@ -1,0 +1,21 @@
+# Terraform source and project integration
+
+## Canonical source
+
+Use this exact module source:
+
+```hcl
+source = "git::https://github.com/oci-landing-zones/terraform-oci-modules-oracle-database.git//exadata-database?ref=<release-tag-or-commit-sha>"
+```
+
+Default to `ref=main`. Use a release tag or immutable commit SHA only when the user explicitly provides one; do not request approval for `main`. The upstream module currently requires Terraform `>= 1.5.0`.
+
+Canonical upstream folder path for this skill: `https://github.com/oci-landing-zones/terraform-oci-modules-oracle-database/tree/main/exadata-database`.
+
+## Existing project
+
+Reuse compatible existing OCI providers, aliases, required-provider constraints, backend, variables, module naming, and secret-injection approach. Do not add a duplicate provider, backend, or Exadata module block. Extend the existing module's configuration object when it already manages the requested resource family.
+
+## New project baseline
+
+Create only `main.tf`, `variables.tf`, and `terraform.tfvars` in the user-selected directory. Use the existing project's authentication method where available; otherwise use an API-key provider baseline. Keep private key paths—not contents—in variables. Omit `private_key_password` and all database, wallet, or clone secrets from `terraform.tfvars`; declare them sensitive and document the chosen secure injection path.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/references/validation.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-exadata-database-skill/references/validation.md
@@ -1,0 +1,109 @@
+# Validation contract
+
+Read only after all required inputs and optional choices are collected. Never generate usable configuration with a missing, `null`, empty, malformed, unresolved, or known-invalid supplied value.
+
+## Contents
+
+- OCI MCP is mandatory
+- Common input rules and identifier validation matrix
+- Dependency readiness
+- Baseline prerequisite gate
+- DB Home
+- Container Database
+- Pluggable Database
+- Lifecycle gate
+
+## OCI MCP is mandatory
+
+Before any OCI-dependent validation, inspect the available tool inventory for both OCI MCP tools: `get_oci_command_help` and `run_oci_command`. If either tool is absent or cannot be invoked, stop and tell the user that OCI MCP validation is required for this skill and is unavailable. Do not fall back to the local OCI CLI, shell commands, provider data sources, guesses, or unverified configuration.
+
+For every OCI API call:
+
+1. Call `get_oci_command_help` for the exact command before its first use in the request.
+2. Call `run_oci_command` with only the text after `oci`; never pass `oci`, `--profile`, `--auth`, credentials, or write flags.
+3. Treat a successful response for the exact supplied ID as valid. Treat not found, forbidden, authentication failure, a different returned ID, or a service error as a validation failure. Stop and ask for corrected ID/access.
+4. Preserve map-key references. Validate an internal map key structurally; validate an external dependency key's resolved literal `id` through OCI MCP.
+
+## Common input rules
+
+- Validate every required attribute for every supplied map entry: it must be present and non-null. String values must also be non-empty; lists must be non-empty where required.
+- Validate every optional attribute that is supplied: it must be non-null and match its declared type, enum, format, and source-specific constraints. Do not silently omit an invalid optional value.
+- Require an effective compartment for every resource: `default_compartment_id` or a supplied resource-level `compartment_id`. A tenancy is the root compartment; validate its OCID and every other compartment OCID with `iam compartment get --compartment-id <OCID>`.
+- Validate literal OCIDs with the resource-specific OCI MCP command. Validate a dependency key by confirming it exists, has a non-empty `id`, and then validating that resolved ID with the same command.
+- Validate module-local DB Home → CDB → PDB references against the corresponding declared configuration map. Do not call OCI MCP for a resource that this database-layer configuration will create in the same apply.
+- Treat passwords and credentials as secrets. Never request their plaintext, put them in files, or send them to OCI MCP. Confirm only secure injection and validate their policy constraints without exposing their value.
+
+## OCI identifier validation matrix
+
+| Supplied value | Required OCI MCP read |
+| --- | --- |
+| Tenancy, `default_compartment_id`, `compartment_id`, `compartments_dependency[*].id` | `iam compartment get --compartment-id <OCID>` |
+| Client/backup subnet, `network_dependency.subnets[*].id` | `network subnet get --subnet-id <OCID>` |
+| NSG IDs, `network_dependency.network_security_groups[*].id` | `network nsg get --network-security-group-id <OCID>` |
+| Literal existing Exadata Infrastructure ID | `db cloud-exa-infra get --cloud-exa-infra-id <OCID>` |
+| Literal existing VM Cluster ID | Confirm current syntax with `get_oci_command_help` for `db vm-cluster get`, then read that exact ID. |
+| Literal existing DB Home ID | Confirm current syntax with `get_oci_command_help` for `db home get`, then read that exact ID. |
+| Literal existing Container Database ID | Confirm current syntax with `get_oci_command_help` for `db database get`, then read that exact ID. |
+| Literal existing Pluggable Database ID | Confirm current syntax with `get_oci_command_help` for `db pluggable-database get`, then read that exact ID. |
+| KMS key/key-version, Vault, backup, source database, or clone source ID | Confirm the resource's current OCI CLI get command through `get_oci_command_help`, then read the exact ID. |
+| Subscription ID or dependency ID | Confirm the currently supported subscription read/list command with `get_oci_command_help`; validate that the exact supplied ID belongs to the authenticated tenancy/region. |
+
+## Dependency readiness
+
+A successful get call proves only that an ID exists. Before a resource can be used by a downstream resource, its OCI MCP get response must also show that it is usable.
+
+| Downstream configuration | Referenced resource | Required validation |
+| --- | --- | --- |
+| Existing VM Cluster used by a DB Home | Its existing Cloud Exadata Infrastructure | `db cloud-exa-infra get` must return the exact ID with `lifecycle_state` (or `lifecycleState`) equal to `AVAILABLE`. |
+| Existing VM Cluster used by a DB Home | Existing Cloud Exadata Infrastructure | Resolve the VM Cluster through OCI MCP; its referenced Exadata Infrastructure must also resolve and be `AVAILABLE`. |
+| `cloud_db_homes_configuration[*].vm_cluster_id` or `db_system_id` | Existing VM Cluster | Its OCI MCP get response must return the exact ID in `AVAILABLE`. |
+| `databases_configuration[*].db_home_id` | Existing DB Home | Its OCI MCP get response must return the exact ID in `AVAILABLE`. |
+| `pluggable_databases_configuration[*].container_database_id` | Existing Container Database | Its OCI MCP get response must return the exact ID in `AVAILABLE`. |
+| Clone, backup, Vault, KMS, subscription, or network reference | Existing external resource | Use its documented read response to confirm the exact ID and its service-specific ready/usable state before using it. |
+
+Apply this distinction to every reference:
+
+- **Literal OCID or external dependency key:** resolve it through OCI MCP and require the listed usable state. Reject `CREATING`, `PROVISIONING`, `UPDATING`, `TERMINATING`, `TERMINATED`, `FAILED`, `INACTIVE`, or any state other than the required ready state. If the response does not contain a lifecycle/availability field, do not assume readiness; obtain the resource's current documented readiness signal through OCI MCP or stop.
+- **Module-local map key:** permit it for the Exadata Infrastructure → VM Cluster → DB Home → CDB → PDB chain. Require the producer key to exist in the current configuration, retain the module's built-in key reference (never replace it with an OCID), and ensure it precedes the consumer. Terraform will then create the ordering edge in the same apply.
+- **External module or remote Terraform output:** resolve the resulting literal ID and apply the same OCI MCP existence-and-readiness check as for a literal OCID.
+- **Mismatch:** if the resource exists but is not usable, stop and tell the user which reference is not ready. Do not generate a workaround, bypass the dependency, or promise a retry will succeed.
+
+## Configuration validation scope
+
+- Before generating a standalone `cloud_exadata_infrastructures_configuration`, validate its supplied tenancy/IAM authentication, compartment, availability domain, and requested service shape/capacity where OCI exposes a read-only validation. Do not require, collect, or validate VCN, subnet, route, NSG, or Object Storage identifiers: they are not inputs to the infrastructure object.
+- Before generating `cloud_vm_clusters_configuration`, validate its required and supplied configuration inputs, including client/backup subnet and NSG IDs where supplied. Do not require route, gateway, security-control, or Object Storage readiness evidence beyond the IDs represented in the object.
+- Before creating a DB Home, require a VM Cluster reference. For a literal OCID or external dependency key, OCI MCP must confirm the resolved VM Cluster is `AVAILABLE`; for a module-local VM Cluster map key, require the producer key to exist in the current configuration.
+- Before creating database-layer resources, validate their supplied configuration inputs and references. Do not request or validate operational identifiers that are not inputs to the requested object.
+- Treat deployment prerequisites described in `reference.md` as informational only; do not block configuration generation on them.
+
+## DB Home
+
+For every `cloud_db_homes_configuration` entry:
+
+- Validate every supplied optional field as non-null and type-correct. For the normal `VM_CLUSTER_NEW` path, accept `vm_cluster_id` as a module-local VM Cluster map key or as a literal/external dependency reference. Require the producer map key to exist in the current configuration; for a literal or external dependency reference, require OCI MCP to confirm the resolved VM Cluster is `AVAILABLE`.
+- Validate supplied `compartment_id`, `db_system_id`, `database_software_image_id`, `kms_key_id`, `kms_key_version_id`, backup IDs, Vault IDs, and every other literal OCI reference through their dynamically confirmed OCI MCP get command.
+- Validate `source` as `NONE`, `DB_BACKUP`, or `VM_CLUSTER_NEW`; enforce source-specific input combinations using the approved upstream `SPEC.md` and provider help.
+- When `database` is supplied, require its `admin_password` to be securely injected. Validate supplied DB names, versions, character sets, backup settings, KMS/encryption references, and all nested optional fields against the approved module/provider contract.
+
+## Container Database
+
+For every `databases_configuration` entry:
+
+- Require non-null, non-empty `db_home_id`, `source`, `database.admin_password`, and `database.db_name`. Do not expose the password; confirm secure injection and the documented password-policy compliance.
+- Validate `db_home_id` as an internal DB-home key or an OCI MCP-validated literal DB Home ID in `AVAILABLE` state. Validate `source` and all source-specific restore/Data Guard combinations through the approved module/provider contract.
+- Require `database.db_name` to start with a letter, contain only letters, digits, or underscores, and be at most 8 characters.
+- Validate all supplied optional top-level and nested values. In particular, validate literal backup, source-database, KMS, key-version, key-store, Vault, and encryption-location identifiers with OCI MCP; validate booleans, backup-policy enums, character sets, tags, and names locally against the documented contract.
+
+## Pluggable Database
+
+For every `pluggable_databases_configuration` entry:
+
+- Require non-null, non-empty `container_database_id` and `pdb_name`.
+- Validate `container_database_id` as an internal database key or an OCI MCP-validated literal Container Database ID in `AVAILABLE` state. Validate every supplied `kms_key_version_id` and clone-source ID through OCI MCP.
+- Validate `pdb_name` against the provider's current naming rule through approved documentation/help before generation. Reject a PDB name that equals its container database name when both are known.
+- When `pdb_creation_type_details` is supplied, require non-null `creation_type` and `source_pluggable_database_id`; validate the source PDB through OCI MCP and validate all clone/refresh options against the approved contract.
+- Do not expose `container_database_admin_password`, `pdb_admin_password`, TDE-wallet, or database-link secrets. Confirm secure injection and documented password policy instead.
+
+## Lifecycle gate
+
+For an update, deletion, recovery, or replacement, inspect accessible local Terraform state read-only and require the exact address to exist. Then validate the resource's literal OCI ID using the matching OCI MCP get command before proposing the change. If state ownership or the OCI read cannot be confirmed, stop. Do not import, adopt, replace, or alter state.


### PR DESCRIPTION
## Summary

Adds the **OCI Exadata Database Landing Zones Terraform skill**.

The skill supports safe, module-constrained Terraform configuration for OCI Exadata Database Service on Dedicated Infrastructure across its complete dependency chain:

* **Cloud Exadata Infrastructure**
* **Cloud VM Clusters**
* **DB Homes**
* **Container Databases (CDBs)**
* **Pluggable Databases (PDBs)**

It strictly uses `oci-landing-zones/terraform-oci-modules-oracle-database/tree/main/exadata-database`, preserves existing repository patterns, and validates configuration via OCI MCP. It explicitly avoids local Terraform execution, managing prerequisite infrastructure (networking, IAM, Object Storage), or committing secrets and passwords to repository files.

---

## Changes

* ** Includes `SKILL.md` along with reference documentation (`module.md`, `reference.md`, `input-collection.md`, `terraform-sources.md`, `validation.md`, `main-tf-map.md`, and `lifecycle-safety.md`).
* **Establish lifecycle & safety guardrails:** Enforces sequential resource ordering, immutable field validation, state-ownership checks, a mandatory two-stage DB Home/database deletion flow, and user warnings for long-running Exadata operations.

---

## Capabilities & Scope Boundaries

* **In Scope:** Generating or updating configurations for Exadata Infrastructure, Cloud VM Clusters, DB Homes, CDBs, and PDBs.
* **Explicitly Out of Scope:** Local execution (`terraform init/plan/apply` — requires Terraform 1.5.0+), creating prerequisite network resources (VCNs, subnets, NSGs, gateways), IAM, or Object Storage components. Unsupported requests report module limitations directly rather than generating unapproved alternatives.