### PR TITLE
Add OCI networking landing zones skill

### DIFF
--- a/oci/SKILL.md
+++ b/oci/SKILL.md
@@ -5,7 +5,7 @@ description: Oracle Cloud Infrastructure guidance for designing, operating, and 
 
 # Oracle Cloud Infrastructure Skills
 
-Use this domain for practical Oracle Cloud Infrastructure guidance. Current content covers OCI Kubernetes Engine (OKE): cluster design, operational troubleshooting, Generic VNIC Attachment (GVA), and Multus multi-interface pod validation. It covers OCI Internet of Things Platform resource discovery, digital twin lifecycle workflows, device publish flows, and optional MCP-assisted operation. It covers OCI Functions local deployment and diagnosis-first troubleshooting. It also covers Enterprise AI because that work is built around OCI Generative AI, OCI networking, IAM, cost estimation, hosted applications, and OCI platform integrations.
+Use this domain for practical Oracle Cloud Infrastructure guidance. Current content covers OCI Kubernetes Engine (OKE): cluster design, operational troubleshooting, Generic VNIC Attachment (GVA), and Multus multi-interface pod validation. It covers OCI Internet of Things Platform resource discovery, digital twin lifecycle workflows, device publish flows, and optional MCP-assisted operation. It covers OCI Functions local deployment and diagnosis-first troubleshooting. It includes a constrained Terraform configuration generator for OCI networking resources. It also covers Enterprise AI because that work is built around OCI Generative AI, OCI networking, IAM, cost estimation, hosted applications, and OCI platform integrations.
 
 ## How to Use This Domain
 
@@ -46,6 +46,11 @@ oci/
 │   ├── scripts/
 │   ├── templates/
 │   └── tests/
+├── oci-landing-zone-terraform-module/
+│   └── terraform-oci-modules-networking-skill/
+│       ├── SKILL.md
+│       ├── agents/
+│       └── references/
 └── oke/
     ├── cluster-design.md
     ├── troubleshooting.md
@@ -69,6 +74,7 @@ oci/
 | Deploy or validate Multus NetworkAttachmentDefinitions and multi-interface pods on OKE | Start with `oci/oke/multus-multihome.md`, then load `oci/oke/skills/oke-multihome-deployer/SKILL.md` |
 | Deploy an OCI Function from a local macOS or Linux workstation | `oci/functions/oci-functions-deploy/SKILL.md` |
 | Troubleshoot OCI Functions setup, deployment, invocation, or observability | `oci/functions/oci-functions-troubleshoot/SKILL.md` |
+| Generate or update Terraform configuration for OCI VCNs, subnets, routes, gateways, security lists, NSGs, or ZPR security-attribute assignments | `oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/SKILL.md` |
 | OCI IoT domains, domain groups, digital twin models, adapters, instances, relationships, raw commands, Data API access, or HTTPS publish flows | `oci/iot-platform/SKILL.md` |
 | OCI Generative AI models, custom/imported models, endpoints, or private endpoints | `oci/enterprise-ai/SKILL.md` |
 | OCI Responses API agents, tools, memory, File Search, Code Interpreter, MCP, or SQL Search | `oci/enterprise-ai/SKILL.md` |
@@ -85,6 +91,7 @@ oci/
 - `oci/functions/oci-functions-troubleshoot/SKILL.md`
 - `oci/functions/oci-functions-deploy/references/oci-functions-quickstart.md`
 - `oci/functions/oci-functions-troubleshoot/references/error-patterns.md`
+- `oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/SKILL.md`
 - `oci/iot-platform/SKILL.md`
 - `oci/iot-platform/references/cli-workflows.md`
 - `oci/iot-platform/references/mcp-optional-use.md`
@@ -116,6 +123,7 @@ The OKE operational skills include deterministic helper tools under `oci/oke/scr
 | Deploy a local function | `functions/oci-functions-deploy/SKILL.md` -> preflight -> Fn context validation -> OCIR auth check -> app selection -> scaffold -> deploy |
 | Troubleshoot a failed function deploy | `functions/oci-functions-troubleshoot/SKILL.md` -> `functions/oci-functions-troubleshoot/references/error-patterns.md` -> `functions/oci-functions-troubleshoot/references/deploy.md` |
 | Troubleshoot function invocation failures | `functions/oci-functions-troubleshoot/SKILL.md` -> `functions/oci-functions-troubleshoot/references/invoke.md` -> logs, traces, metrics, and limits |
+| Generate OCI networking Terraform configuration | `oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/SKILL.md` -> determine support -> collect and validate inputs -> generate a compatible configuration change without running Terraform |
 | Explore or update OCI IoT digital twin resources | `iot-platform/SKILL.md` -> `iot-platform/references/cli-workflows.md` -> `iot-platform/references/resilience-guidance.md` |
 | Publish test telemetry to an OCI IoT twin | `iot-platform/SKILL.md` -> `iot-platform/references/cli-workflows.md` -> `iot-platform/templates/publish-curl.template.sh` |
 | Build a governed enterprise assistant | `enterprise-ai/SKILL.md` -> `enterprise-ai/agent-workflows/agent-tools.md` -> `enterprise-ai/data/rag-and-search.md` -> `enterprise-ai/governance/private-endpoints-and-governance.md` |
@@ -123,6 +131,7 @@ The OKE operational skills include deterministic helper tools under `oci/oke/scr
 ## Scope Boundaries
 
 - Keep OCI service, networking, IAM, agent hosting, and cost-estimation guidance in this domain.
+- Route OCI networking Terraform configuration to `oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/`; it supports only `oci-landing-zones/terraform-oci-modules-networking` and does not manage ZPR policies.
 - Route OCI IoT domain, digital twin, adapter, device publish, raw command, and Data API workflows to `oci/iot-platform/`.
 - Route Oracle Database-owned implementation details to `db/features/`.
 - Route APEX artifact generation to `apex/apexlang/`.
@@ -134,6 +143,7 @@ The OKE operational skills include deterministic helper tools under `oci/oke/scr
 - https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contengAttaching_Multiple_VNICs.htm
 - https://docs.oracle.com/en-us/iaas/Content/ContEng/Tasks/contenggrantingworkloadaccesstoresources.htm
 - https://github.com/oracle-terraform-modules/terraform-oci-oke
+- https://github.com/oci-landing-zones/terraform-oci-modules-networking
 - https://docs.oracle.com/en-us/iaas/Content/internet-of-things/home.htm
 - https://github.com/oracle-samples/oci-iot-samples
 - https://docs.oracle.com/en-us/iaas/Content/generative-ai/overview.htm

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/README.txt
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/README.txt
@@ -1,0 +1,74 @@
+Build OCI Networking Landing Zones Terraform Skill
+===================================================
+
+This skill safely generates or updates Terraform network configuration for OCI
+by using only the supported module from:
+https://github.com/oci-landing-zones/terraform-oci-modules-networking
+
+It supports VCNs, subnets, route tables, internet/NAT/service gateways,
+security lists and rules, network security groups and rules, and ZPR security
+attribute assignments. It does not manage ZPR policies or use direct OCI
+provider resources as substitutes for unsupported module features.
+
+How this skill works
+--------------------
+
+1. Inspects the target Terraform project before making changes.
+2. Checks module-support.md to confirm the requested capability is supported.
+3. Collects required inputs from the matching input-collection.md section.
+4. Asks whether the user wants documented optional parameters, then validates
+   the completed inputs with validation.md.
+5. Uses terraform-sources.md and main-tf-map.md to make the smallest safe
+   configuration change.
+6. Does not install or run Terraform. It hands off Terraform validation, plan,
+   and apply to the customer pipeline for review and execution.
+
+How to use
+----------
+
+Load this skill whenever the use case is to create or update OCI networking
+Terraform using `oci-landing-zones/terraform-oci-modules-networking`.
+
+After loading, the agent reads `SKILL.md` first and follows its reference-routing
+workflow: confirm support, collect inputs, ask about optional parameters,
+validate supplied resources through read-only OCI API MCP commands when
+available, then generate the smallest compatible change. The agent must not
+run or install Terraform; the customer pipeline must review and run Terraform
+validation, plan, and apply stages.
+
+The skill is additive by default. It preserves existing project layout and
+pipeline behavior. Updates, removals, replacements, and deletion requests
+require the extra lifecycle checks in lifecycle-safety.md.
+
+Reference files
+---------------
+
+module-support.md
+  The upstream support allowlist and rejection wording for unsupported requests.
+
+input-collection.md
+  Required and optional input checklists for VCNs, subnets, routes, gateways,
+  security lists, NSGs, and ZPR security-attribute assignment.
+
+terraform-sources.md
+  The canonical Git module source, pinning guidance, and safe existing-project
+  integration rules.
+
+validation.md
+  The read-only OCI API MCP and structural validation contract.
+
+main-tf-map.md
+  Rules for placing new VCNs under `vcns` and injecting resources into an
+  existing VCN through `inject_into_existing_vcns`.
+
+lifecycle-safety.md
+  Additional guardrails for updates, removals, replacements, and deletion.
+
+Quick reference flow
+--------------------
+
+request -> module-support.md -> relevant input-collection.md section +
+terraform-sources.md -> validation.md -> main-tf-map.md -> generate safely
+
+For lifecycle changes, read lifecycle-safety.md before collecting inputs and
+apply the state checks in validation.md before proposing a configuration change.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/SKILL.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: oci-networking-landing-zones
+description: "Generate or update safe OCI network Terraform configuration using only `oci-landing-zones/terraform-oci-modules-networking`. Use for VCNs, subnets, route tables, internet/NAT/service gateways, security lists and rules, NSGs and rules, and ZPR security-attribute assignments when inputs must be collected and validated through read-only OCI API MCP checks, then integrated without disrupting an existing Terraform pipeline or provider setup."
+---
+
+# Build OCI Networking Landing Zones Terraform
+
+Generate only configuration supported by the upstream networking module. Preserve the customer's existing Terraform and pipeline behavior. Use the OCI API MCP server only for read-only validation; avoid using it to create, update, delete, or otherwise mutate OCI resources. Never install or execute Terraform locally.
+
+## Required workflow
+
+1. Inspect the target before writing.
+   - Inspect the Terraform repository, provider aliases, backend, module source pins, variable-data convention, and existing `network_configuration` values.
+   - For every lifecycle request, inspect accessible state only read-only. If pipeline state is not accessible, require the customer to supply the exact pipeline state address and ownership confirmation.
+   - Read [module support](references/module-support.md). If the requested capability is unavailable, report it using the required response and stop that portion.
+   - Read [lifecycle safety](references/lifecycle-safety.md) for update, removal, replacement, or deletion.
+
+2. Collect supported inputs.
+   - Read the shared section plus only the matching resource sections of [input collection](references/input-collection.md). Read its existing-VCN injection section whenever the target VCN already exists.
+   - Ask for missing required values and the customer-approved traffic purpose for any gateway, route, public access, or security rule. Avoid inferring topology, OCIDs, CIDRs, or access scope.
+   - After required values are complete, ask whether the customer wants documented optional parameters. Use documented defaults when declined.
+
+3. Validate before generating configuration.
+   - Read [validation](references/validation.md) after all requested inputs are collected.
+   - Use OCI API MCP read commands only to validate supplied and referenced OCI resources. Use a dry-run flag only when current MCP command help confirms it is supported and non-mutating.
+   - Pause for corrected input if a value is missing or known invalid. If OCI API MCP is unavailable, state that MCP validation was skipped and continue only with the documented non-MCP checks.
+
+4. Generate the smallest compatible change.
+   - Read [terraform sources](references/terraform-sources.md) and [configuration map](references/main-tf-map.md). The configuration map decides whether to extend an existing root module, add one supported root module, or reject an unsupported request.
+   - Reuse the existing compatible OCI provider, aliases, backend, module source pin, variables, and module block. Avoid adding duplicate providers, changing credentials, or disrupting the existing setup.
+   - Create VCNs under `vcns`; add new resources to an existing VCN only through `inject_into_existing_vcns`. Preserve stable map keys and existing values.
+
+5. Hand off to the customer pipeline.
+   - Avoid running local Terraform operations. State that the customer pipeline must run the approved Terraform validation, plan, and apply stages and that the plan must be reviewed before apply.
+
+## Boundaries
+
+- Use only `oci-landing-zones/terraform-oci-modules-networking`; avoid direct `oci_*` resource substitutes, other landing-zone repositories, or custom modules.
+- Avoid creating or changing ZPR policies. The upstream networking module supports security-attribute assignment but not ZPR policy management.
+- Avoid replacing, deleting, moving, renaming, or modifying an existing resource unless the customer explicitly identifies it, confirms state ownership, and approves the exact action.
+- Avoid changing providers, aliases, backend, authentication, Terraform version constraints, or module pins unless the customer explicitly requests that change.
+- Avoid executing `terraform`, `tofu`, Terraform state commands, provider login, installations, or pipeline commands.
+
+## Reference routing
+
+```text
+request
+  -> module-support.md
+       -> unsupported: report and stop that portion
+       -> supported: relevant input section + terraform-sources.md
+            -> lifecycle-safety.md when lifecycle change
+            -> validation.md
+                 -> main-tf-map.md
+                      -> generate configuration for pipeline review
+```
+
+| Need | Read |
+| --- | --- |
+| Confirm support or reject the capability | [module-support.md](references/module-support.md) |
+| Collect VCN, subnet, route, gateway, security, or ZPR inputs | [input-collection.md](references/input-collection.md) |
+| Apply OCI API MCP and structural validation | [validation.md](references/validation.md) |
+| Preserve provider, source, backend, and pipeline behavior | [terraform-sources.md](references/terraform-sources.md) |
+| Handle update, removal, replacement, or delete | [lifecycle-safety.md](references/lifecycle-safety.md) |
+| Place data in `vcns` or `inject_into_existing_vcns` | [main-tf-map.md](references/main-tf-map.md) |

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/agents/openai.yaml
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "OCI Networking Landing Zones"
+  short_description: "Build safe OCI network Terraform changes"
+  default_prompt: "Use $oci-networking-landing-zones to create validated Terraform root files for supported OCI Networking modules.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/agents/openai.yaml
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "OCI Networking Landing Zones"
   short_description: "Build safe OCI network Terraform changes"
-  default_prompt: "Use $oci-networking-landing-zones to create validated Terraform root files for supported OCI Networking modules.
+  default_prompt: "Use $oci-networking-landing-zones to create validated Terraform root files for supported OCI Networking modules"

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/references/input-collection.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/references/input-collection.md
@@ -1,0 +1,163 @@
+# OCI networking input collection
+
+Use this reference only after `module-support.md` confirms support. Map values exactly to the selected upstream `network_configuration` shape; re-check the selected release's `SPEC.md` before using any field not listed here. Preserve stable logical keys: changing an applied key can recreate its resource.
+
+## Shared topology and dependency inputs
+
+Collect for every request:
+
+- target repository and environment, approved source pin, intended OCI region, and whether the request creates a VCN or injects components into an existing VCN;
+- `default_compartment_id` or a category/resource-level `compartment_id`; use a literal OCID or a documented `compartments_dependency` key only;
+- category logical key; optional category compartment override, tags, `category_enable_cis_checks`, and `category_ssh_ports_to_check`;
+- optional global defaults: defined/freeform tags, `default_enable_cis_checks` (defaults to `true`), and `default_ssh_ports_to_check` (defaults to `[22, 3389]`);
+- for injection: a literal `vcn_id` or `network_dependency.vcns.<key>.id`. Avoid using a display name as a VCN identifier.
+
+After required data for each selected family is complete, ask:
+
+> Do you want to provide documented optional parameters for the selected networking components, including tags, DNS or IPv6 settings, CIS controls, associations, and gateway-specific options?
+
+If declined, use upstream defaults only. Avoid inventing optional values.
+
+## VCNs
+
+Use `network_configuration_categories.<category>.vcns` only to create a VCN.
+
+### Required inputs
+
+- stable VCN map key;
+- `cidr_blocks`: approved IPv4 CIDR list;
+- effective compartment context, inherited or explicit;
+- customer-approved display name when the customer naming policy requires one.
+
+### Documented optional inputs
+
+- `display_name`, `dns_label`, `compartment_id`, `defined_tags`, `freeform_tags`, and `enable_cis_checks`;
+- IPv6 controls: `is_ipv6enabled`, `is_oracle_gua_allocation_enabled`, `ipv6private_cidr_blocks`, and documented BYOIPv6 details;
+- `block_nat_traffic`;
+- VCN default security list/default route table, DHCP options, subnets, NSGs, gateways, and `security.zpr_attributes` as separately collected below.
+
+### Structural checks and output discipline
+
+Require non-overlapping VCN CIDRs and a valid DNS label when supplied. Put the VCN and child topology beneath its stable key; avoid using `inject_into_existing_vcns` to recreate it.
+
+## Existing VCN injection
+
+Use `inject_into_existing_vcns` only for additive components in an existing VCN. It does not create the VCN.
+
+### Required inputs
+
+- stable injection map key;
+- `vcn_id`, either literal or supported network-dependency key;
+- requested child resource family and all its required inputs.
+
+### Important differences from new VCNs
+
+- subnet associations may accept existing external `dhcp_options_id`, `route_table_id`, and `security_list_ids`, in addition to same-configuration keys;
+- gateway route-table association may accept `route_table_id` or `route_table_key`;
+- use external resource IDs only after OCI MCP parentage validation; use a same-configuration key only where the upstream schema permits it;
+- ZPR security attributes are supported in the new-VCN schema only. Treat assigning attributes to an existing VCN as unsupported by this module and direct the customer to OCI support.
+
+## Subnets
+
+### Required inputs
+
+For every `subnets` map entry collect stable key, `cidr_block`, effective compartment, and intended VCN. For each subnet collect whether it is regional or availability-domain-specific and whether it is private or requires approved public exposure.
+
+### Documented optional inputs
+
+- `availability_domain`, `display_name`, `dns_label`, `compartment_id`, defined/freeform tags;
+- `ipv6cidr_block` or `ipv6cidr_blocks` where supported by the selected VCN form;
+- `prohibit_internet_ingress` and `prohibit_public_ip_on_vnic`; default new subnets to private with public-IP assignment prohibited;
+- `dhcp_options_key`, plus `dhcp_options_id` for existing-VCN injection;
+- `route_table_key`, plus `route_table_id` for existing-VCN injection;
+- `security_list_keys`, plus `security_list_ids` for existing-VCN injection.
+
+### Structural checks and output discipline
+
+Require a subnet CIDR within its VCN and non-overlapping with all existing/requested subnets. Avoid mixing a key and OCID for the same association unless upstream documentation explicitly permits precedence. Require business purpose and confirmation before allowing public IPs or internet ingress.
+
+## Route tables and route rules
+
+Use `route_tables` for dedicated tables and `default_route_table` only when the customer explicitly asks to alter the VCN default table.
+
+### Required inputs
+
+- stable table key or explicit default-table target;
+- for every `route_rules` entry: stable rule key, `destination`, `destination_type`, and exactly one validated next-hop reference (`network_entity_id` or `network_entity_key`), plus business purpose.
+
+### Documented optional inputs
+
+- table `compartment_id`, `display_name`, defined/freeform tags;
+- rule `description`;
+- `destination_type` of `CIDR_BLOCK`, or `SERVICE_CIDR_BLOCK` only for a service-gateway path. The documented service destinations are `objectstorage` and `all-services`.
+
+### Structural checks and output discipline
+
+Require destinations to be valid CIDRs or documented service names. Verify the target is the appropriate gateway/resource and belongs to the VCN when applicable. Avoid modifying default route tables, adding a default route, or replacing complete route-rule sets without explicit impact confirmation.
+
+## Internet, NAT, and service gateways
+
+Place these in `vcn_specific_gateways`.
+
+### Internet gateway
+
+Collect stable key and traffic purpose. Optional inputs are `compartment_id`, `display_name`, `enabled`, tags, and `route_table_key` for a new VCN or `route_table_id`/`route_table_key` for injection. Require an explicit public-access purpose and matching route/security design before creation or enablement.
+
+### NAT gateway
+
+Collect stable key and private-egress purpose. Optional inputs are `compartment_id`, `display_name`, `block_traffic`, `public_ip_id`, tags, and route-table association (`route_table_key`, or ID/key for injection). Avoid inferring public-IP reuse; validate a supplied public-IP OCID and require explicit approval before changing `block_traffic`.
+
+### Service gateway
+
+Collect stable key and required `services`: `objectstorage` or `all-services`. Optional inputs are `compartment_id`, `display_name`, tags, and route-table association. Require the required OCI-service path and a route using the matching `SERVICE_CIDR_BLOCK` destination.
+
+## Security lists and security-list rules
+
+Use `security_lists` for a dedicated list. Use `default_security_list` only when the customer explicitly identifies the VCN default security list and approves changing its complete ruleset.
+
+### Required inputs
+
+For the list, collect stable key where applicable, effective compartment, intended VCN, and any requested rule list. For every ingress rule collect `protocol`, `src`, and `src_type`; for every egress rule collect `protocol`, `dst`, and `dst_type`. Collect direction, traffic purpose, and rule description for customer review.
+
+### Documented optional rule inputs
+
+- `stateless`, `description`, `src_port_min`, `src_port_max`, `dst_port_min`, `dst_port_max`, `icmp_type`, and `icmp_code`;
+- list `display_name`, `compartment_id`, defined/freeform tags.
+
+### Structural checks and output discipline
+
+Require port fields only when applicable to the protocol; ensure min ≤ max. Require ICMP type/code only for ICMP. Require explicit approval and recovery considerations for `0.0.0.0/0`, `::/0`, unrestricted egress, SSH/RDP ports, stateless rules, or a default-list change. Attach only validated same-configuration security-list keys or validated external IDs supported by the selected VCN form.
+
+## Network security groups and rules
+
+Use `network_security_groups`; ingress and egress rules are maps keyed by stable rule keys.
+
+### Required inputs
+
+For each NSG collect stable key, effective compartment, intended VCN, and display name if required by policy. For every ingress rule collect `protocol`, `src`, and `src_type`; for every egress rule collect `protocol`, `dst`, and `dst_type`. Collect business purpose, direction, and the intended protected workload.
+
+### Documented optional inputs
+
+- NSG `compartment_id`, `display_name`, defined/freeform tags;
+- rule `description`, `stateless`, source/destination port bounds, and ICMP type/code.
+
+### Structural checks and output discipline
+
+Apply the same protocol, port, ICMP, broad-exposure, and duplicate-rule checks as security lists. Avoid assuming that declaring an NSG attaches it to a VNIC; record that attachment is outside the requested module scope unless the customer has an independently managed attachment path.
+
+## ZPR security attributes
+
+Use `security.zpr_attributes` only beneath a newly created VCN and only after policy evidence is validated.
+
+### Required inputs
+
+- `attr_name`, `attr_value`, application and management traffic flows, existing approved ZPR policy evidence, and recovery path.
+
+### Documented optional inputs
+
+- `namespace`, defaulting upstream to `oracle-zpr` only if the customer accepts it;
+- `mode`, defaulting upstream to `enforce` only if the customer accepts it.
+
+### Structural checks and output discipline
+
+Avoid inventing namespaces, attributes, values, or policies. Confirm ZPR policy, routing, and security-list/NSG controls jointly allow the required flows before assignment. ZPR policy creation, update, and deletion are unsupported: direct the customer to OCI support.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/references/lifecycle-safety.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/references/lifecycle-safety.md
@@ -1,0 +1,32 @@
+# OCI networking lifecycle safety
+
+Read this for update, removal, replacement, or deletion. Treat configuration changes as infrastructure changes, not source cleanup.
+
+## Common gate
+
+Require the exact logical key, OCI OCID, state address/ownership confirmation, desired action, current OCI read result, dependency analysis, and customer confirmation. Avoid assuming configuration presence means Terraform owns the resource.
+
+## Update and replacement
+
+- Distinguish metadata/tag changes from association, route, CIDR, security, or public-access changes. Surface any expected replacement or destroy/create action clearly.
+- Preserve map keys, names, provider settings, source pin, and unrelated values. Avoid renaming keys; the upstream module warns that it can recreate resources.
+- Before changing routes/gateways, identify affected subnets and egress/ingress paths. Before security changes, identify affected workloads and management access. Before ZPR attributes, identify permitted flows and recovery.
+
+## Default resources
+
+Default route tables and default security lists are existing VCN resources managed as complete rule/table configurations. Require explicit identification of the default resource, current rules, all affected associations, replacement/full-ruleset effect, and a recovery plan before generation.
+
+## Remove and delete
+
+- Treat removing a configuration entry as an intended Terraform destroy.
+- Require explicit current-conversation confirmation for the exact target, dependency impact, expected destroy/replacement, and customer-approved maintenance/recovery plan.
+- Avoid deleting a VCN until all child subnets, gateways, route tables, security lists, NSGs, attachments/workloads, and external references are addressed.
+- Avoid deleting/widening/narrowing a rule until its traffic impact is confirmed. Never attempt state imports, removals, recovery, or OCI mutations.
+
+## Ownership ambiguity
+
+If pipeline state cannot establish ownership or the resource is absent from state, stop. Direct the customer to their approved state-inspection, adoption/import, or stale-configuration reconciliation process. Avoid creating a replacement as an implicit recovery.
+
+## Required handoff
+
+For every lifecycle change, summarize the exact target, expected Terraform action, dependencies, public/security impact, confirmation, rollback/recovery consideration, and requirement to review the customer pipeline plan before apply.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/references/main-tf-map.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/references/main-tf-map.md
@@ -1,0 +1,43 @@
+# Terraform file and configuration map
+
+Use this only after validation succeeds. Separate the upstream support decision from whether the customer repository already invokes the root networking module.
+
+## Choose the change
+
+| Customer request | Existing repository state | Required change |
+| --- | --- | --- |
+| Add a supported VCN/component or documented optional input | A compatible root networking module already exists | Trace the value passed to `network_configuration`; extend that object in its established location. Avoid adding a second module block. |
+| Add a supported VCN/component | No compatible root networking module exists | Add one root module block using the approved pinned upstream source, a typed `network_configuration` variable, and the smallest compatible data change; reuse existing OCI provider/backend setup. |
+| Unsupported capability, including ZPR policy management | Any state | Report it as unsupported and do not add direct `oci_*` resources, another landing-zone module, or a custom replacement. |
+
+The absence of a module block in the current repository does not mean the capability is unsupported. `module-support.md` determines upstream support.
+
+## Existing repository placement
+
+- Inspect module blocks and trace the variable/local/source that supplies `network_configuration`. It may be in `*.tfvars`, environment JSON, locals, or another established configuration source.
+- Extend the existing data source only; preserve existing categories, VCN/injection entries, keys, tags, dependencies, and unrelated values.
+- Reuse the existing OCI provider, aliases, `required_providers`, backend, version constraints, module name, and source pin. Avoid duplicates or authentication changes.
+- Add a typed declaration only when needed and compatible with the repository's established type strategy. Avoid weakening an existing type to `any` merely to add fields.
+- Add validated non-secret values in the repository's current variable-data convention. Avoid writing private-key material, tokens, or passwords.
+
+## Map request to `network_configuration`
+
+| Request | Location |
+| --- | --- |
+| Create VCN and its child resources | `network_configuration.network_configuration_categories.<category>.vcns.<vcn-key>` |
+| Inject child resources into an existing VCN | `network_configuration.network_configuration_categories.<category>.inject_into_existing_vcns.<injection-key>` with `vcn_id` |
+| External compartment reference | `compartments_dependency.<key>.id`; use the key only in documented compartment fields |
+| External VCN reference | `network_dependency.vcns.<key>.id`; use the key as documented `vcn_id` |
+| Dedicated/default route table | `route_tables` / `default_route_table` under the selected VCN or injection |
+| Dedicated/default security list | `security_lists` / `default_security_list` under the selected VCN or injection |
+| NSG and rules | `network_security_groups` under the selected VCN or injection |
+| Gateways | `vcn_specific_gateways.internet_gateways`, `.nat_gateways`, or `.service_gateways` |
+| New-VCN ZPR attributes | `security.zpr_attributes` under the selected new VCN |
+
+## New project mode
+
+If no project, module, provider, or configuration convention exists, use the minimal-workspace mode in [terraform-sources.md](terraform-sources.md#empty-starting-point-minimal-workspace-mode). After the customer supplies a target directory, approved source pin, and authentication mechanism, create one root module invocation, typed variable declaration, and non-secret variable data. Require Terraform `>= 1.3.0`; avoid running Terraform or creating a backend/state configuration without explicit customer direction.
+
+## Handoff
+
+State the changed data source and module block, preserved provider/backend/source pin, expected pipeline plan impact, and required pipeline review. Avoid running local Terraform commands.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/references/module-support.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/references/module-support.md
@@ -1,0 +1,21 @@
+# Upstream module support matrix
+
+Source repository: `https://github.com/oci-landing-zones/terraform-oci-modules-networking`. Verify the selected release's `README.md` and `SPEC.md` before generation. This is an allowlist for the customer's requested scope.
+
+| Capability | Status | Exact configuration location | Customer boundary |
+| --- | --- | --- | --- |
+| Create VCN | Supported | `network_configuration_categories.*.vcns` | Supports VCN plus declared components. |
+| Inject components into existing VCN | Supported | `network_configuration_categories.*.inject_into_existing_vcns` | Requires VCN OCID or documented external dependency key; does not create the VCN. |
+| Subnet | Supported | `subnets` | Supports documented CIDR, AD, IPv6, public-IP, DHCP, route, and security-list fields. |
+| Route table/rules | Supported | `route_tables`, `default_route_table` | Default-table changes are lifecycle-sensitive. |
+| Internet/NAT/service gateway | Supported | `vcn_specific_gateways` | SGW services limited to documented values. |
+| Security list/rules | Supported | `security_lists`, `default_security_list` | Default-list changes are lifecycle-sensitive. |
+| NSG/rules | Supported | `network_security_groups` | This module does not attach NSGs to VNICs. |
+| ZPR security-attribute assignment | Supported | New VCN `security.zpr_attributes` | Requires existing policy evidence; not available for existing-VCN injection. |
+| ZPR policy management | Not supported | — | Contact OCI support for an approved implementation. |
+
+## Required unsupported response
+
+> The Terraform module for `<capability>` is not supported by `oci-landing-zones/terraform-oci-modules-networking`. Contact OCI support if you need an approved implementation.
+
+For an out-of-skill capability that the upstream repository could support, state that it is outside this customer skill's supported scope and ask whether the customer wants a separately approved skill/workflow. If a request combines supported and unsupported portions, ask whether to continue only with the supported portion.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/references/terraform-sources.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/references/terraform-sources.md
@@ -1,0 +1,85 @@
+# Terraform source, dependencies, and pipeline integration
+
+## Canonical source
+
+Use only the upstream root module:
+
+```hcl
+source = "git::https://github.com/oci-landing-zones/terraform-oci-modules-networking.git?ref=<release-tag-or-commit-sha>"
+```
+
+Reuse the existing approved pin. If no pin exists, require a customer-approved release tag or immutable commit SHA for production. Use `ref=main` only for an explicitly approved evaluation draft. Confirm the selected version's `README.md` and `SPEC.md` before emitting arguments.
+
+## Documented dependency shapes
+
+`compartments_dependency` is a map whose objects contain an `id` compartment OCID. `network_dependency` is a map organized by supported resource family; for this scope, use `network_dependency.vcns.<key>.id` for an externally managed VCN. Avoid inventing dependency shapes or using an external key where the SPEC requires an OCID.
+
+## Existing repository integration
+
+- Inspect provider blocks, aliases, required-provider constraints, backend, Terraform version, module source pins, variable/local conventions, and `.gitignore` before editing.
+- Reuse the compatible provider and aliases. Pass a provider alias to the module only when the module documentation supports it and the existing project requires the same tenancy/region context.
+- Preserve backend/state model, module source pin, authentication, file layout, formatting, naming, and variable-data convention. Avoid adding a provider, backend, lock file, or `.terraform` directory.
+- Extend an existing root networking module's data rather than adding a duplicate. Choose non-conflicting names only when a new root module is required.
+- Keep private keys, secrets, tokens, and credentials out of generated configuration and chat examples.
+
+## Empty starting point: minimal workspace mode
+
+Use this mode only when no Terraform project, compatible networking module, provider block, or established configuration convention is in scope. Ask for the target directory, customer-approved module pin, and approved pipeline authentication mechanism; avoid assuming any of them. Create exactly these files unless the customer asks for more:
+
+```text
+main.tf
+variables.tf
+terraform.tfvars
+```
+
+Avoid creating a backend configuration, lock file, `.terraform` directory, or pipeline files. The customer's pipeline remains responsible for backend and state configuration.
+
+### `main.tf` baseline
+
+Include Terraform `>= 1.3.0`, the OCI required provider, one OCI provider block using variables for the selected approved authentication model, and one root networking module invocation:
+
+```hcl
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    oci = {
+      source = "oracle/oci"
+    }
+  }
+}
+
+provider "oci" {
+  tenancy_ocid     = var.tenancy_ocid
+  user_ocid        = var.user_ocid
+  fingerprint      = var.fingerprint
+  private_key_path = var.private_key_path
+  region           = var.region
+}
+
+module "networking" {
+  source = "git::https://github.com/oci-landing-zones/terraform-oci-modules-networking.git?ref=<customer-approved-release-or-commit>"
+
+  network_configuration = var.network_configuration
+}
+```
+
+Use this API-key provider example only when it matches the customer's approved pipeline authentication. For instance principals, resource principals, security-token, or environment-variable authentication, model only the documented provider settings the customer approves. Avoid guessing aliases, credentials, tenancy, region, or a source pin.
+
+### `variables.tf` baseline
+
+For the API-key baseline, declare `tenancy_ocid`, `user_ocid`, `fingerprint`, `private_key_path`, and `region` as strings. Add a typed `network_configuration` variable copied from the selected upstream release's `SPEC.md`; avoid weakening it to `any`. Add `compartments_dependency` or `network_dependency` declarations only when the approved topology uses them.
+
+### `terraform.tfvars` baseline
+
+Put validated, non-secret topology values in the established variable-data file. Use placeholders for unsupplied provider values and preserve private-key contents, tokens, passwords, and pipeline credentials outside the file. For an API-key pipeline, `private_key_path` may be a pipeline-managed path but must never contain the key itself.
+
+### Empty-workspace output discipline
+
+- Create one `network_configuration` object and one root networking module block, covering only supported requested components.
+- Keep new VCNs under `vcns`; use `inject_into_existing_vcns` only when the customer supplies and validates an existing VCN OCID/dependency.
+- State the approved source pin, authentication assumption, absence of a backend configuration, and required pipeline validation/plan/apply handoff.
+
+## Pipeline handoff
+
+Never run local Terraform operations. Direct the customer to their pipeline's approved init, validation, plan, approval, and apply process. Require plan review, especially for public exposure, routing, security-rule, replacement, and destroy actions.

--- a/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/references/validation.md
+++ b/oci/oci-landing-zone-terraform-module/terraform-oci-modules-networking-skill/references/validation.md
@@ -1,0 +1,70 @@
+# Validation contract
+
+Read this after support confirmation and all required/optional inputs are collected. Never proceed with a known-invalid value. OCI API MCP is validation-only: use `get_oci_command_help` for current syntax and `run_oci_command` only with `list`/`get` reads or a help-confirmed non-mutating dry run. Avoid create, update, delete, attach, detach, rule-change, and policy-change commands.
+
+## Validation outcomes
+
+- **Pass:** generate the scoped Terraform configuration.
+- **Missing/invalid:** pause and request the corrected value.
+- **MCP unavailable:** state that OCI MCP validation was skipped and apply non-MCP structural validation only.
+- **MCP available but read fails:** distinguish authentication, authorization, region, connectivity, and not-found failures from tool unavailability; request corrected access or identity and do not claim validation passed.
+- **Dry run unavailable/ambiguous:** skip it; pipeline plan review is still mandatory.
+
+## OCI MCP availability and command discipline
+
+Before declaring MCP unavailable, inspect the tool inventory for `get_oci_command_help` and `run_oci_command`. If present, use help for the exact read family before the first live read. MCP command text begins with the OCI service group, such as `network vcn get`; avoid including `oci`, `--profile`, or `--auth`.
+
+The MCP server region/profile is server-selected. Compare it with the customer's intended region; a mismatch is a validation failure requiring the correct configured server context.
+
+## Common validations
+
+- Confirm each OCID has the expected type, is accessible, and belongs to the supplied tenancy, region, compartment, and VCN where OCI exposes those fields.
+- Confirm referenced compartments and VCNs are active/available. Resolve a display name to an OCID only within the narrowest relevant compartment and then validate the OCID.
+- Parse all IPv4/IPv6 CIDRs; confirm syntax, address family, containment, and no overlap. For injection, read the target VCN plus existing subnets before accepting a subnet CIDR.
+- Validate logical-key uniqueness, no duplicate display-name conflict within the requested parent scope, and no unresolved same-configuration or dependency references.
+- Validate tags, names, and DNS labels against customer policy when supplied; do not fabricate policy values.
+
+## OCI API MCP read matrix
+
+| Subject | Read-only commands and checks |
+| --- | --- |
+| Compartment/VCN | `iam compartment get`, `network vcn get/list`: expected OCID, lifecycle state, compartment, VCN CIDRs, DNS/IPv6 and NAT-traffic intent. |
+| Existing VCN injection | `network vcn get`, `network subnet list`, `network route-table list`, `network security-list list`, `network nsg list`, gateway lists: target VCN identity, its existing CIDRs/components, and collision/association context. |
+| Subnet | `network subnet get/list`: VCN/compartment parentage, CIDR, AD/regional shape, public-IP and internet-ingress settings, route/security/DHCP associations. |
+| Route table | `network route-table get/list`: VCN parentage, existing rules, and affected associations. Verify CIDR versus service destination and the target resource type. |
+| IGW/NAT/SGW | `network internet-gateway`, `network nat-gateway`, `network service-gateway` get/list: VCN parentage, enabled/block state, route-table association, and service-gateway enabled services. Use `network service list` to resolve an Oracle service when required. |
+| Security list | `network security-list get/list`: VCN parentage, complete ingress/egress rules, and associated subnets before rule/default-list changes. |
+| NSG and rules | `network nsg get/list`, `network nsg rules list`: VCN parentage, exact current rule IDs, duplicate/equivalent rule scope, and affected workload attachment information if exposed. |
+| ZPR prerequisites | Current `security-attribute security-attribute-namespace` and `security-attribute security-attribute` list/get reads, plus `zpr zpr-policy` list/get: provided namespace/attribute identity and existing policy evidence. |
+
+## Resource-specific structural validation
+
+### Routes and gateways
+
+- Require exactly one next-hop ID/key per route rule. Resolve it to the correct same-configuration or existing-VPC resource.
+- Require `CIDR_BLOCK` destinations to be valid CIDRs. Require `SERVICE_CIDR_BLOCK` only with a service gateway and documented `objectstorage`/`all-services` value.
+- Check routes do not create duplicate destinations with ambiguous next hops in the same table. Flag a default route, public path, NAT path, and service path for explicit traffic-impact review.
+- Verify a supplied NAT public-IP OCID and supplied route-table/security-list/DHCP IDs belong to the expected VCN before use.
+
+### Security rules
+
+- Validate protocol, direction, endpoint type, CIDR/NSG source/destination, ports, and stateless behavior. Require min ≤ max and valid protocol-specific range semantics.
+- Accept ICMP type/code only with an ICMP protocol. Reject port fields that the selected protocol does not support.
+- Detect identical, shadowing, or broader-than-requested rules in the proposed configuration. Require explicit approval for public ingress, unrestricted egress, administrative ports, and stateless traffic.
+- Verify security lists are associated only with intended subnets. Record that this module creates NSGs/rules but does not attach an NSG to a VNIC.
+
+### ZPR
+
+- Validate the proposed namespace, attribute name/value, and policy evidence are already available through OCI reads.
+- Require an approved traffic matrix and recovery path. Confirm routing and NSG/security-list rules still permit required flows; ZPR is an additional control, not a substitute.
+- Avoid validating ZPR policy creation through a mutation or fabricating a policy; report it as unsupported by the module.
+
+## Lifecycle-state gate
+
+For update, removal, replacement, or deletion: inspect accessible state read-only and require the exact state address. If state is unavailable, require customer confirmation from the approved pipeline state-inspection process. Configuration presence is not state ownership.
+
+If the target is absent from state or ownership is unclear, stop and direct the customer to their approved adoption/import or stale-configuration reconciliation process. Avoid Terraform state commands and OCI mutations. Retrieve the current OCI resource before generating a lifecycle change, identify dependencies, state the expected action, and require explicit destructive confirmation for removal/delete.
+
+## Dry-run handling
+
+Use `get_oci_command_help` to discover whether the exact proposed validation path accepts a dry-run parameter. Use it only if help confirms the operation is non-mutating and customer policy allows it; otherwise omit it. Never represent OCI dry-run output as a Terraform plan or a substitute for pipeline review.


### PR DESCRIPTION
## Summary

Adds an OCI Networking Landing Zones Terraform skill, following the directory pattern established by oracle/skills#111.

The skill supports safe, module-constrained Terraform configuration for:

- VCNs and subnets
- Route tables and internet, NAT, and service gateways
- Security lists, rules, network security groups, and NSG rules
- ZPR security-attribute assignments

It uses only `oci-landing-zones/terraform-oci-modules-networking`, preserves existing Terraform and pipeline conventions, validates OCI resources with read-only MCP operations when available, and explicitly avoids local Terraform execution and ZPR policy management.

## Changes

- Add `terraform-oci-modules-networking-skill` under `oci/oci-landing-zone-terraform-module/`
- Include skill instructions, agent metadata, and support/input/validation/lifecycle references
- Add OCI skill routing, scope boundaries, and source documentation

## Validation

- Ran `git diff --check`
- Confirmed the imported skill files match the supplied source, excluding the source-only archive and local metadata file